### PR TITLE
whitespace cleanup in all .org files

### DIFF
--- a/01_GEN.org
+++ b/01_GEN.org
@@ -36,7 +36,7 @@
 
 29. And God said, Behold, I have given you every herb bearing seed, which /is/ upon the face of all the earth, and every tree, in the which /is/ the fruit of a tree yielding seed; to you it shall be for meat.
 30. And to every beast of the earth, and to every fowl of the air, and to every thing that creepeth upon the earth, wherein /there is/ life, /I have given/ every green herb for meat: and it was so.
-31. And God saw every thing that he had made, and, behold, /it was/ very good. And the evening and the morning were the sixth day. 
+31. And God saw every thing that he had made, and, behold, /it was/ very good. And the evening and the morning were the sixth day.
 * 2
 1. Thus the heavens and the earth were finished, and all the host of them.
 2. And on the seventh day God ended his work which he had made; and he rested on the seventh day from all his work which he had made.
@@ -65,7 +65,7 @@
 22. And the rib, which the LORD God had taken from man, made he a woman, and brought her unto the man.
 23. And Adam said, This /is/ now bone of my bones, and flesh of my flesh: she shall be called Woman, because she was taken out of Man.
 24. Therefore shall a man leave his father and his mother, and shall cleave unto his wife: and they shall be one flesh.
-25. And they were both naked, the man and his wife, and were not ashamed. 
+25. And they were both naked, the man and his wife, and were not ashamed.
 * 3
 1. Now the serpent was more subtil than any beast of the field which the LORD God had made. And he said unto the woman, Yea, hath God said, Ye shall not eat of every tree of the garden?
 2. And the woman said unto the serpent, We may eat of the fruit of the trees of the garden:
@@ -91,7 +91,7 @@
 
 22. And the LORD God said, Behold, the man is become as one of us, to know good and evil: and now, lest he put forth his hand, and take also of the tree of life, and eat, and live for ever:
 23. Therefore the LORD God sent him forth from the garden of Eden, to till the ground from whence he was taken.
-24. So he drove out the man; and he placed at the east of the garden of Eden Cherubims, and a flaming sword which turned every way, to keep the way of the tree of life. 
+24. So he drove out the man; and he placed at the east of the garden of Eden Cherubims, and a flaming sword which turned every way, to keep the way of the tree of life.
 * 4
 1. And Adam knew Eve his wife; and she conceived, and bare Cain, and said, I have gotten a man from the LORD.
 2. And she again bare his brother Abel. And Abel was a keeper of sheep, but Cain was a tiller of the ground.
@@ -122,7 +122,7 @@
 24. If Cain shall be avenged sevenfold, truly Lamech seventy and sevenfold.
 
 25. And Adam knew his wife again; and she bare a son, and called his name Seth: For God, /said she/, hath appointed me another seed instead of Abel, whom Cain slew.
-26. And to Seth, to him also there was born a son; and he called his name Enos: then began men to call upon the name of the LORD. 
+26. And to Seth, to him also there was born a son; and he called his name Enos: then began men to call upon the name of the LORD.
 * 5
 1. This /is/ the book of the generations of Adam. In the day that God created man, in the likeness of God made he him;
 2. Male and female created he them; and blessed them, and called their name Adam, in the day when they were created.
@@ -162,7 +162,7 @@
 29. And he called his name Noah, saying, This /same/ shall comfort us concerning our work and toil of our hands, because of the ground which the LORD hath cursed.
 30. And Lamech lived after he begat Noah five hundred ninety and five years, and begat sons and daughters:
 31. And all the days of Lamech were seven hundred seventy and seven years: and he died.
-32. And Noah was five hundred years old: and Noah begat Shem, Ham, and Japheth. 
+32. And Noah was five hundred years old: and Noah begat Shem, Ham, and Japheth.
 * 6
 1. And it came to pass, when men began to multiply on the face of the earth, and daughters were born unto them,
 2. That the sons of God saw the daughters of men that they /were/ fair; and they took them wives of all which they chose.
@@ -188,7 +188,7 @@
 19. And of every living thing of all flesh, two of every /sort/ shalt thou bring into the ark, to keep /them/ alive with thee; they shall be male and female.
 20. Of fowls after their kind, and of cattle after their kind, of every creeping thing of the earth after his kind, two of every /sort/ shall come unto thee, to keep /them/ alive.
 21. And take thou unto thee of all food that is eaten, and thou shalt gather /it/ to thee; and it shall be for food for thee, and for them.
-22. Thus did Noah; according to all that God commanded him, so did he. 
+22. Thus did Noah; according to all that God commanded him, so did he.
 * 7
 1. And the LORD said unto Noah, Come thou and all thy house into the ark; for thee have I seen righteous before me in this generation.
 2. Of every clean beast thou shalt take to thee by sevens, the male and his female: and of beasts that /are/ not clean by two, the male and his female.
@@ -215,7 +215,7 @@
 21. And all flesh died that moved upon the earth, both of fowl, and of cattle, and of beast, and of every creeping thing that creepeth upon the earth, and every man:
 22. All in whose nostrils /was/ the breath of life, of all that /was/ in the dry /land/, died.
 23. And every living substance was destroyed which was upon the face of the ground, both man, and cattle, and the creeping things, and the fowl of the heaven; and they were destroyed from the earth: and Noah only remained /alive/, and they that /were/ with him in the ark.
-24. And the waters prevailed upon the earth an hundred and fifty days. 
+24. And the waters prevailed upon the earth an hundred and fifty days.
 * 8
 1. And God remembered Noah, and every living thing, and all the cattle that /was/ with him in the ark: and God made a wind to pass over the earth, and the waters asswaged;
 2. The fountains also of the deep and the windows of heaven were stopped, and the rain from heaven was restrained;
@@ -242,7 +242,7 @@
 
 20. And Noah builded an altar unto the LORD; and took of every clean beast, and of every clean fowl, and offered burnt offerings on the altar.
 21. And the LORD smelled a sweet savour; and the LORD said in his heart, I will not again curse the ground any more for man's sake; for the imagination of man's heart /is/ evil from his youth; neither will I again smite any more every thing living, as I have done.
-22. While the earth remaineth, seedtime and harvest, and cold and heat, and summer and winter, and day and night shall not cease. 
+22. While the earth remaineth, seedtime and harvest, and cold and heat, and summer and winter, and day and night shall not cease.
 * 9
 1. And God blessed Noah and his sons, and said unto them, Be fruitful, and multiply, and replenish the earth.
 2. And the fear of you and the dread of you shall be upon every beast of the earth, and upon every fowl of the air, upon all that moveth /upon/ the earth, and upon all the fishes of the sea; into your hand are they delivered.
@@ -275,7 +275,7 @@
 27. God shall enlarge Japheth, and he shall dwell in the tents of Shem; and Canaan shall be his servant.
 
 28. And Noah lived after the flood three hundred and fifty years.
-29. And all the days of Noah were nine hundred and fifty years: and he died. 
+29. And all the days of Noah were nine hundred and fifty years: and he died.
 * 10
 1. Now these /are/ the generations of the sons of Noah, Shem, Ham, and Japheth: and unto them were sons born after the flood.
 2. The sons of Japheth; Gomer, and Magog, and Madai, and Javan, and Tubal, and Meshech, and Tiras.
@@ -311,7 +311,7 @@
 29. And Ophir, and Havilah, and Jobab: all these /were/ the sons of Joktan.
 30. And their dwelling was from Mesha, as thou goest unto Sephar a mount of the east.
 31. These /are/ the sons of Shem, after their families, after their tongues, in their lands, after their nations.
-32. These /are/ the families of the sons of Noah, after their generations, in their nations: and by these were the nations divided in the earth after the flood. 
+32. These /are/ the families of the sons of Noah, after their generations, in their nations: and by these were the nations divided in the earth after the flood.
 * 11
 1. And the whole earth was of one language, and of one speech.
 2. And it came to pass, as they journeyed from the east, that they found a plain in the land of Shinar; and they dwelt there.
@@ -346,7 +346,7 @@
 29. And Abram and Nahor took them wives: the name of Abram's wife /was/ Sarai; and the name of Nahor's wife, Milcah, the daughter of Haran, the father of Milcah, and the father of Iscah.
 30. But Sarai was barren; she /had/ no child.
 31. And Terah took Abram his son, and Lot the son of Haran his son's son, and Sarai his daughter in law, his son Abram's wife; and they went forth with them from Ur of the Chaldees, to go into the land of Canaan; and they came unto Haran, and dwelt there.
-32. And the days of Terah were two hundred and five years: and Terah died in Haran. 
+32. And the days of Terah were two hundred and five years: and Terah died in Haran.
 * 12
 1. Now the LORD had said unto Abram, Get thee out of thy country, and from thy kindred, and from thy father's house, unto a land that I will shew thee:
 2. And I will make of thee a great nation, and I will bless thee, and make thy name great; and thou shalt be a blessing:
@@ -370,7 +370,7 @@
 17. And the LORD plagued Pharaoh and his house with great plagues because of Sarai Abram's wife.
 18. And Pharaoh called Abram, and said, What /is/ this /that/ thou hast done unto me? why didst thou not tell me that she /was/ thy wife?
 19. Why saidst thou, She /is/ my sister? so I might have taken her to me to wife: now therefore behold thy wife, take /her/, and go thy way.
-20. And Pharaoh commanded /his/ men concerning him: and they sent him away, and his wife, and all that he had. 
+20. And Pharaoh commanded /his/ men concerning him: and they sent him away, and his wife, and all that he had.
 * 13
 1. And Abram went up out of Egypt, he, and his wife, and all that he had, and Lot with him, into the south.
 2. And Abram /was/ very rich in cattle, in silver, and in gold.
@@ -391,7 +391,7 @@
 15. For all the land which thou seest, to thee will I give it, and to thy seed for ever.
 16. And I will make thy seed as the dust of the earth: so that if a man can number the dust of the earth, /then/ shall thy seed also be numbered.
 17. Arise, walk through the land in the length of it and in the breadth of it; for I will give it unto thee.
-18. Then Abram removed /his/ tent, and came and dwelt in the plain of Mamre, which /is/ in Hebron, and built there an altar unto the LORD. 
+18. Then Abram removed /his/ tent, and came and dwelt in the plain of Mamre, which /is/ in Hebron, and built there an altar unto the LORD.
 * 14
 1. And it came to pass in the days of Amraphel king of Shinar, Arioch king of Ellasar, Chedorlaomer king of Elam, and Tidal king of nations;
 2. /That these/ made war with Bera king of Sodom, and with Birsha king of Gomorrah, Shinab king of Admah, and Shemeber king of Zeboiim, and the king of Bela, which is Zoar.
@@ -418,7 +418,7 @@
 21. And the king of Sodom said unto Abram, Give me the persons, and take the goods to thyself.
 22. And Abram said to the king of Sodom, I have lift up mine hand unto the LORD, the most high God, the possessor of heaven and earth,
 23. That I will not /take/ from a thread even to a shoelatchet, and that I will not take any thing that /is/ thine, lest thou shouldest say, I have made Abram rich:
-24. Save only that which the young men have eaten, and the portion of the men which went with me, Aner, Eshcol, and Mamre; let them take their portion. 
+24. Save only that which the young men have eaten, and the portion of the men which went with me, Aner, Eshcol, and Mamre; let them take their portion.
 * 15
 1. After these things the word of the LORD came unto Abram in a vision, saying, Fear not, Abram: I /am/ thy shield, /and/ thy exceeding great reward.
 2. And Abram said, Lord GOD, what wilt thou give me, seeing I go childless, and the steward of my house /is/ this Eliezer of Damascus?
@@ -440,7 +440,7 @@
 18. In the same day the LORD made a covenant with Abram, saying, Unto thy seed have I given this land, from the river of Egypt unto the great river, the river Euphrates:
 19. The Kenites, and the Kenizzites, and the Kadmonites,
 20. And the Hittites, and the Perizzites, and the Rephaims,
-21. And the Amorites, and the Canaanites, and the Girgashites, and the Jebusites. 
+21. And the Amorites, and the Canaanites, and the Girgashites, and the Jebusites.
 * 16
 1. Now Sarai Abram's wife bare him no children: and she had an handmaid, an Egyptian, whose name /was/ Hagar.
 2. And Sarai said unto Abram, Behold now, the LORD hath restrained me from bearing: I pray thee, go in unto my maid; it may be that I may obtain children by her. And Abram hearkened to the voice of Sarai.
@@ -460,7 +460,7 @@
 14. Wherefore the well was called Beer–lahai–roi; behold, /it is/ between Kadesh and Bered.
 
 15. And Hagar bare Abram a son: and Abram called his son's name, which Hagar bare, Ishmael.
-16. And Abram /was/ fourscore and six years old, when Hagar bare Ishmael to Abram. 
+16. And Abram /was/ fourscore and six years old, when Hagar bare Ishmael to Abram.
 * 17
 1. And when Abram was ninety years old and nine, the LORD appeared to Abram, and said unto him, I /am/ the Almighty God; walk before me, and be thou perfect.
 2. And I will make my covenant between me and thee, and will multiply thee exceedingly.
@@ -491,7 +491,7 @@
 24. And Abraham /was/ ninety years old and nine, when he was circumcised in the flesh of his foreskin.
 25. And Ishmael his son /was/ thirteen years old, when he was circumcised in the flesh of his foreskin.
 26. In the selfsame day was Abraham circumcised, and Ishmael his son.
-27. And all the men of his house, born in the house, and bought with money of the stranger, were circumcised with him. 
+27. And all the men of his house, born in the house, and bought with money of the stranger, were circumcised with him.
 * 18
 1. And the LORD appeared unto him in the plains of Mamre: and he sat in the tent door in the heat of the day;
 2. And he lift up his eyes and looked, and, lo, three men stood by him: and when he saw /them/, he ran to meet them from the tent door, and bowed himself toward the ground,
@@ -528,7 +528,7 @@
 30. And he said /unto him/, Oh let not the Lord be angry, and I will speak: Peradventure there shall thirty be found there. And he said, I will not do /it/, if I find thirty there.
 31. And he said, Behold now, I have taken upon me to speak unto the Lord: Peradventure there shall be twenty found there. And he said, I will not destroy /it/ for twenty's sake.
 32. And he said, Oh let not the Lord be angry, and I will speak yet but this once: Peradventure ten shall be found there. And he said, I will not destroy /it/ for ten's sake.
-33. And the LORD went his way, as soon as he had left communing with Abraham: and Abraham returned unto his place. 
+33. And the LORD went his way, as soon as he had left communing with Abraham: and Abraham returned unto his place.
 * 19
 1. And there came two angels to Sodom at even; and Lot sat in the gate of Sodom: and Lot seeing /them/ rose up to meet them; and he bowed himself with his face toward the ground;
 2. And he said, Behold now, my lords, turn in, I pray you, into your servant's house, and tarry all night, and wash your feet, and ye shall rise up early, and go on your ways. And they said, Nay; but we will abide in the street all night.
@@ -576,7 +576,7 @@
 35. And they made their father drink wine that night also: and the younger arose, and lay with him; and he perceived not when she lay down, nor when she arose.
 36. Thus were both the daughters of Lot with child by their father.
 37. And the firstborn bare a son, and called his name Moab: the same /is/ the father of the Moabites unto this day.
-38. And the younger, she also bare a son, and called his name Ben–ammi: the same /is/ the father of the children of Ammon unto this day. 
+38. And the younger, she also bare a son, and called his name Ben–ammi: the same /is/ the father of the children of Ammon unto this day.
 * 20
 1. And Abraham journeyed from thence toward the south country, and dwelled between Kadesh and Shur, and sojourned in Gerar.
 2. And Abraham said of Sarah his wife, She /is/ my sister: and Abimelech king of Gerar sent, and took Sarah.
@@ -596,7 +596,7 @@
 16. And unto Sarah he said, Behold, I have given thy brother a thousand /pieces/ of silver: behold, he /is/ to thee a covering of the eyes, unto all that /are/ with thee, and with all /other/: thus she was reproved.
 
 17. So Abraham prayed unto God: and God healed Abimelech, and his wife, and his maidservants; and they bare /children/.
-18. For the LORD had fast closed up all the wombs of the house of Abimelech, because of Sarah Abraham's wife. 
+18. For the LORD had fast closed up all the wombs of the house of Abimelech, because of Sarah Abraham's wife.
 * 21
 1. And the LORD visited Sarah as he had said, and the LORD did unto Sarah as he had spoken.
 2. For Sarah conceived, and bare Abraham a son in his old age, at the set time of which God had spoken to him.
@@ -636,7 +636,7 @@
 32. Thus they made a covenant at Beer–sheba: then Abimelech rose up, and Phichol the chief captain of his host, and they returned into the land of the Philistines.
 
 33. And /Abraham/ planted a grove in Beer–sheba, and called there on the name of the LORD, the everlasting God.
-34. And Abraham sojourned in the Philistines' land many days. 
+34. And Abraham sojourned in the Philistines' land many days.
 * 22
 1. And it came to pass after these things, that God did tempt Abraham, and said unto him, Abraham: and he said, Behold, /here/ I /am/.
 2. And he said, Take now thy son, thine only /son/ Isaac, whom thou lovest, and get thee into the land of Moriah; and offer him there for a burnt offering upon one of the mountains which I will tell thee of.
@@ -664,7 +664,7 @@
 21. Huz his firstborn, and Buz his brother, and Kemuel the father of Aram,
 22. And Chesed, and Hazo, and Pildash, and Jidlaph, and Bethuel.
 23. And Bethuel begat Rebekah: these eight Milcah did bear to Nahor, Abraham's brother.
-24. And his concubine, whose name /was/ Reumah, she bare also Tebah, and Gaham, and Thahash, and Maachah. 
+24. And his concubine, whose name /was/ Reumah, she bare also Tebah, and Gaham, and Thahash, and Maachah.
 * 23
 1. And Sarah was an hundred and seven and twenty years old: /these were/ the years of the life of Sarah.
 2. And Sarah died in Kirjath–arba; the same /is/ Hebron in the land of Canaan: and Abraham came to mourn for Sarah, and to weep for her.
@@ -687,7 +687,7 @@
 17. And the field of Ephron, which /was/ in Machpelah, which /was/ before Mamre, the field, and the cave which /was/ therein, and all the trees that /were/ in the field, that /were/ in all the borders round about, were made sure
 18. Unto Abraham for a possession in the presence of the children of Heth, before all that went in at the gate of his city.
 19. And after this, Abraham buried Sarah his wife in the cave of the field of Machpelah before Mamre: the same /is/ Hebron in the land of Canaan.
-20. And the field, and the cave that /is/ therein, were made sure unto Abraham for a possession of a buryingplace by the sons of Heth. 
+20. And the field, and the cave that /is/ therein, were made sure unto Abraham for a possession of a buryingplace by the sons of Heth.
 * 24
 1. And Abraham was old, /and/ well stricken in age: and the LORD had blessed Abraham in all things.
 2. And Abraham said unto his eldest servant of his house, that ruled over all that he had, Put, I pray thee, thy hand under my thigh:
@@ -761,7 +761,7 @@
 64. And Rebekah lifted up her eyes, and when she saw Isaac, she lighted off the camel.
 65. For she /had/ said unto the servant, What man /is/ this that walketh in the field to meet us? And the servant /had/ said, It /is/ my master: therefore she took a vail, and covered herself.
 66. And the servant told Isaac all things that he had done.
-67. And Isaac brought her into his mother Sarah's tent, and took Rebekah, and she became his wife; and he loved her: and Isaac was comforted after his mother's /death/. 
+67. And Isaac brought her into his mother Sarah's tent, and took Rebekah, and she became his wife; and he loved her: and Isaac was comforted after his mother's /death/.
 * 25
 1. Then again Abraham took a wife, and her name /was/ Keturah.
 2. And she bare him Zimran, and Jokshan, and Medan, and Midian, and Ishbak, and Shuah.
@@ -802,7 +802,7 @@
 31. And Jacob said, Sell me this day thy birthright.
 32. And Esau said, Behold, I /am/ at the point to die: and what profit shall this birthright do to me?
 33. And Jacob said, Swear to me this day; and he sware unto him: and he sold his birthright unto Jacob.
-34. Then Jacob gave Esau bread and pottage of lentiles; and he did eat and drink, and rose up, and went his way: thus Esau despised /his/ birthright. 
+34. Then Jacob gave Esau bread and pottage of lentiles; and he did eat and drink, and rose up, and went his way: thus Esau despised /his/ birthright.
 * 26
 1. And there was a famine in the land, beside the first famine that was in the days of Abraham. And Isaac went unto Abimelech king of the Philistines unto Gerar.
 2. And the LORD appeared unto him, and said, Go not down into Egypt; dwell in the land which I shall tell thee of:
@@ -842,7 +842,7 @@
 33. And he called it Shebah: therefore the name of the city /is/ Beer–sheba unto this day.
 
 34. And Esau was forty years old when he took to wife Judith the daughter of Beeri the Hittite, and Bashemath the daughter of Elon the Hittite:
-35. Which were a grief of mind unto Isaac and to Rebekah. 
+35. Which were a grief of mind unto Isaac and to Rebekah.
 * 27
 1. And it came to pass, that when Isaac was old, and his eyes were dim, so that he could not see, he called Esau his eldest son, and said unto him, My son: and he said unto him, Behold, /here am/ I.
 2. And he said, Behold now, I am old, I know not the day of my death:
@@ -893,7 +893,7 @@
 43. Now therefore, my son, obey my voice; and arise, flee thou to Laban my brother to Haran;
 44. And tarry with him a few days, until thy brother's fury turn away;
 45. Until thy brother's anger turn away from thee, and he forget /that/ which thou hast done to him: then I will send, and fetch thee from thence: why should I be deprived also of you both in one day?
-46. And Rebekah said to Isaac, I am weary of my life because of the daughters of Heth: if Jacob take a wife of the daughters of Heth, such as these /which are/ of the daughters of the land, what good shall my life do me? 
+46. And Rebekah said to Isaac, I am weary of my life because of the daughters of Heth: if Jacob take a wife of the daughters of Heth, such as these /which are/ of the daughters of the land, what good shall my life do me?
 * 28
 1. And Isaac called Jacob, and blessed him, and charged him, and said unto him, Thou shalt not take a wife of the daughters of Canaan.
 2. Arise, go to Padan–aram, to the house of Bethuel thy mother's father; and take thee a wife from thence of the daughters of Laban thy mother's brother.
@@ -919,7 +919,7 @@
 19. And he called the name of that place Beth–el: but the name of that city /was called/ Luz at the first.
 20. And Jacob vowed a vow, saying, If God will be with me, and will keep me in this way that I go, and will give me bread to eat, and raiment to put on,
 21. So that I come again to my father's house in peace; then shall the LORD be my God:
-22. And this stone, which I have set /for/ a pillar, shall be God's house: and of all that thou shalt give me I will surely give the tenth unto thee. 
+22. And this stone, which I have set /for/ a pillar, shall be God's house: and of all that thou shalt give me I will surely give the tenth unto thee.
 * 29
 1. Then Jacob went on his journey, and came into the land of the people of the east.
 2. And he looked, and behold a well in the field, and, lo, there /were/ three flocks of sheep lying by it; for out of that well they watered the flocks: and a great stone /was/ upon the well's mouth.
@@ -959,7 +959,7 @@
 32. And Leah conceived, and bare a son, and she called his name Reuben: for she said, Surely the LORD hath looked upon my affliction; now therefore my husband will love me.
 33. And she conceived again, and bare a son; and said, Because the LORD hath heard that I /was/ hated, he hath therefore given me this /son/ also: and she called his name Simeon.
 34. And she conceived again, and bare a son; and said, Now this time will my husband be joined unto me, because I have born him three sons: therefore was his name called Levi.
-35. And she conceived again, and bare a son: and she said, Now will I praise the LORD: therefore she called his name Judah; and left bearing. 
+35. And she conceived again, and bare a son: and she said, Now will I praise the LORD: therefore she called his name Judah; and left bearing.
 * 30
 1. And when Rachel saw that she bare Jacob no children, Rachel envied her sister; and said unto Jacob, Give me children, or else I die.
 2. And Jacob's anger was kindled against Rachel: and he said, /Am/ I in God's stead, who hath withheld from thee the fruit of the womb?
@@ -1007,7 +1007,7 @@
 40. And Jacob did separate the lambs, and set the faces of the flocks toward the ringstraked, and all the brown in the flock of Laban; and he put his own flocks by themselves, and put them not unto Laban's cattle.
 41. And it came to pass, whensoever the stronger cattle did conceive, that Jacob laid the rods before the eyes of the cattle in the gutters, that they might conceive among the rods.
 42. But when the cattle were feeble, he put /them/ not in: so the feebler were Laban's, and the stronger Jacob's.
-43. And the man increased exceedingly, and had much cattle, and maidservants, and menservants, and camels, and asses. 
+43. And the man increased exceedingly, and had much cattle, and maidservants, and menservants, and camels, and asses.
 * 31
 1. And he heard the words of Laban's sons, saying, Jacob hath taken away all that /was/ our father's; and of /that/ which /was/ our father's hath he gotten all this glory.
 2. And Jacob beheld the countenance of Laban, and, behold, it /was/ not toward him as before.
@@ -1067,7 +1067,7 @@
 52. This heap /be/ witness, and /this/ pillar /be/ witness, that I will not pass over this heap to thee, and that thou shalt not pass over this heap and this pillar unto me, for harm.
 53. The God of Abraham, and the God of Nahor, the God of their father, judge betwixt us. And Jacob sware by the fear of his father Isaac.
 54. Then Jacob offered sacrifice upon the mount, and called his brethren to eat bread: and they did eat bread, and tarried all night in the mount.
-55. And early in the morning Laban rose up, and kissed his sons and his daughters, and blessed them: and Laban departed, and returned unto his place. 
+55. And early in the morning Laban rose up, and kissed his sons and his daughters, and blessed them: and Laban departed, and returned unto his place.
 * 32
 1. And Jacob went on his way, and the angels of God met him.
 2. And when Jacob saw them, he said, This /is/ God's host: and he called the name of that place Mahanaim.
@@ -1104,7 +1104,7 @@
 29. And Jacob asked /him/, and said, Tell /me/, I pray thee, thy name. And he said, Wherefore /is/ it /that/ thou dost ask after my name? And he blessed him there.
 30. And Jacob called the name of the place Peniel: for I have seen God face to face, and my life is preserved.
 31. And as he passed over Penuel the sun rose upon him, and he halted upon his thigh.
-32. Therefore the children of Israel eat not /of/ the sinew which shrank, which /is/ upon the hollow of the thigh, unto this day: because he touched the hollow of Jacob's thigh in the sinew that shrank. 
+32. Therefore the children of Israel eat not /of/ the sinew which shrank, which /is/ upon the hollow of the thigh, unto this day: because he touched the hollow of Jacob's thigh in the sinew that shrank.
 * 33
 1. And Jacob lifted up his eyes, and looked, and, behold, Esau came, and with him four hundred men. And he divided the children unto Leah, and unto Rachel, and unto the two handmaids.
 2. And he put the handmaids and their children foremost, and Leah and her children after, and Rachel and Joseph hindermost.
@@ -1127,7 +1127,7 @@
 
 18. And Jacob came to Shalem, a city of Shechem, which /is/ in the land of Canaan, when he came from Padan–aram; and pitched his tent before the city.
 19. And he bought a parcel of a field, where he had spread his tent, at the hand of the children of Hamor, Shechem's father, for an hundred pieces of money.
-20. And he erected there an altar, and called it El–elohe–Israel. 
+20. And he erected there an altar, and called it El–elohe–Israel.
 * 34
 1. And Dinah the daughter of Leah, which she bare unto Jacob, went out to see the daughters of the land.
 2. And when Shechem the son of Hamor the Hivite, prince of the country, saw her, he took her, and lay with her, and defiled her.
@@ -1162,7 +1162,7 @@
 28. They took their sheep, and their oxen, and their asses, and that which /was/ in the city, and that which /was/ in the field,
 29. And all their wealth, and all their little ones, and their wives took they captive, and spoiled even all that /was/ in the house.
 30. And Jacob said to Simeon and Levi, Ye have troubled me to make me to stink among the inhabitants of the land, among the Canaanites and the Perizzites: and I /being/ few in number, they shall gather themselves together against me, and slay me; and I shall be destroyed, I and my house.
-31. And they said, Should he deal with our sister as with an harlot? 
+31. And they said, Should he deal with our sister as with an harlot?
 * 35
 1. And God said unto Jacob, Arise, go up to Beth–el, and dwell there: and make there an altar unto God, that appeared unto thee when thou fleddest from the face of Esau thy brother.
 2. Then Jacob said unto his household, and to all that /were/ with him, Put away the strange gods that /are/ among you, and be clean, and change your garments:
@@ -1197,7 +1197,7 @@
 
 27. And Jacob came unto Isaac his father unto Mamre, unto the city of Arbah, which /is/ Hebron, where Abraham and Isaac sojourned.
 28. And the days of Isaac were an hundred and fourscore years.
-29. And Isaac gave up the ghost, and died, and was gathered unto his people, /being/ old and full of days: and his sons Esau and Jacob buried him. 
+29. And Isaac gave up the ghost, and died, and was gathered unto his people, /being/ old and full of days: and his sons Esau and Jacob buried him.
 * 36
 1. Now these /are/ the generations of Esau, who /is/ Edom.
 2. Esau took his wives of the daughters of Canaan; Adah the daughter of Elon the Hittite, and Aholibamah the daughter of Anah the daughter of Zibeon the Hivite;
@@ -1248,7 +1248,7 @@
 40. And these /are/ the names of the dukes /that came/ of Esau, according to their families, after their places, by their names; duke Timnah, duke Alvah, duke Jetheth,
 41. Duke Aholibamah, duke Elah, duke Pinon,
 42. Duke Kenaz, duke Teman, duke Mibzar,
-43. Duke Magdiel, duke Iram: these /be/ the dukes of Edom, according to their habitations in the land of their possession: he /is/ Esau the father of the Edomites. 
+43. Duke Magdiel, duke Iram: these /be/ the dukes of Edom, according to their habitations in the land of their possession: he /is/ Esau the father of the Edomites.
 * 37
 1. And Jacob dwelt in the land wherein his father was a stranger, in the land of Canaan.
 2. These /are/ the generations of Jacob. Joseph, /being/ seventeen years old, was feeding the flock with his brethren; and the lad /was/ with the sons of Bilhah, and with the sons of Zilpah, his father's wives: and Joseph brought unto his father their evil report.
@@ -1291,7 +1291,7 @@
 33. And he knew it, and said, /It is/ my son's coat; an evil beast hath devoured him; Joseph is without doubt rent in pieces.
 34. And Jacob rent his clothes, and put sackcloth upon his loins, and mourned for his son many days.
 35. And all his sons and all his daughters rose up to comfort him; but he refused to be comforted; and he said, For I will go down into the grave unto my son mourning. Thus his father wept for him.
-36. And the Midianites sold him into Egypt unto Potiphar, an officer of Pharaoh's, /and/ captain of the guard. 
+36. And the Midianites sold him into Egypt unto Potiphar, an officer of Pharaoh's, /and/ captain of the guard.
 * 38
 1. And it came to pass at that time, that Judah went down from his brethren, and turned in to a certain Adullamite, whose name /was/ Hirah.
 2. And Judah saw there a daughter of a certain Canaanite, whose name /was/ Shuah; and he took her, and went in unto her.
@@ -1325,7 +1325,7 @@
 27. And it came to pass in the time of her travail, that, behold, twins /were/ in her womb.
 28. And it came to pass, when she travailed, that /the one/ put out /his/ hand: and the midwife took and bound upon his hand a scarlet thread, saying, This came out first.
 29. And it came to pass, as he drew back his hand, that, behold, his brother came out: and she said, How hast thou broken forth? /this/ breach /be/ upon thee: therefore his name was called Pharez.
-30. And afterward came out his brother, that had the scarlet thread upon his hand: and his name was called Zarah. 
+30. And afterward came out his brother, that had the scarlet thread upon his hand: and his name was called Zarah.
 * 39
 1. And Joseph was brought down to Egypt; and Potiphar, an officer of Pharaoh, captain of the guard, an Egyptian, bought him of the hands of the Ishmeelites, which had brought him down thither.
 2. And the LORD was with Joseph, and he was a prosperous man; and he was in the house of his master the Egyptian.
@@ -1351,7 +1351,7 @@
 
 21. But the LORD was with Joseph, and shewed him mercy, and gave him favour in the sight of the keeper of the prison.
 22. And the keeper of the prison committed to Joseph's hand all the prisoners that /were/ in the prison; and whatsoever they did there, he was the doer /of it/.
-23. The keeper of the prison looked not to any thing /that was/ under his hand; because the LORD was with him, and /that/ which he did, the LORD made /it/ to prosper. 
+23. The keeper of the prison looked not to any thing /that was/ under his hand; because the LORD was with him, and /that/ which he did, the LORD made /it/ to prosper.
 * 40
 1. And it came to pass after these things, /that/ the butler of the king of Egypt and /his/ baker had offended their lord the king of Egypt.
 2. And Pharaoh was wroth against two /of/ his officers, against the chief of the butlers, and against the chief of the bakers.
@@ -1377,7 +1377,7 @@
 20. And it came to pass the third day, /which was/ Pharaoh's birthday, that he made a feast unto all his servants: and he lifted up the head of the chief butler and of the chief baker among his servants.
 21. And he restored the chief butler unto his butlership again; and he gave the cup into Pharaoh's hand:
 22. But he hanged the chief baker: as Joseph had interpreted to them.
-23. Yet did not the chief butler remember Joseph, but forgat him. 
+23. Yet did not the chief butler remember Joseph, but forgat him.
 * 41
 1. And it came to pass at the end of two full years, that Pharaoh dreamed: and, behold, he stood by the river.
 2. And, behold, there came up out of the river seven well favoured kine and fatfleshed; and they fed in a meadow.
@@ -1441,7 +1441,7 @@
 54. And the seven years of dearth began to come, according as Joseph had said: and the dearth was in all lands; but in all the land of Egypt there was bread.
 55. And when all the land of Egypt was famished, the people cried to Pharaoh for bread: and Pharaoh said unto all the Egyptians, Go unto Joseph; what he saith to you, do.
 56. And the famine was over all the face of the earth: And Joseph opened all the storehouses, and sold unto the Egyptians; and the famine waxed sore in the land of Egypt.
-57. And all countries came into Egypt to Joseph for to buy /corn/; because that the famine was /so/ sore in all lands. 
+57. And all countries came into Egypt to Joseph for to buy /corn/; because that the famine was /so/ sore in all lands.
 * 42
 1. Now when Jacob saw that there was corn in Egypt, Jacob said unto his sons, Why do ye look one upon another?
 2. And he said, Behold, I have heard that there is corn in Egypt: get you down thither, and buy for us from thence; that we may live, and not die.
@@ -1485,7 +1485,7 @@
 35. And it came to pass as they emptied their sacks, that, behold, every man's bundle of money /was/ in his sack: and when /both/ they and their father saw the bundles of money, they were afraid.
 36. And Jacob their father said unto them, Me have ye bereaved /of my children/: Joseph /is/ not, and Simeon /is/ not, and ye will take Benjamin /away/: all these things are against me.
 37. And Reuben spake unto his father, saying, Slay my two sons, if I bring him not to thee: deliver him into my hand, and I will bring him to thee again.
-38. And he said, My son shall not go down with you; for his brother is dead, and he is left alone: if mischief befall him by the way in the which ye go, then shall ye bring down my gray hairs with sorrow to the grave. 
+38. And he said, My son shall not go down with you; for his brother is dead, and he is left alone: if mischief befall him by the way in the which ye go, then shall ye bring down my gray hairs with sorrow to the grave.
 * 43
 1. And the famine /was/ sore in the land.
 2. And it came to pass, when they had eaten up the corn which they had brought out of Egypt, their father said unto them, Go again, buy us a little food.
@@ -1522,7 +1522,7 @@
 31. And he washed his face, and went out, and refrained himself, and said, Set on bread.
 32. And they set on for him by himself, and for them by themselves, and for the Egyptians, which did eat with him, by themselves: because the Egyptians might not eat bread with the Hebrews; for that /is/ an abomination unto the Egyptians.
 33. And they sat before him, the firstborn according to his birthright, and the youngest according to his youth: and the men marvelled one at another.
-34. And he took /and sent/ messes unto them from before him: but Benjamin's mess was five times so much as any of theirs. And they drank, and were merry with him. 
+34. And he took /and sent/ messes unto them from before him: but Benjamin's mess was five times so much as any of theirs. And they drank, and were merry with him.
 * 44
 1. And he commanded the steward of his house, saying, Fill the men's sacks /with/ food, as much as they can carry, and put every man's money in his sack's mouth.
 2. And put my cup, the silver cup, in the sack's mouth of the youngest, and his corn money. And he did according to the word that Joseph had spoken.
@@ -1560,7 +1560,7 @@
 31. It shall come to pass, when he seeth that the lad /is/ not /with us/, that he will die: and thy servants shall bring down the gray hairs of thy servant our father with sorrow to the grave.
 32. For thy servant became surety for the lad unto my father, saying, If I bring him not unto thee, then I shall bear the blame to my father for ever.
 33. Now therefore, I pray thee, let thy servant abide instead of the lad a bondman to my lord; and let the lad go up with his brethren.
-34. For how shall I go up to my father, and the lad /be/ not with me? lest peradventure I see the evil that shall come on my father. 
+34. For how shall I go up to my father, and the lad /be/ not with me? lest peradventure I see the evil that shall come on my father.
 * 45
 1. Then Joseph could not refrain himself before all them that stood by him; and he cried, Cause every man to go out from me. And there stood no man with him, while Joseph made himself known unto his brethren.
 2. And he wept aloud: and the Egyptians and the house of Pharaoh heard.
@@ -1591,7 +1591,7 @@
 25. And they went up out of Egypt, and came into the land of Canaan unto Jacob their father,
 26. And told him, saying, Joseph /is/ yet alive, and he /is/ governor over all the land of Egypt. And Jacob's heart fainted, for he believed them not.
 27. And they told him all the words of Joseph, which he had said unto them: and when he saw the wagons which Joseph had sent to carry him, the spirit of Jacob their father revived:
-28. And Israel said, /It is/ enough; Joseph my son /is/ yet alive: I will go and see him before I die. 
+28. And Israel said, /It is/ enough; Joseph my son /is/ yet alive: I will go and see him before I die.
 * 46
 1. And Israel took his journey with all that he had, and came to Beer–sheba, and offered sacrifices unto the God of his father Isaac.
 2. And God spake unto Israel in the visions of the night, and said, Jacob, Jacob. And he said, Here /am/ I.
@@ -1639,7 +1639,7 @@
 31. And Joseph said unto his brethren, and unto his father's house, I will go up, and shew Pharaoh, and say unto him, My brethren, and my father's house, which /were/ in the land of Canaan, are come unto me;
 32. And the men /are/ shepherds, for their trade hath been to feed cattle; and they have brought their flocks, and their herds, and all that they have.
 33. And it shall come to pass, when Pharaoh shall call you, and shall say, What /is/ your occupation?
-34. That ye shall say, Thy servants' trade hath been about cattle from our youth even until now, both we, /and/ also our fathers: that ye may dwell in the land of Goshen; for every shepherd /is/ an abomination unto the Egyptians. 
+34. That ye shall say, Thy servants' trade hath been about cattle from our youth even until now, both we, /and/ also our fathers: that ye may dwell in the land of Goshen; for every shepherd /is/ an abomination unto the Egyptians.
 * 47
 1. Then Joseph came and told Pharaoh, and said, My father and my brethren, and their flocks, and their herds, and all that they have, are come out of the land of Canaan; and, behold, they /are/ in the land of Goshen.
 2. And he took some of his brethren, /even/ five men, and presented them unto Pharaoh.
@@ -1674,7 +1674,7 @@
 28. And Jacob lived in the land of Egypt seventeen years: so the whole age of Jacob was an hundred forty and seven years.
 29. And the time drew nigh that Israel must die: and he called his son Joseph, and said unto him, If now I have found grace in thy sight, put, I pray thee, thy hand under my thigh, and deal kindly and truly with me; bury me not, I pray thee, in Egypt:
 30. But I will lie with my fathers, and thou shalt carry me out of Egypt, and bury me in their buryingplace. And he said, I will do as thou hast said.
-31. And he said, Swear unto me. And he sware unto him. And Israel bowed himself upon the bed's head. 
+31. And he said, Swear unto me. And he sware unto him. And Israel bowed himself upon the bed's head.
 * 48
 1. And it came to pass after these things, that /one/ told Joseph, Behold, thy father /is/ sick: and he took with him his two sons, Manasseh and Ephraim.
 2. And /one/ told Jacob, and said, Behold, thy son Joseph cometh unto thee: and Israel strengthened himself, and sat upon the bed.
@@ -1699,7 +1699,7 @@
 19. And his father refused, and said, I know /it/, my son, I know /it/: he also shall become a people, and he also shall be great: but truly his younger brother shall be greater than he, and his seed shall become a multitude of nations.
 20. And he blessed them that day, saying, In thee shall Israel bless, saying, God make thee as Ephraim and as Manasseh: and he set Ephraim before Manasseh.
 21. And Israel said unto Joseph, Behold, I die: but God shall be with you, and bring you again unto the land of your fathers.
-22. Moreover I have given to thee one portion above thy brethren, which I took out of the hand of the Amorite with my sword and with my bow. 
+22. Moreover I have given to thee one portion above thy brethren, which I took out of the hand of the Amorite with my sword and with my bow.
 * 49
 1. And Jacob called unto his sons, and said, Gather yourselves together, that I may tell you /that/ which shall befall you in the last days.
 2. Gather yourselves together, and hear, ye sons of Jacob; and hearken unto Israel your father.
@@ -1745,7 +1745,7 @@
 30. In the cave that /is/ in the field of Machpelah, which /is/ before Mamre, in the land of Canaan, which Abraham bought with the field of Ephron the Hittite for a possession of a buryingplace.
 31. There they buried Abraham and Sarah his wife; there they buried Isaac and Rebekah his wife; and there I buried Leah.
 32. The purchase of the field and of the cave that /is/ therein /was/ from the children of Heth.
-33. And when Jacob had made an end of commanding his sons, he gathered up his feet into the bed, and yielded up the ghost, and was gathered unto his people. 
+33. And when Jacob had made an end of commanding his sons, he gathered up his feet into the bed, and yielded up the ghost, and was gathered unto his people.
 * 50
 1. And Joseph fell upon his father's face, and wept upon him, and kissed him.
 2. And Joseph commanded his servants the physicians to embalm his father: and the physicians embalmed Israel.
@@ -1776,4 +1776,4 @@
 23. And Joseph saw Ephraim's children of the third /generation/: the children also of Machir the son of Manasseh were brought up upon Joseph's knees.
 24. And Joseph said unto his brethren, I die: and God will surely visit you, and bring you out of this land unto the land which he sware to Abraham, to Isaac, and to Jacob.
 25. And Joseph took an oath of the children of Israel, saying, God will surely visit you, and ye shall carry up my bones from hence.
-26. So Joseph died, /being/ an hundred and ten years old: and they embalmed him, and he was put in a coffin in Egypt.  
+26. So Joseph died, /being/ an hundred and ten years old: and they embalmed him, and he was put in a coffin in Egypt.

--- a/02_EXO.org
+++ b/02_EXO.org
@@ -23,7 +23,7 @@
 19. And the midwives said unto Pharaoh, Because the Hebrew women /are/ not as the Egyptian women; for they /are/ lively, and are delivered ere the midwives come in unto them.
 20. Therefore God dealt well with the midwives: and the people multiplied, and waxed very mighty.
 21. And it came to pass, because the midwives feared God, that he made them houses.
-22. And Pharaoh charged all his people, saying, Every son that is born ye shall cast into the river, and every daughter ye shall save alive. 
+22. And Pharaoh charged all his people, saying, Every son that is born ye shall cast into the river, and every daughter ye shall save alive.
 * 2
 1. And there went a man of the house of Levi, and took /to wife/ a daughter of Levi.
 2. And the woman conceived, and bare a son: and when she saw him that he /was a/ goodly /child/, she hid him three months.
@@ -52,7 +52,7 @@
 
 23. And it came to pass in process of time, that the king of Egypt died: and the children of Israel sighed by reason of the bondage, and they cried, and their cry came up unto God by reason of the bondage.
 24. And God heard their groaning, and God remembered his covenant with Abraham, with Isaac, and with Jacob.
-25. And God looked upon the children of Israel, and God had respect unto /them/. 
+25. And God looked upon the children of Israel, and God had respect unto /them/.
 * 3
 1. Now Moses kept the flock of Jethro his father in law, the priest of Midian: and he led the flock to the backside of the desert, and came to the mountain of God, /even/ to Horeb.
 2. And the angel of the LORD appeared unto him in a flame of fire out of the midst of a bush: and he looked, and, behold, the bush burned with fire, and the bush /was/ not consumed.
@@ -78,7 +78,7 @@
 19. And I am sure that the king of Egypt will not let you go, no, not by a mighty hand.
 20. And I will stretch out my hand, and smite Egypt with all my wonders which I will do in the midst thereof: and after that he will let you go.
 21. And I will give this people favour in the sight of the Egyptians: and it shall come to pass, that, when ye go, ye shall not go empty:
-22. But every woman shall borrow of her neighbour, and of her that sojourneth in her house, jewels of silver, and jewels of gold, and raiment: and ye shall put /them/ upon your sons, and upon your daughters; and ye shall spoil the Egyptians. 
+22. But every woman shall borrow of her neighbour, and of her that sojourneth in her house, jewels of silver, and jewels of gold, and raiment: and ye shall put /them/ upon your sons, and upon your daughters; and ye shall spoil the Egyptians.
 * 4
 1. And Moses answered and said, But, behold, they will not believe me, nor hearken unto my voice: for they will say, The LORD hath not appeared unto thee.
 2. And the LORD said unto him, What /is/ that in thine hand? And he said, A rod.
@@ -116,7 +116,7 @@
 
 29. And Moses and Aaron went and gathered together all the elders of the children of Israel:
 30. And Aaron spake all the words which the LORD had spoken unto Moses, and did the signs in the sight of the people.
-31. And the people believed: and when they heard that the LORD had visited the children of Israel, and that he had looked upon their affliction, then they bowed their heads and worshipped. 
+31. And the people believed: and when they heard that the LORD had visited the children of Israel, and that he had looked upon their affliction, then they bowed their heads and worshipped.
 * 5
 1. And afterward Moses and Aaron went in, and told Pharaoh, Thus saith the LORD God of Israel, Let my people go, that they may hold a feast unto me in the wilderness.
 2. And Pharaoh said, Who /is/ the LORD, that I should obey his voice to let Israel go? I know not the LORD, neither will I let Israel go.
@@ -143,7 +143,7 @@
 20. And they met Moses and Aaron, who stood in the way, as they came forth from Pharaoh:
 21. And they said unto them, The LORD look upon you, and judge; because ye have made our savour to be abhorred in the eyes of Pharaoh, and in the eyes of his servants, to put a sword in their hand to slay us.
 22. And Moses returned unto the LORD, and said, Lord, wherefore hast thou /so/ evil entreated this people? why /is/ it /that/ thou hast sent me?
-23. For since I came to Pharaoh to speak in thy name, he hath done evil to this people; neither hast thou delivered thy people at all. 
+23. For since I came to Pharaoh to speak in thy name, he hath done evil to this people; neither hast thou delivered thy people at all.
 * 6
 1. Then the LORD said unto Moses, Now shalt thou see what I will do to Pharaoh: for with a strong hand shall he let them go, and with a strong hand shall he drive them out of his land.
 2. And God spake unto Moses, and said unto him, I /am/ the LORD:
@@ -179,7 +179,7 @@
 
 28. And it came to pass on the day /when/ the LORD spake unto Moses in the land of Egypt,
 29. That the LORD spake unto Moses, saying, I /am/ the LORD: speak thou unto Pharaoh king of Egypt all that I say unto thee.
-30. And Moses said before the LORD, Behold, I /am/ of uncircumcised lips, and how shall Pharaoh hearken unto me? 
+30. And Moses said before the LORD, Behold, I /am/ of uncircumcised lips, and how shall Pharaoh hearken unto me?
 * 7
 1. And the LORD said unto Moses, See, I have made thee a god to Pharaoh: and Aaron thy brother shall be thy prophet.
 2. Thou shalt speak all that I command thee: and Aaron thy brother shall speak unto Pharaoh, that he send the children of Israel out of his land.
@@ -209,7 +209,7 @@
 22. And the magicians of Egypt did so with their enchantments: and Pharaoh's heart was hardened, neither did he hearken unto them; as the LORD had said.
 23. And Pharaoh turned and went into his house, neither did he set his heart to this also.
 24. And all the Egyptians digged round about the river for water to drink; for they could not drink of the water of the river.
-25. And seven days were fulfilled, after that the LORD had smitten the river. 
+25. And seven days were fulfilled, after that the LORD had smitten the river.
 * 8
 1. And the LORD spake unto Moses, Go unto Pharaoh, and say unto him, Thus saith the LORD, Let my people go, that they may serve me.
 2. And if thou refuse to let /them/ go, behold, I will smite all thy borders with frogs:
@@ -247,7 +247,7 @@
 29. And Moses said, Behold, I go out from thee, and I will intreat the LORD that the swarms /of flies/ may depart from Pharaoh, from his servants, and from his people, to morrow: but let not Pharaoh deal deceitfully any more in not letting the people go to sacrifice to the LORD.
 30. And Moses went out from Pharaoh, and intreated the LORD.
 31. And the LORD did according to the word of Moses; and he removed the swarms /of flies/ from Pharaoh, from his servants, and from his people; there remained not one.
-32. And Pharaoh hardened his heart at this time also, neither would he let the people go. 
+32. And Pharaoh hardened his heart at this time also, neither would he let the people go.
 * 9
 1. Then the LORD said unto Moses, Go in unto Pharaoh, and tell him, Thus saith the LORD God of the Hebrews, Let my people go, that they may serve me.
 2. For if thou refuse to let /them/ go, and wilt hold them still,
@@ -287,7 +287,7 @@
 32. But the wheat and the rie were not smitten: for they /were/ not grown up.
 33. And Moses went out of the city from Pharaoh, and spread abroad his hands unto the LORD: and the thunders and hail ceased, and the rain was not poured upon the earth.
 34. And when Pharaoh saw that the rain and the hail and the thunders were ceased, he sinned yet more, and hardened his heart, he and his servants.
-35. And the heart of Pharaoh was hardened, neither would he let the children of Israel go; as the LORD had spoken by Moses. 
+35. And the heart of Pharaoh was hardened, neither would he let the children of Israel go; as the LORD had spoken by Moses.
 * 10
 1. And the LORD said unto Moses, Go in unto Pharaoh: for I have hardened his heart, and the heart of his servants, that I might shew these my signs before him:
 2. And that thou mayest tell in the ears of thy son, and of thy son's son, what things I have wrought in Egypt, and my signs which I have done among them; that ye may know how that I /am/ the LORD.
@@ -322,7 +322,7 @@
 
 27. But the LORD hardened Pharaoh's heart, and he would not let them go.
 28. And Pharaoh said unto him, Get thee from me, take heed to thyself, see my face no more; for in /that/ day thou seest my face thou shalt die.
-29. And Moses said, Thou hast spoken well, I will see thy face again no more. 
+29. And Moses said, Thou hast spoken well, I will see thy face again no more.
 * 11
 1. And the LORD said unto Moses, Yet will I bring one plague /more/ upon Pharaoh, and upon Egypt; afterwards he will let you go hence: when he shall let /you/ go, he shall surely thrust you out hence altogether.
 2. Speak now in the ears of the people, and let every man borrow of his neighbour, and every woman of her neighbour, jewels of silver, and jewels of gold.
@@ -333,7 +333,7 @@
 7. But against any of the children of Israel shall not a dog move his tongue, against man or beast: that ye may know how that the LORD doth put a difference between the Egyptians and Israel.
 8. And all these thy servants shall come down unto me, and bow down themselves unto me, saying, Get thee out, and all the people that follow thee: and after that I will go out. And he went out from Pharaoh in a great anger.
 9. And the LORD said unto Moses, Pharaoh shall not hearken unto you; that my wonders may be multiplied in the land of Egypt.
-10. And Moses and Aaron did all these wonders before Pharaoh: and the LORD hardened Pharaoh's heart, so that he would not let the children of Israel go out of his land. 
+10. And Moses and Aaron did all these wonders before Pharaoh: and the LORD hardened Pharaoh's heart, so that he would not let the children of Israel go out of his land.
 * 12
 1. And the LORD spake unto Moses and Aaron in the land of Egypt, saying,
 2. This month /shall be/ unto you the beginning of months: it /shall be/ the first month of the year to you.
@@ -394,7 +394,7 @@
 48. And when a stranger shall sojourn with thee, and will keep the passover to the LORD, let all his males be circumcised, and then let him come near and keep it; and he shall be as one that is born in the land: for no uncircumcised person shall eat thereof.
 49. One law shall be to him that is homeborn, and unto the stranger that sojourneth among you.
 50. Thus did all the children of Israel; as the LORD commanded Moses and Aaron, so did they.
-51. And it came to pass the selfsame day, /that/ the LORD did bring the children of Israel out of the land of Egypt by their armies. 
+51. And it came to pass the selfsame day, /that/ the LORD did bring the children of Israel out of the land of Egypt by their armies.
 * 13
 1. And the LORD spake unto Moses, saying,
 2. Sanctify unto me all the firstborn, whatsoever openeth the womb among the children of Israel, /both/ of man and of beast: it /is/ mine.
@@ -424,7 +424,7 @@
 
 20. And they took their journey from Succoth, and encamped in Etham, in the edge of the wilderness.
 21. And the LORD went before them by day in a pillar of a cloud, to lead them the way; and by night in a pillar of fire, to give them light; to go by day and night:
-22. He took not away the pillar of the cloud by day, nor the pillar of fire by night, /from/ before the people. 
+22. He took not away the pillar of the cloud by day, nor the pillar of fire by night, /from/ before the people.
 * 14
 1. And the LORD spake unto Moses, saying,
 2. Speak unto the children of Israel, that they turn and encamp before Pi–hahiroth, between Migdol and the sea, over against Baal–zephon: before it shall ye encamp by the sea.
@@ -463,7 +463,7 @@
 28. And the waters returned, and covered the chariots, and the horsemen, /and/ all the host of Pharaoh that came into the sea after them; there remained not so much as one of them.
 29. But the children of Israel walked upon dry /land/ in the midst of the sea; and the waters /were/ a wall unto them on their right hand, and on their left.
 30. Thus the LORD saved Israel that day out of the hand of the Egyptians; and Israel saw the Egyptians dead upon the sea shore.
-31. And Israel saw that great work which the LORD did upon the Egyptians: and the people feared the LORD, and believed the LORD, and his servant Moses. 
+31. And Israel saw that great work which the LORD did upon the Egyptians: and the people feared the LORD, and believed the LORD, and his servant Moses.
 * 15
 1. Then sang Moses and the children of Israel this song unto the LORD, and spake, saying, I will sing unto the LORD, for he hath triumphed gloriously: the horse and his rider hath he thrown into the sea.
 2. The LORD /is/ my strength and song, and he is become my salvation: he /is/ my God, and I will prepare him an habitation; my father's God, and I will exalt him.
@@ -494,7 +494,7 @@
 25. And he cried unto the LORD; and the LORD shewed him a tree, /which/ when he had cast into the waters, the waters were made sweet: there he made for them a statute and an ordinance, and there he proved them,
 26. And said, If thou wilt diligently hearken to the voice of the LORD thy God, and wilt do that which is right in his sight, and wilt give ear to his commandments, and keep all his statutes, I will put none of these diseases upon thee, which I have brought upon the Egyptians: for I /am/ the LORD that healeth thee.
 
-27. And they came to Elim, where /were/ twelve wells of water, and threescore and ten palm trees: and they encamped there by the waters. 
+27. And they came to Elim, where /were/ twelve wells of water, and threescore and ten palm trees: and they encamped there by the waters.
 * 16
 1. And they took their journey from Elim, and all the congregation of the children of Israel came unto the wilderness of Sin, which /is/ between Elim and Sinai, on the fifteenth day of the second month after their departing out of the land of Egypt.
 2. And the whole congregation of the children of Israel murmured against Moses and Aaron in the wilderness:
@@ -538,7 +538,7 @@
 33. And Moses said unto Aaron, Take a pot, and put an omer full of manna therein, and lay it up before the LORD, to be kept for your generations.
 34. As the LORD commanded Moses, so Aaron laid it up before the Testimony, to be kept.
 35. And the children of Israel did eat manna forty years, until they came to a land inhabited; they did eat manna, until they came unto the borders of the land of Canaan.
-36. Now an omer /is/ the tenth /part/ of an ephah. 
+36. Now an omer /is/ the tenth /part/ of an ephah.
 * 17
 1. And all the congregation of the children of Israel journeyed from the wilderness of Sin, after their journeys, according to the commandment of the LORD, and pitched in Rephidim: and /there was/ no water for the people to drink.
 2. Wherefore the people did chide with Moses, and said, Give us water that we may drink. And Moses said unto them, Why chide ye with me? wherefore do ye tempt the LORD?
@@ -556,7 +556,7 @@
 13. And Joshua discomfited Amalek and his people with the edge of the sword.
 14. And the LORD said unto Moses, Write this /for/ a memorial in a book, and rehearse /it/ in the ears of Joshua: for I will utterly put out the remembrance of Amalek from under heaven.
 15. And Moses built an altar, and called the name of it Jehovah–nissi:
-16. For he said, Because the LORD hath sworn /that/ the LORD /will have/ war with Amalek from generation to generation. 
+16. For he said, Because the LORD hath sworn /that/ the LORD /will have/ war with Amalek from generation to generation.
 * 18
 1. When Jethro, the priest of Midian, Moses' father in law, heard of all that God had done for Moses, and for Israel his people, /and/ that the LORD had brought Israel out of Egypt;
 2. Then Jethro, Moses' father in law, took Zipporah, Moses' wife, after he had sent her back,
@@ -587,7 +587,7 @@
 25. And Moses chose able men out of all Israel, and made them heads over the people, rulers of thousands, rulers of hundreds, rulers of fifties, and rulers of tens.
 26. And they judged the people at all seasons: the hard causes they brought unto Moses, but every small matter they judged themselves.
 
-27. And Moses let his father in law depart; and he went his way into his own land. 
+27. And Moses let his father in law depart; and he went his way into his own land.
 * 19
 1. In the third month, when the children of Israel were gone forth out of the land of Egypt, the same day came they /into/ the wilderness of Sinai.
 2. For they were departed from Rephidim, and were come /to/ the desert of Sinai, and had pitched in the wilderness; and there Israel camped before the mount.
@@ -617,7 +617,7 @@
 22. And let the priests also, which come near to the LORD, sanctify themselves, lest the LORD break forth upon them.
 23. And Moses said unto the LORD, The people cannot come up to mount Sinai: for thou chargedst us, saying, Set bounds about the mount, and sanctify it.
 24. And the LORD said unto him, Away, get thee down, and thou shalt come up, thou, and Aaron with thee: but let not the priests and the people break through to come up unto the LORD, lest he break forth upon them.
-25. So Moses went down unto the people, and spake unto them. 
+25. So Moses went down unto the people, and spake unto them.
 * 20
 1. And God spake all these words, saying,
 2. I /am/ the LORD thy God, which have brought thee out of the land of Egypt, out of the house of bondage.
@@ -648,7 +648,7 @@
 
 24. An altar of earth thou shalt make unto me, and shalt sacrifice thereon thy burnt offerings, and thy peace offerings, thy sheep, and thine oxen: in all places where I record my name I will come unto thee, and I will bless thee.
 25. And if thou wilt make me an altar of stone, thou shalt not build it of hewn stone: for if thou lift up thy tool upon it, thou hast polluted it.
-26. Neither shalt thou go up by steps unto mine altar, that thy nakedness be not discovered thereon. 
+26. Neither shalt thou go up by steps unto mine altar, that thy nakedness be not discovered thereon.
 * 21
 1. Now these /are/ the judgments which thou shalt set before them.
 2. If thou buy an Hebrew servant, six years he shall serve: and in the seventh he shall go out free for nothing.
@@ -697,7 +697,7 @@
 34. The owner of the pit shall make /it/ good, /and/ give money unto the owner of them; and the dead /beast/ shall be his.
 
 35. And if one man's ox hurt another's, that he die; then they shall sell the live ox, and divide the money of it; and the dead /ox/ also they shall divide.
-36. Or if it be known that the ox hath used to push in time past, and his owner hath not kept him in; he shall surely pay ox for ox; and the dead shall be his own. 
+36. Or if it be known that the ox hath used to push in time past, and his owner hath not kept him in; he shall surely pay ox for ox; and the dead shall be his own.
 * 22
 1. If a man shall steal an ox, or a sheep, and kill it, or sell it; he shall restore five oxen for an ox, and four sheep for a sheep.
 
@@ -744,7 +744,7 @@
 29. Thou shalt not delay /to offer/ the first of thy ripe fruits, and of thy liquors: the firstborn of thy sons shalt thou give unto me.
 30. Likewise shalt thou do with thine oxen, /and/ with thy sheep: seven days it shall be with his dam; on the eighth day thou shalt give it me.
 
-31. And ye shall be holy men unto me: neither shall ye eat /any/ flesh /that is/ torn of beasts in the field; ye shall cast it to the dogs. 
+31. And ye shall be holy men unto me: neither shall ye eat /any/ flesh /that is/ torn of beasts in the field; ye shall cast it to the dogs.
 * 23
 1. Thou shalt not raise a false report: put not thine hand with the wicked to be an unrighteous witness.
 
@@ -786,7 +786,7 @@
 30. By little and little I will drive them out from before thee, until thou be increased, and inherit the land.
 31. And I will set thy bounds from the Red sea even unto the sea of the Philistines, and from the desert unto the river: for I will deliver the inhabitants of the land into your hand; and thou shalt drive them out before thee.
 32. Thou shalt make no covenant with them, nor with their gods.
-33. They shall not dwell in thy land, lest they make thee sin against me: for if thou serve their gods, it will surely be a snare unto thee. 
+33. They shall not dwell in thy land, lest they make thee sin against me: for if thou serve their gods, it will surely be a snare unto thee.
 * 24
 1. And he said unto Moses, Come up unto the LORD, thou, and Aaron, Nadab, and Abihu, and seventy of the elders of Israel; and worship ye afar off.
 2. And Moses alone shall come near the LORD: but they shall not come nigh; neither shall the people go up with him.
@@ -808,7 +808,7 @@
 15. And Moses went up into the mount, and a cloud covered the mount.
 16. And the glory of the LORD abode upon mount Sinai, and the cloud covered it six days: and the seventh day he called unto Moses out of the midst of the cloud.
 17. And the sight of the glory of the LORD /was/ like devouring fire on the top of the mount in the eyes of the children of Israel.
-18. And Moses went into the midst of the cloud, and gat him up into the mount: and Moses was in the mount forty days and forty nights. 
+18. And Moses went into the midst of the cloud, and gat him up into the mount: and Moses was in the mount forty days and forty nights.
 * 25
 1. And the LORD spake unto Moses, saying,
 2. Speak unto the children of Israel, that they bring me an offering: of every man that giveth it willingly with his heart ye shall take my offering.
@@ -852,7 +852,7 @@
 37. And thou shalt make the seven lamps thereof: and they shall light the lamps thereof, that they may give light over against it.
 38. And the tongs thereof, and the snuffdishes thereof, /shall be of/ pure gold.
 39. /Of/ a talent of pure gold shall he make it, with all these vessels.
-40. And look that thou make /them/ after their pattern, which was shewed thee in the mount. 
+40. And look that thou make /them/ after their pattern, which was shewed thee in the mount.
 * 26
 1. Moreover thou shalt make the tabernacle /with/ ten curtains /of/ fine twined linen, and blue, and purple, and scarlet: /with/ cherubims of cunning work shalt thou make them.
 2. The length of one curtain /shall be/ eight and twenty cubits, and the breadth of one curtain four cubits: and every one of the curtains shall have one measure.
@@ -895,7 +895,7 @@
 34. And thou shalt put the mercy seat upon the ark of the testimony in the most holy /place/.
 35. And thou shalt set the table without the vail, and the candlestick over against the table on the side of the tabernacle toward the south: and thou shalt put the table on the north side.
 36. And thou shalt make an hanging for the door of the tent, /of/ blue, and purple, and scarlet, and fine twined linen, wrought with needlework.
-37. And thou shalt make for the hanging five pillars /of/ shittim /wood/, and overlay them with gold, /and/ their hooks /shall be of/ gold: and thou shalt cast five sockets of brass for them. 
+37. And thou shalt make for the hanging five pillars /of/ shittim /wood/, and overlay them with gold, /and/ their hooks /shall be of/ gold: and thou shalt cast five sockets of brass for them.
 * 27
 1. And thou shalt make an altar /of/ shittim wood, five cubits long, and five cubits broad; the altar shall be foursquare: and the height thereof /shall be/ three cubits.
 2. And thou shalt make the horns of it upon the four corners thereof: his horns shall be of the same: and thou shalt overlay it with brass.
@@ -922,7 +922,7 @@
 19. All the vessels of the tabernacle in all the service thereof, and all the pins thereof, and all the pins of the court, /shall be of/ brass.
 
 20. And thou shalt command the children of Israel, that they bring thee pure oil olive beaten for the light, to cause the lamp to burn always.
-21. In the tabernacle of the congregation without the vail, which /is/ before the testimony, Aaron and his sons shall order it from evening to morning before the LORD: /it shall be/ a statute for ever unto their generations on the behalf of the children of Israel. 
+21. In the tabernacle of the congregation without the vail, which /is/ before the testimony, Aaron and his sons shall order it from evening to morning before the LORD: /it shall be/ a statute for ever unto their generations on the behalf of the children of Israel.
 * 28
 1. And take thou unto thee Aaron thy brother, and his sons with him, from among the children of Israel, that he may minister unto me in the priest's office, /even/ Aaron, Nadab and Abihu, Eleazar and Ithamar, Aaron's sons.
 2. And thou shalt make holy garments for Aaron thy brother for glory and for beauty.
@@ -977,7 +977,7 @@
 40. And for Aaron's sons thou shalt make coats, and thou shalt make for them girdles, and bonnets shalt thou make for them, for glory and for beauty.
 41. And thou shalt put them upon Aaron thy brother, and his sons with him; and shalt anoint them, and consecrate them, and sanctify them, that they may minister unto me in the priest's office.
 42. And thou shalt make them linen breeches to cover their nakedness; from the loins even unto the thighs they shall reach:
-43. And they shall be upon Aaron, and upon his sons, when they come in unto the tabernacle of the congregation, or when they come near unto the altar to minister in the holy /place/; that they bear not iniquity, and die: /it shall be/ a statute for ever unto him and his seed after him. 
+43. And they shall be upon Aaron, and upon his sons, when they come in unto the tabernacle of the congregation, or when they come near unto the altar to minister in the holy /place/; that they bear not iniquity, and die: /it shall be/ a statute for ever unto him and his seed after him.
 * 29
 1. And this /is/ the thing that thou shalt do unto them to hallow them, to minister unto me in the priest's office: Take one young bullock, and two rams without blemish,
 2. And unleavened bread, and cakes unleavened tempered with oil, and wafers unleavened anointed with oil: /of/ wheaten flour shalt thou make them.
@@ -1030,7 +1030,7 @@
 44. And I will sanctify the tabernacle of the congregation, and the altar: I will sanctify also both Aaron and his sons, to minister to me in the priest's office.
 
 45. And I will dwell among the children of Israel, and will be their God.
-46. And they shall know that I /am/ the LORD their God, that brought them forth out of the land of Egypt, that I may dwell among them: I /am/ the LORD their God. 
+46. And they shall know that I /am/ the LORD their God, that brought them forth out of the land of Egypt, that I may dwell among them: I /am/ the LORD their God.
 * 30
 1. And thou shalt make an altar to burn incense upon: /of/ shittim wood shalt thou make it.
 2. A cubit /shall be/ the length thereof, and a cubit the breadth thereof; foursquare shall it be: and two cubits /shall be/ the height thereof: the horns thereof /shall be/ of the same.
@@ -1073,7 +1073,7 @@
 35. And thou shalt make it a perfume, a confection after the art of the apothecary, tempered together, pure /and/ holy:
 36. And thou shalt beat /some/ of it very small, and put of it before the testimony in the tabernacle of the congregation, where I will meet with thee: it shall be unto you most holy.
 37. And /as for/ the perfume which thou shalt make, ye shall not make to yourselves according to the composition thereof: it shall be unto thee holy for the LORD.
-38. Whosoever shall make like unto that, to smell thereto, shall even be cut off from his people. 
+38. Whosoever shall make like unto that, to smell thereto, shall even be cut off from his people.
 * 31
 1. And the LORD spake unto Moses, saying,
 2. See, I have called by name Bezaleel the son of Uri, the son of Hur, of the tribe of Judah:
@@ -1094,7 +1094,7 @@
 16. Wherefore the children of Israel shall keep the sabbath, to observe the sabbath throughout their generations, /for/ a perpetual covenant.
 17. It /is/ a sign between me and the children of Israel for ever: for /in/ six days the LORD made heaven and earth, and on the seventh day he rested, and was refreshed.
 
-18. And he gave unto Moses, when he had made an end of communing with him upon mount Sinai, two tables of testimony, tables of stone, written with the finger of God. 
+18. And he gave unto Moses, when he had made an end of communing with him upon mount Sinai, two tables of testimony, tables of stone, written with the finger of God.
 * 32
 1. And when the people saw that Moses delayed to come down out of the mount, the people gathered themselves together unto Aaron, and said unto him, Up, make us gods, which shall go before us; for /as for/ this Moses, the man that brought us up out of the land of Egypt, we wot not what is become of him.
 2. And Aaron said unto them, Break off the golden earrings, which /are/ in the ears of your wives, of your sons, and of your daughters, and bring /them/ unto me.
@@ -1135,7 +1135,7 @@
 32. Yet now, if thou wilt forgive their sin―; and if not, blot me, I pray thee, out of thy book which thou hast written.
 33. And the LORD said unto Moses, Whosoever hath sinned against me, him will I blot out of my book.
 34. Therefore now go, lead the people unto /the place/ of which I have spoken unto thee: behold, mine Angel shall go before thee: nevertheless in the day when I visit I will visit their sin upon them.
-35. And the LORD plagued the people, because they made the calf, which Aaron made. 
+35. And the LORD plagued the people, because they made the calf, which Aaron made.
 * 33
 1. And the LORD said unto Moses, Depart, /and/ go up hence, thou and the people which thou hast brought up out of the land of Egypt, unto the land which I sware unto Abraham, to Isaac, and to Jacob, saying, Unto thy seed will I give it:
 2. And I will send an angel before thee; and I will drive out the Canaanite, the Amorite, and the Hittite, and the Perizzite, the Hivite, and the Jebusite:
@@ -1161,7 +1161,7 @@
 20. And he said, Thou canst not see my face: for there shall no man see me, and live.
 21. And the LORD said, Behold, /there is/ a place by me, and thou shalt stand upon a rock:
 22. And it shall come to pass, while my glory passeth by, that I will put thee in a clift of the rock, and will cover thee with my hand while I pass by:
-23. And I will take away mine hand, and thou shalt see my back parts: but my face shall not be seen. 
+23. And I will take away mine hand, and thou shalt see my back parts: but my face shall not be seen.
 * 34
 1. And the LORD said unto Moses, Hew thee two tables of stone like unto the first: and I will write upon /these/ tables the words that were in the first tables, which thou brakest.
 2. And be ready in the morning, and come up in the morning unto mount Sinai, and present thyself there to me in the top of the mount.
@@ -1204,7 +1204,7 @@
 32. And afterward all the children of Israel came nigh: and he gave them in commandment all that the LORD had spoken with him in mount Sinai.
 33. And /till/ Moses had done speaking with them, he put a vail on his face.
 34. But when Moses went in before the LORD to speak with him, he took the vail off, until he came out. And he came out, and spake unto the children of Israel /that/ which he was commanded.
-35. And the children of Israel saw the face of Moses, that the skin of Moses' face shone: and Moses put the vail upon his face again, until he went in to speak with him. 
+35. And the children of Israel saw the face of Moses, that the skin of Moses' face shone: and Moses put the vail upon his face again, until he went in to speak with him.
 * 35
 1. And Moses gathered all the congregation of the children of Israel together, and said unto them, These /are/ the words which the LORD hath commanded, that /ye/ should do them.
 2. Six days shall work be done, but on the seventh day there shall be to you an holy day, a sabbath of rest to the LORD: whosoever doeth work therein shall be put to death.
@@ -1243,7 +1243,7 @@
 32. And to devise curious works, to work in gold, and in silver, and in brass,
 33. And in the cutting of stones, to set /them/, and in carving of wood, to make any manner of cunning work.
 34. And he hath put in his heart that he may teach, /both/ he, and Aholiab, the son of Ahisamach, of the tribe of Dan.
-35. Them hath he filled with wisdom of heart, to work all manner of work, of the engraver, and of the cunning workman, and of the embroiderer, in blue, and in purple, in scarlet, and in fine linen, and of the weaver, /even/ of them that do any work, and of those that devise cunning work. 
+35. Them hath he filled with wisdom of heart, to work all manner of work, of the engraver, and of the cunning workman, and of the embroiderer, in blue, and in purple, in scarlet, and in fine linen, and of the weaver, /even/ of them that do any work, and of those that devise cunning work.
 * 36
 1. Then wrought Bezaleel and Aholiab, and every wise hearted man, in whom the LORD put wisdom and understanding to know how to work all manner of work for the service of the sanctuary, according to all that the LORD had commanded.
 2. And Moses called Bezaleel and Aholiab, and every wise hearted man, in whose heart the LORD had put wisdom, /even/ every one whose heart stirred him up to come unto the work to do it:
@@ -1289,7 +1289,7 @@
 36. And he made thereunto four pillars /of/ shittim /wood/, and overlaid them with gold: their hooks /were of/ gold; and he cast for them four sockets of silver.
 
 37. And he made an hanging for the tabernacle door /of/ blue, and purple, and scarlet, and fine twined linen, of needlework;
-38. And the five pillars of it with their hooks: and he overlaid their chapiters and their fillets with gold: but their five sockets /were of/ brass. 
+38. And the five pillars of it with their hooks: and he overlaid their chapiters and their fillets with gold: but their five sockets /were of/ brass.
 * 37
 1. And Bezaleel made the ark /of/ shittim wood: two cubits and a half /was/ the length of it, and a cubit and a half the breadth of it, and a cubit and a half the height of it:
 2. And he overlaid it with pure gold within and without, and made a crown of gold to it round about.
@@ -1324,7 +1324,7 @@
 27. And he made two rings of gold for it under the crown thereof, by the two corners of it, upon the two sides thereof, to be places for the staves to bear it withal.
 28. And he made the staves /of/ shittim wood, and overlaid them with gold.
 
-29. And he made the holy anointing oil, and the pure incense of sweet spices, according to the work of the apothecary. 
+29. And he made the holy anointing oil, and the pure incense of sweet spices, according to the work of the apothecary.
 * 38
 1. And he made the altar of burnt offering /of/ shittim wood: five cubits /was/ the length thereof, and five cubits the breadth thereof; /it was/ foursquare; and three cubits the height thereof.
 2. And he made the horns thereof on the four corners of it; the horns thereof were of the same: and he overlaid it with brass.
@@ -1359,7 +1359,7 @@
 28. And of the thousand seven hundred seventy and five shekels he made hooks for the pillars, and overlaid their chapiters, and filleted them.
 29. And the brass of the offering /was/ seventy talents, and two thousand and four hundred shekels.
 30. And therewith he made the sockets to the door of the tabernacle of the congregation, and the brasen altar, and the brasen grate for it, and all the vessels of the altar,
-31. And the sockets of the court round about, and the sockets of the court gate, and all the pins of the tabernacle, and all the pins of the court round about. 
+31. And the sockets of the court round about, and the sockets of the court gate, and all the pins of the tabernacle, and all the pins of the court round about.
 * 39
 1. And of the blue, and purple, and scarlet, they made cloths of service, to do service in the holy /place/, and made the holy garments for Aaron; as the LORD commanded Moses.
 2. And he made the ephod /of/ gold, blue, and purple, and scarlet, and fine twined linen.
@@ -1410,7 +1410,7 @@
 40. The hangings of the court, his pillars, and his sockets, and the hanging for the court gate, his cords, and his pins, and all the vessels of the service of the tabernacle, for the tent of the congregation,
 41. The cloths of service to do service in the holy /place/, and the holy garments for Aaron the priest, and his sons' garments, to minister in the priest's office.
 42. According to all that the LORD commanded Moses, so the children of Israel made all the work.
-43. And Moses did look upon all the work, and, behold, they had done it as the LORD had commanded, even so had they done it: and Moses blessed them. 
+43. And Moses did look upon all the work, and, behold, they had done it as the LORD had commanded, even so had they done it: and Moses blessed them.
 * 40
 1. And the LORD spake unto Moses, saying,
 2. On the first day of the first month shalt thou set up the tabernacle of the tent of the congregation.
@@ -1457,4 +1457,4 @@
 35. And Moses was not able to enter into the tent of the congregation, because the cloud abode thereon, and the glory of the LORD filled the tabernacle.
 36. And when the cloud was taken up from over the tabernacle, the children of Israel went onward in all their journeys:
 37. But if the cloud were not taken up, then they journeyed not till the day that it was taken up.
-38. For the cloud of the LORD /was/ upon the tabernacle by day, and fire was on it by night, in the sight of all the house of Israel, throughout all their journeys.  
+38. For the cloud of the LORD /was/ upon the tabernacle by day, and fire was on it by night, in the sight of all the house of Israel, throughout all their journeys.

--- a/03_LEV.org
+++ b/03_LEV.org
@@ -18,7 +18,7 @@
 14. And if the burnt sacrifice for his offering to the LORD /be/ of fowls, then he shall bring his offering of turtledoves, or of young pigeons.
 15. And the priest shall bring it unto the altar, and wring off his head, and burn /it/ on the altar; and the blood thereof shall be wrung out at the side of the altar:
 16. And he shall pluck away his crop with his feathers, and cast it beside the altar on the east part, by the place of the ashes:
-17. And he shall cleave it with the wings thereof, /but/ shall not divide /it/ asunder: and the priest shall burn it upon the altar, upon the wood that /is/ upon the fire: it /is/ a burnt sacrifice, an offering made by fire, of a sweet savour unto the LORD. 
+17. And he shall cleave it with the wings thereof, /but/ shall not divide /it/ asunder: and the priest shall burn it upon the altar, upon the wood that /is/ upon the fire: it /is/ a burnt sacrifice, an offering made by fire, of a sweet savour unto the LORD.
 * 2
 1. And when any will offer a meat offering unto the LORD, his offering shall be /of/ fine flour; and he shall pour oil upon it, and put frankincense thereon:
 2. And he shall bring it to Aaron's sons the priests: and he shall take thereout his handful of the flour thereof, and of the oil thereof, with all the frankincense thereof; and the priest shall burn the memorial of it upon the altar, /to be/ an offering made by fire, of a sweet savour unto the LORD:
@@ -39,7 +39,7 @@
 13. And every oblation of thy meat offering shalt thou season with salt; neither shalt thou suffer the salt of the covenant of thy God to be lacking from thy meat offering: with all thine offerings thou shalt offer salt.
 14. And if thou offer a meat offering of thy firstfruits unto the LORD, thou shalt offer for the meat offering of thy firstfruits green ears of corn dried by the fire, /even/ corn beaten out of full ears.
 15. And thou shalt put oil upon it, and lay frankincense thereon: it /is/ a meat offering.
-16. And the priest shall burn the memorial of it, /part/ of the beaten corn thereof, and /part/ of the oil thereof, with all the frankincense thereof: /it is/ an offering made by fire unto the LORD. 
+16. And the priest shall burn the memorial of it, /part/ of the beaten corn thereof, and /part/ of the oil thereof, with all the frankincense thereof: /it is/ an offering made by fire unto the LORD.
 * 3
 1. And if his oblation /be/ a sacrifice of peace offering, if he offer /it/ of the herd; whether /it be/ a male or female, he shall offer it without blemish before the LORD.
 2. And he shall lay his hand upon the head of his offering, and kill it /at/ the door of the tabernacle of the congregation: and Aaron's sons the priests shall sprinkle the blood upon the altar round about.
@@ -59,7 +59,7 @@
 14. And he shall offer thereof his offering, /even/ an offering made by fire unto the LORD; the fat that covereth the inwards, and all the fat that /is/ upon the inwards,
 15. And the two kidneys, and the fat that /is/ upon them, which /is/ by the flanks, and the caul above the liver, with the kidneys, it shall he take away.
 16. And the priest shall burn them upon the altar: /it is/ the food of the offering made by fire for a sweet savour: all the fat /is/ the LORD's.
-17. /It shall be/ a perpetual statute for your generations throughout all your dwellings, that ye eat neither fat nor blood. 
+17. /It shall be/ a perpetual statute for your generations throughout all your dwellings, that ye eat neither fat nor blood.
 * 4
 1. And the LORD spake unto Moses, saying,
 2. Speak unto the children of Israel, saying, If a soul shall sin through ignorance against any of the commandments of the LORD /concerning things/ which ought not to be done, and shall do against any of them:
@@ -98,7 +98,7 @@
 32. And if he bring a lamb for a sin offering, he shall bring it a female without blemish.
 33. And he shall lay his hand upon the head of the sin offering, and slay it for a sin offering in the place where they kill the burnt offering.
 34. And the priest shall take of the blood of the sin offering with his finger, and put /it/ upon the horns of the altar of burnt offering, and shall pour out all the blood thereof at the bottom of the altar:
-35. And he shall take away all the fat thereof, as the fat of the lamb is taken away from the sacrifice of the peace offerings; and the priest shall burn them upon the altar, according to the offerings made by fire unto the LORD: and the priest shall make an atonement for his sin that he hath committed, and it shall be forgiven him. 
+35. And he shall take away all the fat thereof, as the fat of the lamb is taken away from the sacrifice of the peace offerings; and the priest shall burn them upon the altar, according to the offerings made by fire unto the LORD: and the priest shall make an atonement for his sin that he hath committed, and it shall be forgiven him.
 * 5
 1. And if a soul sin, and hear the voice of swearing, and /is/ a witness, whether he hath seen or known /of it/; if he do not utter /it/, then he shall bear his iniquity.
 2. Or if a soul touch any unclean thing, whether /it be/ a carcase of an unclean beast, or a carcase of unclean cattle, or the carcase of unclean creeping things, and /if/ it be hidden from him; he also shall be unclean, and guilty.
@@ -121,7 +121,7 @@
 
 17. And if a soul sin, and commit any of these things which are forbidden to be done by the commandments of the LORD; though he wist /it/ not, yet is he guilty, and shall bear his iniquity.
 18. And he shall bring a ram without blemish out of the flock, with thy estimation, for a trespass offering, unto the priest: and the priest shall make an atonement for him concerning his ignorance wherein he erred and wist /it/ not, and it shall be forgiven him.
-19. It /is/ a trespass offering: he hath certainly trespassed against the LORD. 
+19. It /is/ a trespass offering: he hath certainly trespassed against the LORD.
 * 6
 1. And the LORD spake unto Moses, saying,
 2. If a soul sin, and commit a trespass against the LORD, and lie unto his neighbour in that which was delivered him to keep, or in fellowship, or in a thing taken away by violence, or hath deceived his neighbour;
@@ -156,7 +156,7 @@
 27. Whatsoever shall touch the flesh thereof shall be holy: and when there is sprinkled of the blood thereof upon any garment, thou shalt wash that whereon it was sprinkled in the holy place.
 28. But the earthen vessel wherein it is sodden shall be broken: and if it be sodden in a brasen pot, it shall be both scoured, and rinsed in water.
 29. All the males among the priests shall eat thereof: it /is/ most holy.
-30. And no sin offering, whereof /any/ of the blood is brought into the tabernacle of the congregation to reconcile /withal/ in the holy /place/, shall be eaten: it shall be burnt in the fire. 
+30. And no sin offering, whereof /any/ of the blood is brought into the tabernacle of the congregation to reconcile /withal/ in the holy /place/, shall be eaten: it shall be burnt in the fire.
 * 7
 1. Likewise this /is/ the law of the trespass offering: it /is/ most holy.
 2. In the place where they kill the burnt offering shall they kill the trespass offering: and the blood thereof shall he sprinkle round about upon the altar.
@@ -198,7 +198,7 @@
 35. This /is the portion/ of the anointing of Aaron, and of the anointing of his sons, out of the offerings of the LORD made by fire, in the day /when/ he presented them to minister unto the LORD in the priest's office;
 36. Which the LORD commanded to be given them of the children of Israel, in the day that he anointed them, /by/ a statute for ever throughout their generations.
 37. This /is/ the law of the burnt offering, of the meat offering, and of the sin offering, and of the trespass offering, and of the consecrations, and of the sacrifice of the peace offerings;
-38. Which the LORD commanded Moses in mount Sinai, in the day that he commanded the children of Israel to offer their oblations unto the LORD, in the wilderness of Sinai. 
+38. Which the LORD commanded Moses in mount Sinai, in the day that he commanded the children of Israel to offer their oblations unto the LORD, in the wilderness of Sinai.
 * 8
 1. And the LORD spake unto Moses, saying,
 2. Take Aaron and his sons with him, and the garments, and the anointing oil, and a bullock for the sin offering, and two rams, and a basket of unleavened bread;
@@ -238,7 +238,7 @@
 33. And ye shall not go out of the door of the tabernacle of the congregation /in/ seven days, until the days of your consecration be at an end: for seven days shall he consecrate you.
 34. As he hath done this day, /so/ the LORD hath commanded to do, to make an atonement for you.
 35. Therefore shall ye abide /at/ the door of the tabernacle of the congregation day and night seven days, and keep the charge of the LORD, that ye die not: for so I am commanded.
-36. So Aaron and his sons did all things which the LORD commanded by the hand of Moses. 
+36. So Aaron and his sons did all things which the LORD commanded by the hand of Moses.
 * 9
 1. And it came to pass on the eighth day, /that/ Moses called Aaron and his sons, and the elders of Israel;
 2. And he said unto Aaron, Take thee a young calf for a sin offering, and a ram for a burnt offering, without blemish, and offer /them/ before the LORD.
@@ -266,7 +266,7 @@
 21. And the breasts and the right shoulder Aaron waved /for/ a wave offering before the LORD; as Moses commanded.
 22. And Aaron lifted up his hand toward the people, and blessed them, and came down from offering of the sin offering, and the burnt offering, and peace offerings.
 23. And Moses and Aaron went into the tabernacle of the congregation, and came out, and blessed the people: and the glory of the LORD appeared unto all the people.
-24. And there came a fire out from before the LORD, and consumed upon the altar the burnt offering and the fat: /which/ when all the people saw, they shouted, and fell on their faces. 
+24. And there came a fire out from before the LORD, and consumed upon the altar the burnt offering and the fat: /which/ when all the people saw, they shouted, and fell on their faces.
 * 10
 1. And Nadab and Abihu, the sons of Aaron, took either of them his censer, and put fire therein, and put incense thereon, and offered strange fire before the LORD, which he commanded them not.
 2. And there went out fire from the LORD, and devoured them, and they died before the LORD.
@@ -290,7 +290,7 @@
 17. Wherefore have ye not eaten the sin offering in the holy place, seeing it /is/ most holy, and /God/ hath given it you to bear the iniquity of the congregation, to make atonement for them before the LORD?
 18. Behold, the blood of it was not brought in within the holy /place/: ye should indeed have eaten it in the holy /place/, as I commanded.
 19. And Aaron said unto Moses, Behold, this day have they offered their sin offering and their burnt offering before the LORD; and such things have befallen me: and /if/ I had eaten the sin offering to day, should it have been accepted in the sight of the LORD?
-20. And when Moses heard /that/, he was content. 
+20. And when Moses heard /that/, he was content.
 * 11
 1. And the LORD spake unto Moses and to Aaron, saying unto them,
 2. Speak unto the children of Israel, saying, These /are/ the beasts which ye shall eat among all the beasts that /are/ on the earth.
@@ -341,7 +341,7 @@
 44. For I /am/ the LORD your God: ye shall therefore sanctify yourselves, and ye shall be holy; for I /am/ holy: neither shall ye defile yourselves with any manner of creeping thing that creepeth upon the earth.
 45. For I /am/ the LORD that bringeth you up out of the land of Egypt, to be your God: ye shall therefore be holy, for I /am/ holy.
 46. This /is/ the law of the beasts, and of the fowl, and of every living creature that moveth in the waters, and of every creature that creepeth upon the earth:
-47. To make a difference between the unclean and the clean, and between the beast that may be eaten and the beast that may not be eaten. 
+47. To make a difference between the unclean and the clean, and between the beast that may be eaten and the beast that may not be eaten.
 * 12
 1. And the LORD spake unto Moses, saying,
 2. Speak unto the children of Israel, saying, If a woman have conceived seed, and born a man child: then she shall be unclean seven days; according to the days of the separation for her infirmity shall she be unclean.
@@ -350,7 +350,7 @@
 5. But if she bear a maid child, then she shall be unclean two weeks, as in her separation: and she shall continue in the blood of her purifying threescore and six days.
 6. And when the days of her purifying are fulfilled, for a son, or for a daughter, she shall bring a lamb of the first year for a burnt offering, and a young pigeon, or a turtledove, for a sin offering, unto the door of the tabernacle of the congregation, unto the priest:
 7. Who shall offer it before the LORD, and make an atonement for her; and she shall be cleansed from the issue of her blood. This /is/ the law for her that hath born a male or a female.
-8. And if she be not able to bring a lamb, then she shall bring two turtles, or two young pigeons; the one for the burnt offering, and the other for a sin offering: and the priest shall make an atonement for her, and she shall be clean. 
+8. And if she be not able to bring a lamb, then she shall bring two turtles, or two young pigeons; the one for the burnt offering, and the other for a sin offering: and the priest shall make an atonement for her, and she shall be clean.
 * 13
 1. And the LORD spake unto Moses and Aaron, saying,
 2. When a man shall have in the skin of his flesh a rising, a scab, or bright spot, and it be in the skin of his flesh /like/ the plague of leprosy; then he shall be brought unto Aaron the priest, or unto one of his sons the priests:
@@ -416,7 +416,7 @@
 56. And if the priest look, and, behold, the plague /be/ somewhat dark after the washing of it; then he shall rend it out of the garment, or out of the skin, or out of the warp, or out of the woof:
 57. And if it appear still in the garment, either in the warp, or in the woof, or in any thing of skin; it /is/ a spreading /plague/: thou shalt burn that wherein the plague /is/ with fire.
 58. And the garment, either warp, or woof, or whatsoever thing of skin /it be/, which thou shalt wash, if the plague be departed from them, then it shall be washed the second time, and shall be clean.
-59. This /is/ the law of the plague of leprosy in a garment of woollen or linen, either in the warp, or woof, or any thing of skins, to pronounce it clean, or to pronounce it unclean. 
+59. This /is/ the law of the plague of leprosy in a garment of woollen or linen, either in the warp, or woof, or any thing of skins, to pronounce it clean, or to pronounce it unclean.
 * 14
 1. And the LORD spake unto Moses, saying,
 2. This shall be the law of the leper in the day of his cleansing: He shall be brought unto the priest:
@@ -475,7 +475,7 @@
 54. This /is/ the law for all manner of plague of leprosy, and scall,
 55. And for the leprosy of a garment, and of a house,
 56. And for a rising, and for a scab, and for a bright spot:
-57. To teach when /it is/ unclean, and when /it is/ clean: this /is/ the law of leprosy. 
+57. To teach when /it is/ unclean, and when /it is/ clean: this /is/ the law of leprosy.
 * 15
 1. And the LORD spake unto Moses and to Aaron, saying,
 2. Speak unto the children of Israel, and say unto them, When any man hath a running issue out of his flesh, /because of/ his issue he /is/ unclean.
@@ -510,7 +510,7 @@
 30. And the priest shall offer the one /for/ a sin offering, and the other /for/ a burnt offering; and the priest shall make an atonement for her before the LORD for the issue of her uncleanness.
 31. Thus shall ye separate the children of Israel from their uncleanness; that they die not in their uncleanness, when they defile my tabernacle that /is/ among them.
 32. This /is/ the law of him that hath an issue, and /of him/ whose seed goeth from him, and is defiled therewith;
-33. And of her that is sick of her flowers, and of him that hath an issue, of the man, and of the woman, and of him that lieth with her that is unclean. 
+33. And of her that is sick of her flowers, and of him that hath an issue, of the man, and of the woman, and of him that lieth with her that is unclean.
 * 16
 1. And the LORD spake unto Moses after the death of the two sons of Aaron, when they offered before the LORD, and died;
 2. And the LORD said unto Moses, Speak unto Aaron thy brother, that he come not at all times into the holy /place/ within the vail before the mercy seat, which /is/ upon the ark; that he die not: for I will appear in the cloud upon the mercy seat.
@@ -548,7 +548,7 @@
 31. It /shall be/ a sabbath of rest unto you, and ye shall afflict your souls, by a statute for ever.
 32. And the priest, whom he shall anoint, and whom he shall consecrate to minister in the priest's office in his father's stead, shall make the atonement, and shall put on the linen clothes, /even/ the holy garments:
 33. And he shall make an atonement for the holy sanctuary, and he shall make an atonement for the tabernacle of the congregation, and for the altar, and he shall make an atonement for the priests, and for all the people of the congregation.
-34. And this shall be an everlasting statute unto you, to make an atonement for the children of Israel for all their sins once a year. And he did as the LORD commanded Moses. 
+34. And this shall be an everlasting statute unto you, to make an atonement for the children of Israel for all their sins once a year. And he did as the LORD commanded Moses.
 * 17
 1. And the LORD spake unto Moses, saying,
 2. Speak unto Aaron, and unto his sons, and unto all the children of Israel, and say unto them; This /is/ the thing which the LORD hath commanded, saying,
@@ -567,7 +567,7 @@
 13. And whatsoever man /there be/ of the children of Israel, or of the strangers that sojourn among you, which hunteth and catcheth any beast or fowl that may be eaten; he shall even pour out the blood thereof, and cover it with dust.
 14. For /it is/ the life of all flesh; the blood of it /is/ for the life thereof: therefore I said unto the children of Israel, Ye shall eat the blood of no manner of flesh: for the life of all flesh /is/ the blood thereof: whosoever eateth it shall be cut off.
 15. And every soul that eateth that which died /of itself/, or that which was torn /with beasts, whether it be/ one of your own country, or a stranger, he shall both wash his clothes, and bathe /himself/ in water, and be unclean until the even: then shall he be clean.
-16. But if he wash /them/ not, nor bathe his flesh; then he shall bear his iniquity. 
+16. But if he wash /them/ not, nor bathe his flesh; then he shall bear his iniquity.
 * 18
 1. And the LORD spake unto Moses, saying,
 2. Speak unto the children of Israel, and say unto them, I am the LORD your God.
@@ -599,7 +599,7 @@
 27. (For all these abominations have the men of the land done, which /were/ before you, and the land is defiled;)
 28. That the land spue not you out also, when ye defile it, as it spued out the nations that /were/ before you.
 29. For whosoever shall commit any of these abominations, even the souls that commit /them/ shall be cut off from among their people.
-30. Therefore shall ye keep mine ordinance, that /ye/ commit not /any one/ of these abominable customs, which were committed before you, and that ye defile not yourselves therein: I /am/ the LORD your God. 
+30. Therefore shall ye keep mine ordinance, that /ye/ commit not /any one/ of these abominable customs, which were committed before you, and that ye defile not yourselves therein: I /am/ the LORD your God.
 * 19
 1. And the LORD spake unto Moses, saying,
 2. Speak unto all the congregation of the children of Israel, and say unto them, Ye shall be holy: for I the LORD your God /am/ holy.
@@ -659,7 +659,7 @@
 
 35. Ye shall do no unrighteousness in judgment, in meteyard, in weight, or in measure.
 36. Just balances, just weights, a just ephah, and a just hin, shall ye have: I /am/ the LORD your God, which brought you out of the land of Egypt.
-37. Therefore shall ye observe all my statutes, and all my judgments, and do them: I /am/ the LORD. 
+37. Therefore shall ye observe all my statutes, and all my judgments, and do them: I /am/ the LORD.
 * 20
 1. And the LORD spake unto Moses, saying,
 2. Again, thou shalt say to the children of Israel, Whosoever /he be/ of the children of Israel, or of the strangers that sojourn in Israel, that giveth /any/ of his seed unto Molech; he shall surely be put to death: the people of the land shall stone him with stones.
@@ -693,7 +693,7 @@
 25. Ye shall therefore put difference between clean beasts and unclean, and between unclean fowls and clean: and ye shall not make your souls abominable by beast, or by fowl, or by any manner of living thing that creepeth on the ground, which I have separated from you as unclean.
 26. And ye shall be holy unto me: for I the LORD /am/ holy, and have severed you from /other/ people, that ye should be mine.
 
-27. A man also or woman that hath a familiar spirit, or that is a wizard, shall surely be put to death: they shall stone them with stones: their blood /shall be/ upon them. 
+27. A man also or woman that hath a familiar spirit, or that is a wizard, shall surely be put to death: they shall stone them with stones: their blood /shall be/ upon them.
 * 21
 1. And the LORD said unto Moses, Speak unto the priests the sons of Aaron, and say unto them, There shall none be defiled for the dead among his people:
 2. But for his kin, that is near unto him, /that is/, for his mother, and for his father, and for his son, and for his daughter, and for his brother,
@@ -720,7 +720,7 @@
 21. No man that hath a blemish of the seed of Aaron the priest shall come nigh to offer the offerings of the LORD made by fire: he hath a blemish; he shall not come nigh to offer the bread of his God.
 22. He shall eat the bread of his God, /both/ of the most holy, and of the holy.
 23. Only he shall not go in unto the vail, nor come nigh unto the altar, because he hath a blemish; that he profane not my sanctuaries: for I the LORD do sanctify them.
-24. And Moses told /it/ unto Aaron, and to his sons, and unto all the children of Israel. 
+24. And Moses told /it/ unto Aaron, and to his sons, and unto all the children of Israel.
 * 22
 1. And the LORD spake unto Moses, saying,
 2. Speak unto Aaron and to his sons, that they separate themselves from the holy things of the children of Israel, and that they profane not my holy name /in those things/ which they hallow unto me: I /am/ the LORD.
@@ -757,7 +757,7 @@
 30. On the same day it shall be eaten up; ye shall leave none of it until the morrow: I /am/ the LORD.
 31. Therefore shall ye keep my commandments, and do them: I /am/ the LORD.
 32. Neither shall ye profane my holy name; but I will be hallowed among the children of Israel: I /am/ the LORD which hallow you,
-33. That brought you out of the land of Egypt, to be your God: I /am/ the LORD. 
+33. That brought you out of the land of Egypt, to be your God: I /am/ the LORD.
 * 23
 1. And the LORD spake unto Moses, saying,
 2. Speak unto the children of Israel, and say unto them, /Concerning/ the feasts of the LORD, which ye shall proclaim /to be/ holy convocations, /even/ these /are/ my feasts.
@@ -809,7 +809,7 @@
 41. And ye shall keep it a feast unto the LORD seven days in the year. /It shall be/ a statute for ever in your generations: ye shall celebrate it in the seventh month.
 42. Ye shall dwell in booths seven days; all that are Israelites born shall dwell in booths:
 43. That your generations may know that I made the children of Israel to dwell in booths, when I brought them out of the land of Egypt: I /am/ the LORD your God.
-44. And Moses declared unto the children of Israel the feasts of the LORD. 
+44. And Moses declared unto the children of Israel the feasts of the LORD.
 * 24
 1. And the LORD spake unto Moses, saying,
 2. Command the children of Israel, that they bring unto thee pure oil olive beaten for the light, to cause the lamps to burn continually.
@@ -837,7 +837,7 @@
 21. And he that killeth a beast, he shall restore it: and he that killeth a man, he shall be put to death.
 22. Ye shall have one manner of law, as well for the stranger, as for one of your own country: for I /am/ the LORD your God.
 
-23. And Moses spake to the children of Israel, that they should bring forth him that had cursed out of the camp, and stone him with stones. And the children of Israel did as the LORD commanded Moses. 
+23. And Moses spake to the children of Israel, that they should bring forth him that had cursed out of the camp, and stone him with stones. And the children of Israel did as the LORD commanded Moses.
 * 25
 1. And the LORD spake unto Moses in mount Sinai, saying,
 2. Speak unto the children of Israel, and say unto them, When ye come into the land which I give you, then shall the land keep a sabbath unto the LORD.
@@ -900,7 +900,7 @@
 52. And if there remain but few years unto the year of jubile, then he shall count with him, /and/ according unto his years shall he give him again the price of his redemption.
 53. /And/ as a yearly hired servant shall he be with him: /and the other/ shall not rule with rigour over him in thy sight.
 54. And if he be not redeemed in these /years/, then he shall go out in the year of jubile, /both/ he, and his children with him.
-55. For unto me the children of Israel /are/ servants; they /are/ my servants whom I brought forth out of the land of Egypt: I /am/ the LORD your God. 
+55. For unto me the children of Israel /are/ servants; they /are/ my servants whom I brought forth out of the land of Egypt: I /am/ the LORD your God.
 * 26
 1. Ye shall make you no idols nor graven image, neither rear you up a standing image, neither shall ye set up /any/ image of stone in your land, to bow down unto it: for I /am/ the LORD your God.
 
@@ -951,7 +951,7 @@
 43. The land also shall be left of them, and shall enjoy her sabbaths, while she lieth desolate without them: and they shall accept of the punishment of their iniquity: because, even because they despised my judgments, and because their soul abhorred my statutes.
 44. And yet for all that, when they be in the land of their enemies, I will not cast them away, neither will I abhor them, to destroy them utterly, and to break my covenant with them: for I /am/ the LORD their God.
 45. But I will for their sakes remember the covenant of their ancestors, whom I brought forth out of the land of Egypt in the sight of the heathen, that I might be their God: I /am/ the LORD.
-46. These /are/ the statutes and judgments and laws, which the LORD made between him and the children of Israel in mount Sinai by the hand of Moses. 
+46. These /are/ the statutes and judgments and laws, which the LORD made between him and the children of Israel in mount Sinai by the hand of Moses.
 * 27
 1. And the LORD spake unto Moses, saying,
 2. Speak unto the children of Israel, and say unto them, When a man shall make a singular vow, the persons /shall be/ for the LORD by thy estimation.
@@ -988,4 +988,4 @@
 31. And if a man will at all redeem /ought/ of his tithes, he shall add thereto the fifth /part/ thereof.
 32. And concerning the tithe of the herd, or of the flock, /even/ of whatsoever passeth under the rod, the tenth shall be holy unto the LORD.
 33. He shall not search whether it be good or bad, neither shall he change it: and if he change it at all, then both it and the change thereof shall be holy; it shall not be redeemed.
-34. These /are/ the commandments, which the LORD commanded Moses for the children of Israel in mount Sinai.  
+34. These /are/ the commandments, which the LORD commanded Moses for the children of Israel in mount Sinai.

--- a/04_NUM.org
+++ b/04_NUM.org
@@ -67,7 +67,7 @@
 51. And when the tabernacle setteth forward, the Levites shall take it down: and when the tabernacle is to be pitched, the Levites shall set it up: and the stranger that cometh nigh shall be put to death.
 52. And the children of Israel shall pitch their tents, every man by his own camp, and every man by his own standard, throughout their hosts.
 53. But the Levites shall pitch round about the tabernacle of testimony, that there be no wrath upon the congregation of the children of Israel: and the Levites shall keep the charge of the tabernacle of testimony.
-54. And the children of Israel did according to all that the LORD commanded Moses, so did they. 
+54. And the children of Israel did according to all that the LORD commanded Moses, so did they.
 * 2
 1. And the LORD spake unto Moses and unto Aaron, saying,
 2. Every man of the children of Israel shall pitch by his own standard, with the ensign of their father's house: far off about the tabernacle of the congregation shall they pitch.
@@ -108,7 +108,7 @@
 
 32. These /are/ those which were numbered of the children of Israel by the house of their fathers: all those that were numbered of the camps throughout their hosts /were/ six hundred thousand and three thousand and five hundred and fifty.
 33. But the Levites were not numbered among the children of Israel; as the LORD commanded Moses.
-34. And the children of Israel did according to all that the LORD commanded Moses: so they pitched by their standards, and so they set forward, every one after their families, according to the house of their fathers. 
+34. And the children of Israel did according to all that the LORD commanded Moses: so they pitched by their standards, and so they set forward, every one after their families, according to the house of their fathers.
 * 3
 1. These also /are/ the generations of Aaron and Moses in the day /that/ the LORD spake with Moses in mount Sinai.
 2. And these /are/ the names of the sons of Aaron; Nadab the firstborn, and Abihu, Eleazar, and Ithamar.
@@ -167,7 +167,7 @@
 48. And thou shalt give the money, wherewith the odd number of them is to be redeemed, unto Aaron and to his sons.
 49. And Moses took the redemption money of them that were over and above them that were redeemed by the Levites:
 50. Of the firstborn of the children of Israel took he the money; a thousand three hundred and threescore and five /shekels/, after the shekel of the sanctuary:
-51. And Moses gave the money of them that were redeemed unto Aaron and to his sons, according to the word of the LORD, as the LORD commanded Moses. 
+51. And Moses gave the money of them that were redeemed unto Aaron and to his sons, according to the word of the LORD, as the LORD commanded Moses.
 * 4
 1. And the LORD spake unto Moses and unto Aaron, saying,
 2. Take the sum of the sons of Kohath from among the sons of Levi, after their families, by the house of their fathers,
@@ -224,7 +224,7 @@
 46. All those that were numbered of the Levites, whom Moses and Aaron and the chief of Israel numbered, after their families, and after the house of their fathers,
 47. From thirty years old and upward even unto fifty years old, every one that came to do the service of the ministry, and the service of the burden in the tabernacle of the congregation,
 48. Even those that were numbered of them, were eight thousand and five hundred and fourscore.
-49. According to the commandment of the LORD they were numbered by the hand of Moses, every one according to his service, and according to his burden: thus were they numbered of him, as the LORD commanded Moses. 
+49. According to the commandment of the LORD they were numbered by the hand of Moses, every one according to his service, and according to his burden: thus were they numbered of him, as the LORD commanded Moses.
 * 5
 1. And the LORD spake unto Moses, saying,
 2. Command the children of Israel, that they put out of the camp every leper, and every one that hath an issue, and whosoever is defiled by the dead:
@@ -258,7 +258,7 @@
 28. And if the woman be not defiled, but be clean; then she shall be free, and shall conceive seed.
 29. This /is/ the law of jealousies, when a wife goeth aside /to another/ instead of her husband, and is defiled;
 30. Or when the spirit of jealousy cometh upon him, and he be jealous over his wife, and shall set the woman before the LORD, and the priest shall execute upon her all this law.
-31. Then shall the man be guiltless from iniquity, and this woman shall bear her iniquity. 
+31. Then shall the man be guiltless from iniquity, and this woman shall bear her iniquity.
 * 6
 1. And the LORD spake unto Moses, saying,
 2. Speak unto the children of Israel, and say unto them, When either man or woman shall separate /themselves/ to vow a vow of a Nazarite, to separate /themselves/ unto the LORD:
@@ -288,7 +288,7 @@
 24. The LORD bless thee, and keep thee:
 25. The LORD make his face shine upon thee, and be gracious unto thee:
 26. The LORD lift up his countenance upon thee, and give thee peace.
-27. And they shall put my name upon the children of Israel; and I will bless them. 
+27. And they shall put my name upon the children of Israel; and I will bless them.
 * 7
 1. And it came to pass on the day that Moses had fully set up the tabernacle, and had anointed it, and sanctified it, and all the instruments thereof, both the altar and all the vessels thereof, and had anointed them, and sanctified them;
 2. That the princes of Israel, heads of the house of their fathers, who /were/ the princes of the tribes, and were over them that were numbered, offered:
@@ -391,7 +391,7 @@
 86. The golden spoons /were/ twelve, full of incense, /weighing/ ten /shekels/ apiece, after the shekel of the sanctuary: all the gold of the spoons /was/ an hundred and twenty /shekels/.
 87. All the oxen for the burnt offering /were/ twelve bullocks, the rams twelve, the lambs of the first year twelve, with their meat offering: and the kids of the goats for sin offering twelve.
 88. And all the oxen for the sacrifice of the peace offerings /were/ twenty and four bullocks, the rams sixty, the he goats sixty, the lambs of the first year sixty. This /was/ the dedication of the altar, after that it was anointed.
-89. And when Moses was gone into the tabernacle of the congregation to speak with him, then he heard the voice of one speaking unto him from off the mercy seat that /was/ upon the ark of testimony, from between the two cherubims: and he spake unto him. 
+89. And when Moses was gone into the tabernacle of the congregation to speak with him, then he heard the voice of one speaking unto him from off the mercy seat that /was/ upon the ark of testimony, from between the two cherubims: and he spake unto him.
 * 8
 1. And the LORD spake unto Moses, saying,
 2. Speak unto Aaron, and say unto him, When thou lightest the lamps, the seven lamps shall give light over against the candlestick.
@@ -420,7 +420,7 @@
 23. And the LORD spake unto Moses, saying,
 24. This /is it/ that /belongeth/ unto the Levites: from twenty and five years old and upward they shall go in to wait upon the service of the tabernacle of the congregation:
 25. And from the age of fifty years they shall cease waiting upon the service /thereof/, and shall serve no more:
-26. But shall minister with their brethren in the tabernacle of the congregation, to keep the charge, and shall do no service. Thus shalt thou do unto the Levites touching their charge. 
+26. But shall minister with their brethren in the tabernacle of the congregation, to keep the charge, and shall do no service. Thus shalt thou do unto the Levites touching their charge.
 * 9
 1. And the LORD spake unto Moses in the wilderness of Sinai, in the first month of the second year after they were come out of the land of Egypt, saying,
 2. Let the children of Israel also keep the passover at his appointed season.
@@ -447,7 +447,7 @@
 20. And /so/ it was, when the cloud was a few days upon the tabernacle; according to the commandment of the LORD they abode in their tents, and according to the commandment of the LORD they journeyed.
 21. And /so/ it was, when the cloud abode from even unto the morning, and /that/ the cloud was taken up in the morning, then they journeyed: whether /it was/ by day or by night that the cloud was taken up, they journeyed.
 22. Or /whether it were/ two days, or a month, or a year, that the cloud tarried upon the tabernacle, remaining thereon, the children of Israel abode in their tents, and journeyed not: but when it was taken up, they journeyed.
-23. At the commandment of the LORD they rested in the tents, and at the commandment of the LORD they journeyed: they kept the charge of the LORD, at the commandment of the LORD by the hand of Moses. 
+23. At the commandment of the LORD they rested in the tents, and at the commandment of the LORD they journeyed: they kept the charge of the LORD, at the commandment of the LORD by the hand of Moses.
 * 10
 1. And the LORD spake unto Moses, saying,
 2. Make thee two trumpets of silver; of a whole piece shalt thou make them: that thou mayest use them for the calling of the assembly, and for the journeying of the camps.
@@ -491,7 +491,7 @@
 33. And they departed from the mount of the LORD three days' journey: and the ark of the covenant of the LORD went before them in the three days' journey, to search out a resting place for them.
 34. And the cloud of the LORD /was/ upon them by day, when they went out of the camp.
 35. And it came to pass, when the ark set forward, that Moses said, Rise up, LORD, and let thine enemies be scattered; and let them that hate thee flee before thee.
-36. And when it rested, he said, Return, O LORD, unto the many thousands of Israel. 
+36. And when it rested, he said, Return, O LORD, unto the many thousands of Israel.
 * 11
 1. And /when/ the people complained, it displeased the LORD: and the LORD heard /it/; and his anger was kindled; and the fire of the LORD burnt among them, and consumed /them that were/ in the uttermost parts of the camp.
 2. And the people cried unto Moses; and when Moses prayed unto the LORD, the fire was quenched.
@@ -532,7 +532,7 @@
 32. And the people stood up all that day, and all /that/ night, and all the next day, and they gathered the quails: he that gathered least gathered ten homers: and they spread /them/ all abroad for themselves round about the camp.
 33. And while the flesh /was/ yet between their teeth, ere it was chewed, the wrath of the LORD was kindled against the people, and the LORD smote the people with a very great plague.
 34. And he called the name of that place Kibroth–hattaavah: because there they buried the people that lusted.
-35. /And/ the people journeyed from Kibroth–hattaavah unto Hazeroth; and abode at Hazeroth. 
+35. /And/ the people journeyed from Kibroth–hattaavah unto Hazeroth; and abode at Hazeroth.
 * 12
 1. And Miriam and Aaron spake against Moses because of the Ethiopian woman whom he had married: for he had married an Ethiopian woman.
 2. And they said, Hath the LORD indeed spoken only by Moses? hath he not spoken also by us? And the LORD heard /it/.
@@ -550,7 +550,7 @@
 
 14. And the LORD said unto Moses, If her father had but spit in her face, should she not be ashamed seven days? let her be shut out from the camp seven days, and after that let her be received in /again/.
 15. And Miriam was shut out from the camp seven days: and the people journeyed not till Miriam was brought in /again/.
-16. And afterward the people removed from Hazeroth, and pitched in the wilderness of Paran. 
+16. And afterward the people removed from Hazeroth, and pitched in the wilderness of Paran.
 * 13
 1. And the LORD spake unto Moses, saying,
 2. Send thou men, that they may search the land of Canaan, which I give unto the children of Israel: of every tribe of their fathers shall ye send a man, every one a ruler among them.
@@ -587,7 +587,7 @@
 30. And Caleb stilled the people before Moses, and said, Let us go up at once, and possess it; for we are well able to overcome it.
 31. But the men that went up with him said, We be not able to go up against the people; for they /are/ stronger than we.
 32. And they brought up an evil report of the land which they had searched unto the children of Israel, saying, The land, through which we have gone to search it, /is/ a land that eateth up the inhabitants thereof; and all the people that we saw in it /are/ men of a great stature.
-33. And there we saw the giants, the sons of Anak, /which come/ of the giants: and we were in our own sight as grasshoppers, and so we were in their sight. 
+33. And there we saw the giants, the sons of Anak, /which come/ of the giants: and we were in our own sight as grasshoppers, and so we were in their sight.
 * 14
 1. And all the congregation lifted up their voice, and cried; and the people wept that night.
 2. And all the children of Israel murmured against Moses and against Aaron: and the whole congregation said unto them, Would God that we had died in the land of Egypt! or would God we had died in this wilderness!
@@ -639,7 +639,7 @@
 42. Go not up, for the LORD /is/ not among you; that ye be not smitten before your enemies.
 43. For the Amalekites and the Canaanites /are/ there before you, and ye shall fall by the sword: because ye are turned away from the LORD, therefore the LORD will not be with you.
 44. But they presumed to go up unto the hill top: nevertheless the ark of the covenant of the LORD, and Moses, departed not out of the camp.
-45. Then the Amalekites came down, and the Canaanites which dwelt in that hill, and smote them, and discomfited them, /even/ unto Hormah. 
+45. Then the Amalekites came down, and the Canaanites which dwelt in that hill, and smote them, and discomfited them, /even/ unto Hormah.
 * 15
 1. And the LORD spake unto Moses, saying,
 2. Speak unto the children of Israel, and say unto them, When ye be come into the land of your habitations, which I give unto you,
@@ -687,7 +687,7 @@
 38. Speak unto the children of Israel, and bid them that they make them fringes in the borders of their garments throughout their generations, and that they put upon the fringe of the borders a ribband of blue:
 39. And it shall be unto you for a fringe, that ye may look upon it, and remember all the commandments of the LORD, and do them; and that ye seek not after your own heart and your own eyes, after which ye use to go a whoring:
 40. That ye may remember, and do all my commandments, and be holy unto your God.
-41. I /am/ the LORD your God, which brought you out of the land of Egypt, to be your God: I /am/ the LORD your God. 
+41. I /am/ the LORD your God, which brought you out of the land of Egypt, to be your God: I /am/ the LORD your God.
 * 16
 1. Now Korah, the son of Izhar, the son of Kohath, the son of Levi, and Dathan and Abiram, the sons of Eliab, and On, the son of Peleth, sons of Reuben, took /men/:
 2. And they rose up before Moses, with certain of the children of Israel, two hundred and fifty princes of the assembly, famous in the congregation, men of renown:
@@ -745,7 +745,7 @@
 47. And Aaron took as Moses commanded, and ran into the midst of the congregation; and, behold, the plague was begun among the people: and he put on incense, and made an atonement for the people.
 48. And he stood between the dead and the living; and the plague was stayed.
 49. Now they that died in the plague were fourteen thousand and seven hundred, beside them that died about the matter of Korah.
-50. And Aaron returned unto Moses unto the door of the tabernacle of the congregation: and the plague was stayed. 
+50. And Aaron returned unto Moses unto the door of the tabernacle of the congregation: and the plague was stayed.
 * 17
 1. And the LORD spake unto Moses, saying,
 2. Speak unto the children of Israel, and take of every one of them a rod according to the house of /their/ fathers, of all their princes according to the house of their fathers twelve rods: write thou every man's name upon his rod.
@@ -761,7 +761,7 @@
 10. And the LORD said unto Moses, Bring Aaron's rod again before the testimony, to be kept for a token against the rebels; and thou shalt quite take away their murmurings from me, that they die not.
 11. And Moses did /so/: as the LORD commanded him, so did he.
 12. And the children of Israel spake unto Moses, saying, Behold, we die, we perish, we all perish.
-13. Whosoever cometh any thing near unto the tabernacle of the LORD shall die: shall we be consumed with dying? 
+13. Whosoever cometh any thing near unto the tabernacle of the LORD shall die: shall we be consumed with dying?
 * 18
 1. And the LORD said unto Aaron, Thou and thy sons and thy father's house with thee shall bear the iniquity of the sanctuary: and thou and thy sons with thee shall bear the iniquity of your priesthood.
 2. And thy brethren also of the tribe of Levi, the tribe of thy father, bring thou with thee, that they may be joined unto thee, and minister unto thee: but thou and thy sons with thee /shall minister/ before the tabernacle of witness.
@@ -797,7 +797,7 @@
 29. Out of all your gifts ye shall offer every heave offering of the LORD, of all the best thereof, /even/ the hallowed part thereof out of it.
 30. Therefore thou shalt say unto them, When ye have heaved the best thereof from it, then it shall be counted unto the Levites as the increase of the threshingfloor, and as the increase of the winepress.
 31. And ye shall eat it in every place, ye and your households: for it /is/ your reward for your service in the tabernacle of the congregation.
-32. And ye shall bear no sin by reason of it, when ye have heaved from it the best of it: neither shall ye pollute the holy things of the children of Israel, lest ye die. 
+32. And ye shall bear no sin by reason of it, when ye have heaved from it the best of it: neither shall ye pollute the holy things of the children of Israel, lest ye die.
 * 19
 1. And the LORD spake unto Moses and unto Aaron, saying,
 2. This /is/ the ordinance of the law which the LORD hath commanded, saying, Speak unto the children of Israel, that they bring thee a red heifer without spot, wherein /is/ no blemish, /and/ upon which never came yoke:
@@ -821,7 +821,7 @@
 19. And the clean /person/ shall sprinkle upon the unclean on the third day, and on the seventh day: and on the seventh day he shall purify himself, and wash his clothes, and bathe himself in water, and shall be clean at even.
 20. But the man that shall be unclean, and shall not purify himself, that soul shall be cut off from among the congregation, because he hath defiled the sanctuary of the LORD: the water of separation hath not been sprinkled upon him; he /is/ unclean.
 21. And it shall be a perpetual statute unto them, that he that sprinkleth the water of separation shall wash his clothes; and he that toucheth the water of separation shall be unclean until even.
-22. And whatsoever the unclean /person/ toucheth shall be unclean; and the soul that toucheth /it/ shall be unclean until even. 
+22. And whatsoever the unclean /person/ toucheth shall be unclean; and the soul that toucheth /it/ shall be unclean until even.
 * 20
 1. Then came the children of Israel, /even/ the whole congregation, into the desert of Zin in the first month: and the people abode in Kadesh; and Miriam died there, and was buried there.
 2. And there was no water for the congregation: and they gathered themselves together against Moses and against Aaron.
@@ -855,7 +855,7 @@
 26. And strip Aaron of his garments, and put them upon Eleazar his son: and Aaron shall be gathered /unto his people/, and shall die there.
 27. And Moses did as the LORD commanded: and they went up into mount Hor in the sight of all the congregation.
 28. And Moses stripped Aaron of his garments, and put them upon Eleazar his son; and Aaron died there in the top of the mount: and Moses and Eleazar came down from the mount.
-29. And when all the congregation saw that Aaron was dead, they mourned for Aaron thirty days, /even/ all the house of Israel. 
+29. And when all the congregation saw that Aaron was dead, they mourned for Aaron thirty days, /even/ all the house of Israel.
 * 21
 1. And /when/ king Arad the Canaanite, which dwelt in the south, heard tell that Israel came by the way of the spies; then he fought against Israel, and took /some/ of them prisoners.
 2. And Israel vowed a vow unto the LORD, and said, If thou wilt indeed deliver this people into my hand, then I will utterly destroy their cities.
@@ -899,7 +899,7 @@
 
 33. And they turned and went up by the way of Bashan: and Og the king of Bashan went out against them, he, and all his people, to the battle at Edrei.
 34. And the LORD said unto Moses, Fear him not: for I have delivered him into thy hand, and all his people, and his land; and thou shalt do to him as thou didst unto Sihon king of the Amorites, which dwelt at Heshbon.
-35. So they smote him, and his sons, and all his people, until there was none left him alive: and they possessed his land. 
+35. So they smote him, and his sons, and all his people, until there was none left him alive: and they possessed his land.
 * 22
 1. And the children of Israel set forward, and pitched in the plains of Moab on this side Jordan /by/ Jericho.
 
@@ -945,7 +945,7 @@
 38. And Balaam said unto Balak, Lo, I am come unto thee: have I now any power at all to say any thing? the word that God putteth in my mouth, that shall I speak.
 39. And Balaam went with Balak, and they came unto Kirjath–huzoth.
 40. And Balak offered oxen and sheep, and sent to Balaam, and to the princes that /were/ with him.
-41. And it came to pass on the morrow, that Balak took Balaam, and brought him up into the high places of Baal, that thence he might see the utmost /part/ of the people. 
+41. And it came to pass on the morrow, that Balak took Balaam, and brought him up into the high places of Baal, that thence he might see the utmost /part/ of the people.
 * 23
 1. And Balaam said unto Balak, Build me here seven altars, and prepare me here seven oxen and seven rams.
 2. And Balak did as Balaam had spoken; and Balak and Balaam offered on /every/ altar a bullock and a ram.
@@ -979,7 +979,7 @@
 27. And Balak said unto Balaam, Come, I pray thee, I will bring thee unto another place; peradventure it will please God that thou mayest curse me them from thence.
 28. And Balak brought Balaam unto the top of Peor, that looketh toward Jeshimon.
 29. And Balaam said unto Balak, Build me here seven altars, and prepare me here seven bullocks and seven rams.
-30. And Balak did as Balaam had said, and offered a bullock and a ram on /every/ altar. 
+30. And Balak did as Balaam had said, and offered a bullock and a ram on /every/ altar.
 * 24
 1. And when Balaam saw that it pleased the LORD to bless Israel, he went not, as at other times, to seek for enchantments, but he set his face toward the wilderness.
 2. And Balaam lifted up his eyes, and he saw Israel abiding /in his tents/ according to their tribes; and the spirit of God came upon him.
@@ -1008,7 +1008,7 @@
 22. Nevertheless the Kenite shall be wasted, until Asshur shall carry thee away captive.
 23. And he took up his parable, and said, Alas, who shall live when God doeth this!
 24. And ships /shall come/ from the coast of Chittim, and shall afflict Asshur, and shall afflict Eber, and he also shall perish for ever.
-25. And Balaam rose up, and went and returned to his place: and Balak also went his way. 
+25. And Balaam rose up, and went and returned to his place: and Balak also went his way.
 * 25
 1. And Israel abode in Shittim, and the people began to commit whoredom with the daughters of Moab.
 2. And they called the people unto the sacrifices of their gods: and the people did eat, and bowed down to their gods.
@@ -1030,7 +1030,7 @@
 
 16. And the LORD spake unto Moses, saying,
 17. Vex the Midianites, and smite them:
-18. For they vex you with their wiles, wherewith they have beguiled you in the matter of Peor, and in the matter of Cozbi, the daughter of a prince of Midian, their sister, which was slain in the day of the plague for Peor's sake. 
+18. For they vex you with their wiles, wherewith they have beguiled you in the matter of Peor, and in the matter of Cozbi, the daughter of a prince of Midian, their sister, which was slain in the day of the plague for Peor's sake.
 * 26
 1. And it came to pass after the plague, that the LORD spake unto Moses and unto Eleazar the son of Aaron the priest, saying,
 2. Take the sum of all the congregation of the children of Israel, from twenty years old and upward, throughout their fathers' house, all that are able to go to war in Israel.
@@ -1112,7 +1112,7 @@
 
 63. These /are/ they that were numbered by Moses and Eleazar the priest, who numbered the children of Israel in the plains of Moab by Jordan /near/ Jericho.
 64. But among these there was not a man of them whom Moses and Aaron the priest numbered, when they numbered the children of Israel in the wilderness of Sinai.
-65. For the LORD had said of them, They shall surely die in the wilderness. And there was not left a man of them, save Caleb the son of Jephunneh, and Joshua the son of Nun. 
+65. For the LORD had said of them, They shall surely die in the wilderness. And there was not left a man of them, save Caleb the son of Jephunneh, and Joshua the son of Nun.
 * 27
 1. Then came the daughters of Zelophehad, the son of Hepher, the son of Gilead, the son of Machir, the son of Manasseh, of the families of Manasseh the son of Joseph: and these /are/ the names of his daughters; Mahlah, Noah, and Hoglah, and Milcah, and Tirzah.
 2. And they stood before Moses, and before Eleazar the priest, and before the princes and all the congregation, /by/ the door of the tabernacle of the congregation, saying,
@@ -1140,7 +1140,7 @@
 20. And thou shalt put /some/ of thine honour upon him, that all the congregation of the children of Israel may be obedient.
 21. And he shall stand before Eleazar the priest, who shall ask /counsel/ for him after the judgment of Urim before the LORD: at his word shall they go out, and at his word they shall come in, /both/ he, and all the children of Israel with him, even all the congregation.
 22. And Moses did as the LORD commanded him: and he took Joshua, and set him before Eleazar the priest, and before all the congregation:
-23. And he laid his hands upon him, and gave him a charge, as the LORD commanded by the hand of Moses. 
+23. And he laid his hands upon him, and gave him a charge, as the LORD commanded by the hand of Moses.
 * 28
 1. And the LORD spake unto Moses, saying,
 2. Command the children of Israel, and say unto them, My offering, /and/ my bread for my sacrifices made by fire, /for/ a sweet savour unto me, shall ye observe to offer unto me in their due season.
@@ -1175,7 +1175,7 @@
 28. And their meat offering of flour mingled with oil, three tenth deals unto one bullock, two tenth deals unto one ram,
 29. A several tenth deal unto one lamb, throughout the seven lambs;
 30. /And/ one kid of the goats, to make an atonement for you.
-31. Ye shall offer /them/ beside the continual burnt offering, and his meat offering, (they shall be unto you without blemish) and their drink offerings. 
+31. Ye shall offer /them/ beside the continual burnt offering, and his meat offering, (they shall be unto you without blemish) and their drink offerings.
 * 29
 1. And in the seventh month, on the first /day/ of the month, ye shall have an holy convocation; ye shall do no servile work: it is a day of blowing the trumpets unto you.
 2. And ye shall offer a burnt offering for a sweet savour unto the LORD; one young bullock, one ram, /and/ seven lambs of the first year without blemish:
@@ -1225,7 +1225,7 @@
 37. Their meat offering and their drink offerings for the bullock, for the ram, and for the lambs, /shall be/ according to their number, after the manner:
 38. And one goat /for/ a sin offering; beside the continual burnt offering, and his meat offering, and his drink offering.
 39. These /things/ ye shall do unto the LORD in your set feasts, beside your vows, and your freewill offerings, for your burnt offerings, and for your meat offerings, and for your drink offerings, and for your peace offerings.
-40. And Moses told the children of Israel according to all that the LORD commanded Moses. 
+40. And Moses told the children of Israel according to all that the LORD commanded Moses.
 * 30
 1. And Moses spake unto the heads of the tribes concerning the children of Israel, saying, This /is/ the thing which the LORD hath commanded.
 2. If a man vow a vow unto the LORD, or swear an oath to bind his soul with a bond; he shall not break his word, he shall do according to all that proceedeth out of his mouth.
@@ -1242,7 +1242,7 @@
 13. Every vow, and every binding oath to afflict the soul, her husband may establish it, or her husband may make it void.
 14. But if her husband altogether hold his peace at her from day to day; then he establisheth all her vows, or all her bonds, which /are/ upon her: he confirmeth them, because he held his peace at her in the day that he heard /them/.
 15. But if he shall any ways make them void after that he hath heard /them/; then he shall bear her iniquity.
-16. These /are/ the statutes, which the LORD commanded Moses, between a man and his wife, between the father and his daughter, /being yet/ in her youth in her father's house. 
+16. These /are/ the statutes, which the LORD commanded Moses, between a man and his wife, between the father and his daughter, /being yet/ in her youth in her father's house.
 * 31
 1. And the LORD spake unto Moses, saying,
 2. Avenge the children of Israel of the Midianites: afterward shalt thou be gathered unto thy people.
@@ -1301,7 +1301,7 @@
 51. And Moses and Eleazar the priest took the gold of them, /even/ all wrought jewels.
 52. And all the gold of the offering that they offered up to the LORD, of the captains of thousands, and of the captains of hundreds, was sixteen thousand seven hundred and fifty shekels.
 53. (/For/ the men of war had taken spoil, every man for himself.)
-54. And Moses and Eleazar the priest took the gold of the captains of thousands and of hundreds, and brought it into the tabernacle of the congregation, /for/ a memorial for the children of Israel before the LORD. 
+54. And Moses and Eleazar the priest took the gold of the captains of thousands and of hundreds, and brought it into the tabernacle of the congregation, /for/ a memorial for the children of Israel before the LORD.
 * 32
 1. Now the children of Reuben and the children of Gad had a very great multitude of cattle: and when they saw the land of Jazer, and the land of Gilead, that, behold, the place /was/ a place for cattle;
 2. The children of Gad and the children of Reuben came and spake unto Moses, and to Eleazar the priest, and unto the princes of the congregation, saying,
@@ -1348,7 +1348,7 @@
 39. And the children of Machir the son of Manasseh went to Gilead, and took it, and dispossessed the Amorite which /was/ in it.
 40. And Moses gave Gilead unto Machir the son of Manasseh; and he dwelt therein.
 41. And Jair the son of Manasseh went and took the small towns thereof, and called them Havoth–jair.
-42. And Nobah went and took Kenath, and the villages thereof, and called it Nobah, after his own name. 
+42. And Nobah went and took Kenath, and the villages thereof, and called it Nobah, after his own name.
 * 33
 1. These /are/ the journeys of the children of Israel, which went forth out of the land of Egypt with their armies under the hand of Moses and Aaron.
 2. And Moses wrote their goings out according to their journeys by the commandment of the LORD: and these /are/ their journeys according to their goings out.
@@ -1406,7 +1406,7 @@
 53. And ye shall dispossess /the inhabitants/ of the land, and dwell therein: for I have given you the land to possess it.
 54. And ye shall divide the land by lot for an inheritance among your families: /and/ to the more ye shall give the more inheritance, and to the fewer ye shall give the less inheritance: every man's /inheritance/ shall be in the place where his lot falleth; according to the tribes of your fathers ye shall inherit.
 55. But if ye will not drive out the inhabitants of the land from before you; then it shall come to pass, that those which ye let remain of them /shall be/ pricks in your eyes, and thorns in your sides, and shall vex you in the land wherein ye dwell.
-56. Moreover it shall come to pass, /that/ I shall do unto you, as I thought to do unto them. 
+56. Moreover it shall come to pass, /that/ I shall do unto you, as I thought to do unto them.
 * 34
 1. And the LORD spake unto Moses, saying,
 2. Command the children of Israel, and say unto them, When ye come into the land of Canaan; (this /is/ the land that shall fall unto you for an inheritance, /even/ the land of Canaan with the coasts thereof:)
@@ -1437,7 +1437,7 @@
 26. And the prince of the tribe of the children of Issachar, Paltiel the son of Azzan.
 27. And the prince of the tribe of the children of Asher, Ahihud the son of Shelomi.
 28. And the prince of the tribe of the children of Naphtali, Pedahel the son of Ammihud.
-29. These /are they/ whom the LORD commanded to divide the inheritance unto the children of Israel in the land of Canaan. 
+29. These /are they/ whom the LORD commanded to divide the inheritance unto the children of Israel in the land of Canaan.
 * 35
 1. And the LORD spake unto Moses in the plains of Moab by Jordan /near/ Jericho, saying,
 2. Command the children of Israel, that they give unto the Levites of the inheritance of their possession cities to dwell in; and ye shall give /also/ unto the Levites suburbs for the cities round about them.
@@ -1473,7 +1473,7 @@
 31. Moreover ye shall take no satisfaction for the life of a murderer, which /is/ guilty of death: but he shall be surely put to death.
 32. And ye shall take no satisfaction for him that is fled to the city of his refuge, that he should come again to dwell in the land, until the death of the priest.
 33. So ye shall not pollute the land wherein ye /are/: for blood it defileth the land: and the land cannot be cleansed of the blood that is shed therein, but by the blood of him that shed it.
-34. Defile not therefore the land which ye shall inhabit, wherein I dwell: for I the LORD dwell among the children of Israel. 
+34. Defile not therefore the land which ye shall inhabit, wherein I dwell: for I the LORD dwell among the children of Israel.
 * 36
 1. And the chief fathers of the families of the children of Gilead, the son of Machir, the son of Manasseh, of the families of the sons of Joseph, came near, and spake before Moses, and before the princes, the chief fathers of the children of Israel:
 2. And they said, The LORD commanded my lord to give the land for an inheritance by lot to the children of Israel: and my lord was commanded by the LORD to give the inheritance of Zelophehad our brother unto his daughters.
@@ -1487,4 +1487,4 @@
 10. Even as the LORD commanded Moses, so did the daughters of Zelophehad:
 11. For Mahlah, Tirzah, and Hoglah, and Milcah, and Noah, the daughters of Zelophehad, were married unto their father's brothers' sons:
 12. /And/ they were married into the families of the sons of Manasseh the son of Joseph, and their inheritance remained in the tribe of the family of their father.
-13. These /are/ the commandments and the judgments, which the LORD commanded by the hand of Moses unto the children of Israel in the plains of Moab by Jordan /near/ Jericho.  
+13. These /are/ the commandments and the judgments, which the LORD commanded by the hand of Moses unto the children of Israel in the plains of Moab by Jordan /near/ Jericho.

--- a/05_DEU.org
+++ b/05_DEU.org
@@ -48,7 +48,7 @@
 43. So I spake unto you; and ye would not hear, but rebelled against the commandment of the LORD, and went presumptuously up into the hill.
 44. And the Amorites, which dwelt in that mountain, came out against you, and chased you, as bees do, and destroyed you in Seir, /even/ unto Hormah.
 45. And ye returned and wept before the LORD; but the LORD would not hearken to your voice, nor give ear unto you.
-46. So ye abode in Kadesh many days, according unto the days that ye abode /there/. 
+46. So ye abode in Kadesh many days, according unto the days that ye abode /there/.
 * 2
 1. Then we turned, and took our journey into the wilderness by the way of the Red sea, as the LORD spake unto me: and we compassed mount Seir many days.
 2. And the LORD spake unto me, saying,
@@ -89,7 +89,7 @@
 34. And we took all his cities at that time, and utterly destroyed the men, and the women, and the little ones, of every city, we left none to remain:
 35. Only the cattle we took for a prey unto ourselves, and the spoil of the cities which we took.
 36. From Aroer, which /is/ by the brink of the river of Arnon, and /from/ the city that /is/ by the river, even unto Gilead, there was not one city too strong for us: the LORD our God delivered all unto us:
-37. Only unto the land of the children of Ammon thou camest not, /nor/ unto any place of the river Jabbok, nor unto the cities in the mountains, nor unto whatsoever the LORD our God forbad us. 
+37. Only unto the land of the children of Ammon thou camest not, /nor/ unto any place of the river Jabbok, nor unto the cities in the mountains, nor unto whatsoever the LORD our God forbad us.
 * 3
 1. Then we turned, and went up the way to Bashan: and Og the king of Bashan came out against us, he and all his people, to battle at Edrei.
 2. And the LORD said unto me, Fear him not: for I will deliver him, and all his people, and his land, into thy hand; and thou shalt do unto him as thou didst unto Sihon king of the Amorites, which dwelt at Heshbon.
@@ -121,7 +121,7 @@
 26. But the LORD was wroth with me for your sakes, and would not hear me: and the LORD said unto me, Let it suffice thee; speak no more unto me of this matter.
 27. Get thee up into the top of Pisgah, and lift up thine eyes westward, and northward, and southward, and eastward, and behold /it/ with thine eyes: for thou shalt not go over this Jordan.
 28. But charge Joshua, and encourage him, and strengthen him: for he shall go over before this people, and he shall cause them to inherit the land which thou shalt see.
-29. So we abode in the valley over against Beth–peor. 
+29. So we abode in the valley over against Beth–peor.
 * 4
 1. Now therefore hearken, O Israel, unto the statutes and unto the judgments, which I teach you, for to do /them/, that ye may live, and go in and possess the land which the LORD God of your fathers giveth you.
 2. Ye shall not add unto the word which I command you, neither shall ye diminish /ought/ from it, that ye may keep the commandments of the LORD your God which I command you.
@@ -175,7 +175,7 @@
 46. On this side Jordan, in the valley over against Beth–peor, in the land of Sihon king of the Amorites, who dwelt at Heshbon, whom Moses and the children of Israel smote, after they were come forth out of Egypt:
 47. And they possessed his land, and the land of Og king of Bashan, two kings of the Amorites, which /were/ on this side Jordan toward the sunrising;
 48. From Aroer, which /is/ by the bank of the river Arnon, even unto mount Sion, which /is/ Hermon,
-49. And all the plain on this side Jordan eastward, even unto the sea of the plain, under the springs of Pisgah. 
+49. And all the plain on this side Jordan eastward, even unto the sea of the plain, under the springs of Pisgah.
 * 5
 1. And Moses called all Israel, and said unto them, Hear, O Israel, the statutes and judgments which I speak in your ears this day, that ye may learn them, and keep, and do them.
 2. The LORD our God made a covenant with us in Horeb.
@@ -212,7 +212,7 @@
 30. Go say to them, Get you into your tents again.
 31. But as for thee, stand thou here by me, and I will speak unto thee all the commandments, and the statutes, and the judgments, which thou shalt teach them, that they may do /them/ in the land which I give them to possess it.
 32. Ye shall observe to do therefore as the LORD your God hath commanded you: ye shall not turn aside to the right hand or to the left.
-33. Ye shall walk in all the ways which the LORD your God hath commanded you, that ye may live, and /that it may be/ well with you, and /that/ ye may prolong /your/ days in the land which ye shall possess. 
+33. Ye shall walk in all the ways which the LORD your God hath commanded you, that ye may live, and /that it may be/ well with you, and /that/ ye may prolong /your/ days in the land which ye shall possess.
 * 6
 1. Now these /are/ the commandments, the statutes, and the judgments, which the LORD your God commanded to teach you, that ye might do /them/ in the land whither ye go to possess it:
 2. That thou mightest fear the LORD thy God, to keep all his statutes and his commandments, which I command thee, thou, and thy son, and thy son's son, all the days of thy life; and that thy days may be prolonged.
@@ -240,7 +240,7 @@
 22. And the LORD shewed signs and wonders, great and sore, upon Egypt, upon Pharaoh, and upon all his household, before our eyes:
 23. And he brought us out from thence, that he might bring us in, to give us the land which he sware unto our fathers.
 24. And the LORD commanded us to do all these statutes, to fear the LORD our God, for our good always, that he might preserve us alive, as /it is/ at this day.
-25. And it shall be our righteousness, if we observe to do all these commandments before the LORD our God, as he hath commanded us. 
+25. And it shall be our righteousness, if we observe to do all these commandments before the LORD our God, as he hath commanded us.
 * 7
 1. When the LORD thy God shall bring thee into the land whither thou goest to possess it, and hath cast out many nations before thee, the Hittites, and the Girgashites, and the Amorites, and the Canaanites, and the Perizzites, and the Hivites, and the Jebusites, seven nations greater and mightier than thou;
 2. And when the LORD thy God shall deliver them before thee; thou shalt smite them, /and/ utterly destroy them; thou shalt make no covenant with them, nor shew mercy unto them:
@@ -268,7 +268,7 @@
 23. But the LORD thy God shall deliver them unto thee, and shall destroy them with a mighty destruction, until they be destroyed.
 24. And he shall deliver their kings into thine hand, and thou shalt destroy their name from under heaven: there shall no man be able to stand before thee, until thou have destroyed them.
 25. The graven images of their gods shall ye burn with fire: thou shalt not desire the silver or gold /that is/ on them, nor take /it/ unto thee, lest thou be snared therein: for it /is/ an abomination to the LORD thy God.
-26. Neither shalt thou bring an abomination into thine house, lest thou be a cursed thing like it: /but/ thou shalt utterly detest it, and thou shalt utterly abhor it; for it /is/ a cursed thing. 
+26. Neither shalt thou bring an abomination into thine house, lest thou be a cursed thing like it: /but/ thou shalt utterly detest it, and thou shalt utterly abhor it; for it /is/ a cursed thing.
 * 8
 1. All the commandments which I command thee this day shall ye observe to do, that ye may live, and multiply, and go in and possess the land which the LORD sware unto your fathers.
 2. And thou shalt remember all the way which the LORD thy God led thee these forty years in the wilderness, to humble thee, /and/ to prove thee, to know what /was/ in thine heart, whether thou wouldest keep his commandments, or no.
@@ -289,7 +289,7 @@
 17. And thou say in thine heart, My power and the might of /mine/ hand hath gotten me this wealth.
 18. But thou shalt remember the LORD thy God: for /it is/ he that giveth thee power to get wealth, that he may establish his covenant which he sware unto thy fathers, as /it is/ this day.
 19. And it shall be, if thou do at all forget the LORD thy God, and walk after other gods, and serve them, and worship them, I testify against you this day that ye shall surely perish.
-20. As the nations which the LORD destroyeth before your face, so shall ye perish; because ye would not be obedient unto the voice of the LORD your God. 
+20. As the nations which the LORD destroyeth before your face, so shall ye perish; because ye would not be obedient unto the voice of the LORD your God.
 * 9
 1. Hear, O Israel: Thou /art/ to pass over Jordan this day, to go in to possess nations greater and mightier than thyself, cities great and fenced up to heaven,
 2. A people great and tall, the children of the Anakims, whom thou knowest, and /of whom/ thou hast heard /say/, Who can stand before the children of Anak!
@@ -320,7 +320,7 @@
 26. I prayed therefore unto the LORD, and said, O Lord GOD, destroy not thy people and thine inheritance, which thou hast redeemed through thy greatness, which thou hast brought forth out of Egypt with a mighty hand.
 27. Remember thy servants, Abraham, Isaac, and Jacob; look not unto the stubbornness of this people, nor to their wickedness, nor to their sin:
 28. Lest the land whence thou broughtest us out say, Because the LORD was not able to bring them into the land which he promised them, and because he hated them, he hath brought them out to slay them in the wilderness.
-29. Yet they /are/ thy people and thine inheritance, which thou broughtest out by thy mighty power and by thy stretched out arm. 
+29. Yet they /are/ thy people and thine inheritance, which thou broughtest out by thy mighty power and by thy stretched out arm.
 * 10
 1. At that time the LORD said unto me, Hew thee two tables of stone like unto the first, and come up unto me into the mount, and make thee an ark of wood.
 2. And I will write on the tables the words that were in the first tables which thou brakest, and thou shalt put them in the ark.
@@ -346,7 +346,7 @@
 19. Love ye therefore the stranger: for ye were strangers in the land of Egypt.
 20. Thou shalt fear the LORD thy God; him shalt thou serve, and to him shalt thou cleave, and swear by his name.
 21. He /is/ thy praise, and he /is/ thy God, that hath done for thee these great and terrible things, which thine eyes have seen.
-22. Thy fathers went down into Egypt with threescore and ten persons; and now the LORD thy God hath made thee as the stars of heaven for multitude. 
+22. Thy fathers went down into Egypt with threescore and ten persons; and now the LORD thy God hath made thee as the stars of heaven for multitude.
 * 11
 1. Therefore thou shalt love the LORD thy God, and keep his charge, and his statutes, and his judgments, and his commandments, alway.
 2. And know ye this day: for /I speak/ not with your children which have not known, and which have not seen the chastisement of the LORD your God, his greatness, his mighty hand, and his stretched out arm,
@@ -384,7 +384,7 @@
 29. And it shall come to pass, when the LORD thy God hath brought thee in unto the land whither thou goest to possess it, that thou shalt put the blessing upon mount Gerizim, and the curse upon mount Ebal.
 30. /Are/ they not on the other side Jordan, by the way where the sun goeth down, in the land of the Canaanites, which dwell in the champaign over against Gilgal, beside the plains of Moreh?
 31. For ye shall pass over Jordan to go in to possess the land which the LORD your God giveth you, and ye shall possess it, and dwell therein.
-32. And ye shall observe to do all the statutes and judgments which I set before you this day. 
+32. And ye shall observe to do all the statutes and judgments which I set before you this day.
 * 12
 1. These /are/ the statutes and judgments, which ye shall observe to do in the land, which the LORD God of thy fathers giveth thee to possess it, all the days that ye live upon the earth.
 2. Ye shall utterly destroy all the places, wherein the nations which ye shall possess served their gods, upon the high mountains, and upon the hills, and under every green tree:
@@ -420,7 +420,7 @@
 29. When the LORD thy God shall cut off the nations from before thee, whither thou goest to possess them, and thou succeedest them, and dwellest in their land;
 30. Take heed to thyself that thou be not snared by following them, after that they be destroyed from before thee; and that thou enquire not after their gods, saying, How did these nations serve their gods? even so will I do likewise.
 31. Thou shalt not do so unto the LORD thy God: for every abomination to the LORD, which he hateth, have they done unto their gods; for even their sons and their daughters they have burnt in the fire to their gods.
-32. What thing soever I command you, observe to do it: thou shalt not add thereto, nor diminish from it. 
+32. What thing soever I command you, observe to do it: thou shalt not add thereto, nor diminish from it.
 * 13
 1. If there arise among you a prophet, or a dreamer of dreams, and giveth thee a sign or a wonder,
 2. And the sign or the wonder come to pass, whereof he spake unto thee, saying, Let us go after other gods, which thou hast not known, and let us serve them;
@@ -441,7 +441,7 @@
 15. Thou shalt surely smite the inhabitants of that city with the edge of the sword, destroying it utterly, and all that /is/ therein, and the cattle thereof, with the edge of the sword.
 16. And thou shalt gather all the spoil of it into the midst of the street thereof, and shalt burn with fire the city, and all the spoil thereof every whit, for the LORD thy God: and it shall be an heap for ever; it shall not be built again.
 17. And there shall cleave nought of the cursed thing to thine hand: that the LORD may turn from the fierceness of his anger, and shew thee mercy, and have compassion upon thee, and multiply thee, as he hath sworn unto thy fathers;
-18. When thou shalt hearken to the voice of the LORD thy God, to keep all his commandments which I command thee this day, to do /that which is/ right in the eyes of the LORD thy God. 
+18. When thou shalt hearken to the voice of the LORD thy God, to keep all his commandments which I command thee this day, to do /that which is/ right in the eyes of the LORD thy God.
 * 14
 1. Ye /are/ the children of the LORD your God: ye shall not cut yourselves, nor make any baldness between your eyes for the dead.
 2. For thou /art/ an holy people unto the LORD thy God, and the LORD hath chosen thee to be a peculiar people unto himself, above all the nations that /are/ upon the earth.
@@ -476,7 +476,7 @@
 27. And the Levite that /is/ within thy gates; thou shalt not forsake him; for he hath no part nor inheritance with thee.
 
 28. At the end of three years thou shalt bring forth all the tithe of thine increase the same year, and shalt lay /it/ up within thy gates:
-29. And the Levite, (because he hath no part nor inheritance with thee,) and the stranger, and the fatherless, and the widow, which /are/ within thy gates, shall come, and shall eat and be satisfied; that the LORD thy God may bless thee in all the work of thine hand which thou doest. 
+29. And the Levite, (because he hath no part nor inheritance with thee,) and the stranger, and the fatherless, and the widow, which /are/ within thy gates, shall come, and shall eat and be satisfied; that the LORD thy God may bless thee in all the work of thine hand which thou doest.
 * 15
 1. At the end of /every/ seven years thou shalt make a release.
 2. And this /is/ the manner of the release: Every creditor that lendeth /ought/ unto his neighbour shall release /it/; he shall not exact /it/ of his neighbour, or of his brother; because it is called the LORD's release.
@@ -503,7 +503,7 @@
 20. Thou shalt eat /it/ before the LORD thy God year by year in the place which the LORD shall choose, thou and thy household.
 21. And if there be /any/ blemish therein, /as if it be/ lame, or blind, /or have/ any ill blemish, thou shalt not sacrifice it unto the LORD thy God.
 22. Thou shalt eat it within thy gates: the unclean and the clean /person shall eat it/ alike, as the roebuck, and as the hart.
-23. Only thou shalt not eat the blood thereof; thou shalt pour it upon the ground as water. 
+23. Only thou shalt not eat the blood thereof; thou shalt pour it upon the ground as water.
 * 16
 1. Observe the month of Abib, and keep the passover unto the LORD thy God: for in the month of Abib the LORD thy God brought thee forth out of Egypt by night.
 2. Thou shalt therefore sacrifice the passover unto the LORD thy God, of the flock and the herd, in the place which the LORD shall choose to place his name there.
@@ -531,7 +531,7 @@
 20. That which is altogether just shalt thou follow, that thou mayest live, and inherit the land which the LORD thy God giveth thee.
 
 21. Thou shalt not plant thee a grove of any trees near unto the altar of the LORD thy God, which thou shalt make thee.
-22. Neither shalt thou set thee up /any/ image; which the LORD thy God hateth. 
+22. Neither shalt thou set thee up /any/ image; which the LORD thy God hateth.
 * 17
 1. Thou shalt not sacrifice unto the LORD thy God /any/ bullock, or sheep, wherein is blemish, /or/ any evilfavouredness: for that /is/ an abomination unto the LORD thy God.
 
@@ -555,7 +555,7 @@
 17. Neither shall he multiply wives to himself, that his heart turn not away: neither shall he greatly multiply to himself silver and gold.
 18. And it shall be, when he sitteth upon the throne of his kingdom, that he shall write him a copy of this law in a book out of /that which is/ before the priests the Levites:
 19. And it shall be with him, and he shall read therein all the days of his life: that he may learn to fear the LORD his God, to keep all the words of this law and these statutes, to do them:
-20. That his heart be not lifted up above his brethren, and that he turn not aside from the commandment, /to/ the right hand, or /to/ the left: to the end that he may prolong /his/ days in his kingdom, he, and his children, in the midst of Israel. 
+20. That his heart be not lifted up above his brethren, and that he turn not aside from the commandment, /to/ the right hand, or /to/ the left: to the end that he may prolong /his/ days in his kingdom, he, and his children, in the midst of Israel.
 * 18
 1. The priests the Levites, /and/ all the tribe of Levi, shall have no part nor inheritance with Israel: they shall eat the offerings of the LORD made by fire, and his inheritance.
 2. Therefore shall they have no inheritance among their brethren: the LORD /is/ their inheritance, as he hath said unto them.
@@ -582,7 +582,7 @@
 19. And it shall come to pass, /that/ whosoever will not hearken unto my words which he shall speak in my name, I will require /it/ of him.
 20. But the prophet, which shall presume to speak a word in my name, which I have not commanded him to speak, or that shall speak in the name of other gods, even that prophet shall die.
 21. And if thou say in thine heart, How shall we know the word which the LORD hath not spoken?
-22. When a prophet speaketh in the name of the LORD, if the thing follow not, nor come to pass, that /is/ the thing which the LORD hath not spoken, /but/ the prophet hath spoken it presumptuously: thou shalt not be afraid of him. 
+22. When a prophet speaketh in the name of the LORD, if the thing follow not, nor come to pass, that /is/ the thing which the LORD hath not spoken, /but/ the prophet hath spoken it presumptuously: thou shalt not be afraid of him.
 * 19
 1. When the LORD thy God hath cut off the nations, whose land the LORD thy God giveth thee, and thou succeedest them, and dwellest in their cities, and in their houses;
 2. Thou shalt separate three cities for thee in the midst of thy land, which the LORD thy God giveth thee to possess it.
@@ -609,7 +609,7 @@
 18. And the judges shall make diligent inquisition: and, behold, /if/ the witness /be/ a false witness, /and/ hath testified falsely against his brother;
 19. Then shall ye do unto him, as he had thought to have done unto his brother: so shalt thou put the evil away from among you.
 20. And those which remain shall hear, and fear, and shall henceforth commit no more any such evil among you.
-21. And thine eye shall not pity; /but/ life /shall go/ for life, eye for eye, tooth for tooth, hand for hand, foot for foot. 
+21. And thine eye shall not pity; /but/ life /shall go/ for life, eye for eye, tooth for tooth, hand for hand, foot for foot.
 * 20
 1. When thou goest out to battle against thine enemies, and seest horses, and chariots, /and/ a people more than thou, be not afraid of them: for the LORD thy God /is/ with thee, which brought thee up out of the land of Egypt.
 2. And it shall be, when ye are come nigh unto the battle, that the priest shall approach and speak unto the people,
@@ -633,7 +633,7 @@
 18. That they teach you not to do after all their abominations, which they have done unto their gods; so should ye sin against the LORD your God.
 
 19. When thou shalt besiege a city a long time, in making war against it to take it, thou shalt not destroy the trees thereof by forcing an axe against them: for thou mayest eat of them, and thou shalt not cut them down (for the tree of the field /is/ man's /life/) to employ /them/ in the siege:
-20. Only the trees which thou knowest that they /be/ not trees for meat, thou shalt destroy and cut them down; and thou shalt build bulwarks against the city that maketh war with thee, until it be subdued. 
+20. Only the trees which thou knowest that they /be/ not trees for meat, thou shalt destroy and cut them down; and thou shalt build bulwarks against the city that maketh war with thee, until it be subdued.
 * 21
 1. If /one/ be found slain in the land which the LORD thy God giveth thee to possess it, lying in the field, /and/ it be not known who hath slain him:
 2. Then thy elders and thy judges shall come forth, and they shall measure unto the cities which /are/ round about him that is slain:
@@ -661,7 +661,7 @@
 21. And all the men of his city shall stone him with stones, that he die: so shalt thou put evil away from among you; and all Israel shall hear, and fear.
 
 22. And if a man have committed a sin worthy of death, and he be to be put to death, and thou hang him on a tree:
-23. His body shall not remain all night upon the tree, but thou shalt in any wise bury him that day; (for he that is hanged /is/ accursed of God;) that thy land be not defiled, which the LORD thy God giveth thee /for/ an inheritance. 
+23. His body shall not remain all night upon the tree, but thou shalt in any wise bury him that day; (for he that is hanged /is/ accursed of God;) that thy land be not defiled, which the LORD thy God giveth thee /for/ an inheritance.
 * 22
 1. Thou shalt not see thy brother's ox or his sheep go astray, and hide thyself from them: thou shalt in any case bring them again unto thy brother.
 2. And if thy brother /be/ not nigh unto thee, or if thou know him not, then thou shalt bring it unto thine own house, and it shall be with thee until thy brother seek after it, and thou shalt restore it to him again.
@@ -706,7 +706,7 @@
 28. If a man find a damsel /that is/ a virgin, which is not betrothed, and lay hold on her, and lie with her, and they be found;
 29. Then the man that lay with her shall give unto the damsel's father fifty /shekels/ of silver, and she shall be his wife; because he hath humbled her, he may not put her away all his days.
 
-30. A man shall not take his father's wife, nor discover his father's skirt. 
+30. A man shall not take his father's wife, nor discover his father's skirt.
 * 23
 1. He that is wounded in the stones, or hath his privy member cut off, shall not enter into the congregation of the LORD.
 2. A bastard shall not enter into the congregation of the LORD; even to his tenth generation shall he not enter into the congregation of the LORD.
@@ -741,7 +741,7 @@
 23. That which is gone out of thy lips thou shalt keep and perform; /even/ a freewill offering, according as thou hast vowed unto the LORD thy God, which thou hast promised with thy mouth.
 
 24. When thou comest into thy neighbour's vineyard, then thou mayest eat grapes thy fill at thine own pleasure; but thou shalt not put /any/ in thy vessel.
-25. When thou comest into the standing corn of thy neighbour, then thou mayest pluck the ears with thine hand; but thou shalt not move a sickle unto thy neighbour's standing corn. 
+25. When thou comest into the standing corn of thy neighbour, then thou mayest pluck the ears with thine hand; but thou shalt not move a sickle unto thy neighbour's standing corn.
 * 24
 1. When a man hath taken a wife, and married her, and it come to pass that she find no favour in his eyes, because he hath found some uncleanness in her: then let him write her a bill of divorcement, and give /it/ in her hand, and send her out of his house.
 2. And when she is departed out of his house, she may go and be another man's /wife/.
@@ -772,7 +772,7 @@
 19. When thou cuttest down thine harvest in thy field, and hast forgot a sheaf in the field, thou shalt not go again to fetch it: it shall be for the stranger, for the fatherless, and for the widow: that the LORD thy God may bless thee in all the work of thine hands.
 20. When thou beatest thine olive tree, thou shalt not go over the boughs again: it shall be for the stranger, for the fatherless, and for the widow.
 21. When thou gatherest the grapes of thy vineyard, thou shalt not glean /it/ afterward: it shall be for the stranger, for the fatherless, and for the widow.
-22. And thou shalt remember that thou wast a bondman in the land of Egypt: therefore I command thee to do this thing. 
+22. And thou shalt remember that thou wast a bondman in the land of Egypt: therefore I command thee to do this thing.
 * 25
 1. If there be a controversy between men, and they come unto judgment, that /the judges/ may judge them; then they shall justify the righteous, and condemn the wicked.
 2. And it shall be, if the wicked man /be/ worthy to be beaten, that the judge shall cause him to lie down, and to be beaten before his face, according to his fault, by a certain number.
@@ -797,7 +797,7 @@
 
 17. Remember what Amalek did unto thee by the way, when ye were come forth out of Egypt;
 18. How he met thee by the way, and smote the hindmost of thee, /even/ all /that were/ feeble behind thee, when thou /wast/ faint and weary; and he feared not God.
-19. Therefore it shall be, when the LORD thy God hath given thee rest from all thine enemies round about, in the land which the LORD thy God giveth thee /for/ an inheritance to possess it, /that/ thou shalt blot out the remembrance of Amalek from under heaven; thou shalt not forget /it/. 
+19. Therefore it shall be, when the LORD thy God hath given thee rest from all thine enemies round about, in the land which the LORD thy God giveth thee /for/ an inheritance to possess it, /that/ thou shalt blot out the remembrance of Amalek from under heaven; thou shalt not forget /it/.
 * 26
 1. And it shall be, when thou /art/ come in unto the land which the LORD thy God giveth thee /for/ an inheritance, and possessest it, and dwellest therein;
 2. That thou shalt take of the first of all the fruit of the earth, which thou shalt bring of thy land that the LORD thy God giveth thee, and shalt put /it/ in a basket, and shalt go unto the place which the LORD thy God shall choose to place his name there.
@@ -819,7 +819,7 @@
 16. This day the LORD thy God hath commanded thee to do these statutes and judgments: thou shalt therefore keep and do them with all thine heart, and with all thy soul.
 17. Thou hast avouched the LORD this day to be thy God, and to walk in his ways, and to keep his statutes, and his commandments, and his judgments, and to hearken unto his voice:
 18. And the LORD hath avouched thee this day to be his peculiar people, as he hath promised thee, and that /thou/ shouldest keep all his commandments;
-19. And to make thee high above all nations which he hath made, in praise, and in name, and in honour; and that thou mayest be an holy people unto the LORD thy God, as he hath spoken. 
+19. And to make thee high above all nations which he hath made, in praise, and in name, and in honour; and that thou mayest be an holy people unto the LORD thy God, as he hath spoken.
 * 27
 1. And Moses with the elders of Israel commanded the people, saying, Keep all the commandments which I command you this day.
 2. And it shall be on the day when ye shall pass over Jordan unto the land which the LORD thy God giveth thee, that thou shalt set thee up great stones, and plaister them with plaister:
@@ -849,7 +849,7 @@
 23. Cursed /be/ he that lieth with his mother in law. And all the people shall say, Amen.
 24. Cursed /be/ he that smiteth his neighbour secretly. And all the people shall say, Amen.
 25. Cursed /be/ he that taketh reward to slay an innocent person. And all the people shall say, Amen.
-26. Cursed /be/ he that confirmeth not /all/ the words of this law to do them. And all the people shall say, Amen. 
+26. Cursed /be/ he that confirmeth not /all/ the words of this law to do them. And all the people shall say, Amen.
 * 28
 1. And it shall come to pass, if thou shalt hearken diligently unto the voice of the LORD thy God, to observe /and/ to do all his commandments which I command thee this day, that the LORD thy God will set thee on high above all nations of the earth:
 2. And all these blessings shall come on thee, and overtake thee, if thou shalt hearken unto the voice of the LORD thy God.
@@ -919,7 +919,7 @@
 65. And among these nations shalt thou find no ease, neither shall the sole of thy foot have rest: but the LORD shall give thee there a trembling heart, and failing of eyes, and sorrow of mind:
 66. And thy life shall hang in doubt before thee; and thou shalt fear day and night, and shalt have none assurance of thy life:
 67. In the morning thou shalt say, Would God it were even! and at even thou shalt say, Would God it were morning! for the fear of thine heart wherewith thou shalt fear, and for the sight of thine eyes which thou shalt see.
-68. And the LORD shall bring thee into Egypt again with ships, by the way whereof I spake unto thee, Thou shalt see it no more again: and there ye shall be sold unto your enemies for bondmen and bondwomen, and no man shall buy /you/. 
+68. And the LORD shall bring thee into Egypt again with ships, by the way whereof I spake unto thee, Thou shalt see it no more again: and there ye shall be sold unto your enemies for bondmen and bondwomen, and no man shall buy /you/.
 * 29
 1. These /are/ the words of the covenant, which the LORD commanded Moses to make with the children of Israel in the land of Moab, beside the covenant which he made with them in Horeb.
 
@@ -951,7 +951,7 @@
 26. For they went and served other gods, and worshipped them, gods whom they knew not, and /whom/ he had not given unto them:
 27. And the anger of the LORD was kindled against this land, to bring upon it all the curses that are written in this book:
 28. And the LORD rooted them out of their land in anger, and in wrath, and in great indignation, and cast them into another land, as /it is/ this day.
-29. The secret /things belong/ unto the LORD our God: but those /things which are/ revealed /belong/ unto us and to our children for ever, that /we/ may do all the words of this law. 
+29. The secret /things belong/ unto the LORD our God: but those /things which are/ revealed /belong/ unto us and to our children for ever, that /we/ may do all the words of this law.
 * 30
 1. And it shall come to pass, when all these things are come upon thee, the blessing and the curse, which I have set before thee, and thou shalt call /them/ to mind among all the nations, whither the LORD thy God hath driven thee,
 2. And shalt return unto the LORD thy God, and shalt obey his voice according to all that I command thee this day, thou and thy children, with all thine heart, and with all thy soul;
@@ -974,7 +974,7 @@
 17. But if thine heart turn away, so that thou wilt not hear, but shalt be drawn away, and worship other gods, and serve them;
 18. I denounce unto you this day, that ye shall surely perish, /and that/ ye shall not prolong /your/ days upon the land, whither thou passest over Jordan to go to possess it.
 19. I call heaven and earth to record this day against you, /that/ I have set before you life and death, blessing and cursing: therefore choose life, that both thou and thy seed may live:
-20. That thou mayest love the LORD thy God, /and/ that thou mayest obey his voice, and that thou mayest cleave unto him: for he /is/ thy life, and the length of thy days: that thou mayest dwell in the land which the LORD sware unto thy fathers, to Abraham, to Isaac, and to Jacob, to give them. 
+20. That thou mayest love the LORD thy God, /and/ that thou mayest obey his voice, and that thou mayest cleave unto him: for he /is/ thy life, and the length of thy days: that thou mayest dwell in the land which the LORD sware unto thy fathers, to Abraham, to Isaac, and to Jacob, to give them.
 * 31
 1. And Moses went and spake these words unto all Israel.
 2. And he said unto them, I /am/ an hundred and twenty years old this day; I can no more go out and come in: also the LORD hath said unto me, Thou shalt not go over this Jordan.
@@ -1012,7 +1012,7 @@
 
 28. Gather unto me all the elders of your tribes, and your officers, that I may speak these words in their ears, and call heaven and earth to record against them.
 29. For I know that after my death ye will utterly corrupt /yourselves/, and turn aside from the way which I have commanded you; and evil will befall you in the latter days; because ye will do evil in the sight of the LORD, to provoke him to anger through the work of your hands.
-30. And Moses spake in the ears of all the congregation of Israel the words of this song, until they were ended. 
+30. And Moses spake in the ears of all the congregation of Israel the words of this song, until they were ended.
 * 32
 1. Give ear, O ye heavens, and I will speak; and hear, O earth, the words of my mouth.
 2. My doctrine shall drop as the rain, my speech shall distil as the dew, as the small rain upon the tender herb, and as the showers upon the grass:
@@ -1068,7 +1068,7 @@
 49. Get thee up into this mountain Abarim, /unto/ mount Nebo, which /is/ in the land of Moab, that /is/ over against Jericho; and behold the land of Canaan, which I give unto the children of Israel for a possession:
 50. And die in the mount whither thou goest up, and be gathered unto thy people; as Aaron thy brother died in mount Hor, and was gathered unto his people:
 51. Because ye trespassed against me among the children of Israel at the waters of Meribah–Kadesh, in the wilderness of Zin; because ye sanctified me not in the midst of the children of Israel.
-52. Yet thou shalt see the land before /thee/; but thou shalt not go thither unto the land which I give the children of Israel. 
+52. Yet thou shalt see the land before /thee/; but thou shalt not go thither unto the land which I give the children of Israel.
 * 33
 1. And this /is/ the blessing, wherewith Moses the man of God blessed the children of Israel before his death.
 2. And he said, The LORD came from Sinai, and rose up from Seir unto them; he shined forth from mount Paran, and he came with ten thousands of saints: from his right hand /went/ a fiery law for them.
@@ -1109,7 +1109,7 @@
 26. /There is/ none like unto the God of Jeshurun, /who/ rideth upon the heaven in thy help, and in his excellency on the sky.
 27. The eternal God /is thy/ refuge, and underneath /are/ the everlasting arms: and he shall thrust out the enemy from before thee; and shall say, Destroy /them/.
 28. Israel then shall dwell in safety alone: the fountain of Jacob /shall be/ upon a land of corn and wine; also his heavens shall drop down dew.
-29. Happy /art/ thou, O Israel: who /is/ like unto thee, O people saved by the LORD, the shield of thy help, and who /is/ the sword of thy excellency! and thine enemies shall be found liars unto thee; and thou shalt tread upon their high places. 
+29. Happy /art/ thou, O Israel: who /is/ like unto thee, O people saved by the LORD, the shield of thy help, and who /is/ the sword of thy excellency! and thine enemies shall be found liars unto thee; and thou shalt tread upon their high places.
 * 34
 1. And Moses went up from the plains of Moab unto the mountain of Nebo, to the top of Pisgah, that /is/ over against Jericho. And the LORD shewed him all the land of Gilead, unto Dan,
 2. And all Naphtali, and the land of Ephraim, and Manasseh, and all the land of Judah, unto the utmost sea,
@@ -1127,4 +1127,4 @@
 
 10. And there arose not a prophet since in Israel like unto Moses, whom the LORD knew face to face,
 11. In all the signs and the wonders, which the LORD sent him to do in the land of Egypt to Pharaoh, and to all his servants, and to all his land,
-12. And in all that mighty hand, and in all the great terror which Moses shewed in the sight of all Israel.  
+12. And in all that mighty hand, and in all the great terror which Moses shewed in the sight of all Israel.

--- a/06_JOS.org
+++ b/06_JOS.org
@@ -20,7 +20,7 @@
 
 16. And they answered Joshua, saying, All that thou commandest us we will do, and whithersoever thou sendest us, we will go.
 17. According as we hearkened unto Moses in all things, so will we hearken unto thee: only the LORD thy God be with thee, as he was with Moses.
-18. Whosoever /he be/ that doth rebel against thy commandment, and will not hearken unto thy words in all that thou commandest him, he shall be put to death: only be strong and of a good courage. 
+18. Whosoever /he be/ that doth rebel against thy commandment, and will not hearken unto thy words in all that thou commandest him, he shall be put to death: only be strong and of a good courage.
 * 2
 1. And Joshua the son of Nun sent out of Shittim two men to spy secretly, saying, Go view the land, even Jericho. And they went, and came into an harlot's house, named Rahab, and lodged there.
 2. And it was told the king of Jericho, saying, Behold, there came men in hither to night of the children of Israel to search out the country.
@@ -47,7 +47,7 @@
 22. And they went, and came unto the mountain, and abode there three days, until the pursuers were returned: and the pursuers sought /them/ throughout all the way, but found /them/ not.
 
 23. So the two men returned, and descended from the mountain, and passed over, and came to Joshua the son of Nun, and told him all /things/ that befell them:
-24. And they said unto Joshua, Truly the LORD hath delivered into our hands all the land; for even all the inhabitants of the country do faint because of us. 
+24. And they said unto Joshua, Truly the LORD hath delivered into our hands all the land; for even all the inhabitants of the country do faint because of us.
 * 3
 1. And Joshua rose early in the morning; and they removed from Shittim, and came to Jordan, he and all the children of Israel, and lodged there before they passed over.
 2. And it came to pass after three days, that the officers went through the host;
@@ -68,7 +68,7 @@
 14. And it came to pass, when the people removed from their tents, to pass over Jordan, and the priests bearing the ark of the covenant before the people;
 15. And as they that bare the ark were come unto Jordan, and the feet of the priests that bare the ark were dipped in the brim of the water, (for Jordan overfloweth all his banks all the time of harvest,)
 16. That the waters which came down from above stood /and/ rose up upon an heap very far from the city Adam, that /is/ beside Zaretan: and those that came down toward the sea of the plain, /even/ the salt sea, failed, /and/ were cut off: and the people passed over right against Jericho.
-17. And the priests that bare the ark of the covenant of the LORD stood firm on dry ground in the midst of Jordan, and all the Israelites passed over on dry ground, until all the people were passed clean over Jordan. 
+17. And the priests that bare the ark of the covenant of the LORD stood firm on dry ground in the midst of Jordan, and all the Israelites passed over on dry ground, until all the people were passed clean over Jordan.
 * 4
 1. And it came to pass, when all the people were clean passed over Jordan, that the LORD spake unto Joshua, saying,
 2. Take you twelve men out of the people, out of every tribe a man,
@@ -96,7 +96,7 @@
 21. And he spake unto the children of Israel, saying, When your children shall ask their fathers in time to come, saying, What /mean/ these stones?
 22. Then ye shall let your children know, saying, Israel came over this Jordan on dry land.
 23. For the LORD your God dried up the waters of Jordan from before you, until ye were passed over, as the LORD your God did to the Red sea, which he dried up from before us, until we were gone over:
-24. That all the people of the earth might know the hand of the LORD, that it /is/ mighty: that ye might fear the LORD your God for ever. 
+24. That all the people of the earth might know the hand of the LORD, that it /is/ mighty: that ye might fear the LORD your God for ever.
 * 5
 1. And it came to pass, when all the kings of the Amorites, which /were/ on the side of Jordan westward, and all the kings of the Canaanites, which /were/ by the sea, heard that the LORD had dried up the waters of Jordan from before the children of Israel, until we were passed over, that their heart melted, neither was there spirit in them any more, because of the children of Israel.
 
@@ -116,7 +116,7 @@
 
 13. And it came to pass, when Joshua was by Jericho, that he lifted up his eyes and looked, and, behold, there stood a man over against him with his sword drawn in his hand: and Joshua went unto him, and said unto him, /Art/ thou for us, or for our adversaries?
 14. And he said, Nay; but /as/ captain of the host of the LORD am I now come. And Joshua fell on his face to the earth, and did worship, and said unto him, What saith my lord unto his servant?
-15. And the captain of the LORD's host said unto Joshua, Loose thy shoe from off thy foot; for the place whereon thou standest /is/ holy. And Joshua did so. 
+15. And the captain of the LORD's host said unto Joshua, Loose thy shoe from off thy foot; for the place whereon thou standest /is/ holy. And Joshua did so.
 * 6
 1. Now Jericho was straitly shut up because of the children of Israel: none went out, and none came in.
 2. And the LORD said unto Joshua, See, I have given into thine hand Jericho, and the king thereof, /and/ the mighty men of valour.
@@ -150,7 +150,7 @@
 25. And Joshua saved Rahab the harlot alive, and her father's household, and all that she had; and she dwelleth in Israel /even/ unto this day; because she hid the messengers, which Joshua sent to spy out Jericho.
 
 26. And Joshua adjured /them/ at that time, saying, Cursed /be/ the man before the LORD, that riseth up and buildeth this city Jericho: he shall lay the foundation thereof in his firstborn, and in his youngest /son/ shall he set up the gates of it.
-27. So the LORD was with Joshua; and his fame was /noised/ throughout all the country. 
+27. So the LORD was with Joshua; and his fame was /noised/ throughout all the country.
 * 7
 1. But the children of Israel committed a trespass in the accursed thing: for Achan, the son of Carmi, the son of Zabdi, the son of Zerah, of the tribe of Judah, took of the accursed thing: and the anger of the LORD was kindled against the children of Israel.
 2. And Joshua sent men from Jericho to Ai, which /is/ beside Beth–aven, on the east side of Beth–el, and spake unto them, saying, Go up and view the country. And the men went up and viewed Ai.
@@ -181,7 +181,7 @@
 23. And they took them out of the midst of the tent, and brought them unto Joshua, and unto all the children of Israel, and laid them out before the LORD.
 24. And Joshua, and all Israel with him, took Achan the son of Zerah, and the silver, and the garment, and the wedge of gold, and his sons, and his daughters, and his oxen, and his asses, and his sheep, and his tent, and all that he had: and they brought them unto the valley of Achor.
 25. And Joshua said, Why hast thou troubled us? the LORD shall trouble thee this day. And all Israel stoned him with stones, and burned them with fire, after they had stoned them with stones.
-26. And they raised over him a great heap of stones unto this day. So the LORD turned from the fierceness of his anger. Wherefore the name of that place was called, The valley of Achor, unto this day. 
+26. And they raised over him a great heap of stones unto this day. So the LORD turned from the fierceness of his anger. Wherefore the name of that place was called, The valley of Achor, unto this day.
 * 8
 1. And the LORD said unto Joshua, Fear not, neither be thou dismayed: take all the people of war with thee, and arise, go up to Ai: see, I have given into thy hand the king of Ai, and his people, and his city, and his land:
 2. And thou shalt do to Ai and her king as thou didst unto Jericho and her king: only the spoil thereof, and the cattle thereof, shall ye take for a prey unto yourselves: lay thee an ambush for the city behind it.
@@ -222,7 +222,7 @@
 32. And he wrote there upon the stones a copy of the law of Moses, which he wrote in the presence of the children of Israel.
 33. And all Israel, and their elders, and officers, and their judges, stood on this side the ark and on that side before the priests the Levites, which bare the ark of the covenant of the LORD, as well the stranger, as he that was born among them; half of them over against mount Gerizim, and half of them over against mount Ebal; as Moses the servant of the LORD had commanded before, that they should bless the people of Israel.
 34. And afterward he read all the words of the law, the blessings and cursings, according to all that is written in the book of the law.
-35. There was not a word of all that Moses commanded, which Joshua read not before all the congregation of Israel, with the women, and the little ones, and the strangers that were conversant among them. 
+35. There was not a word of all that Moses commanded, which Joshua read not before all the congregation of Israel, with the women, and the little ones, and the strangers that were conversant among them.
 * 9
 1. And it came to pass, when all the kings which /were/ on this side Jordan, in the hills, and in the valleys, and in all the coasts of the great sea over against Lebanon, the Hittite, and the Amorite, the Canaanite, the Perizzite, the Hivite, and the Jebusite, heard /thereof/;
 2. That they gathered themselves together, to fight with Joshua and with Israel, with one accord.
@@ -253,7 +253,7 @@
 24. And they answered Joshua, and said, Because it was certainly told thy servants, how that the LORD thy God commanded his servant Moses to give you all the land, and to destroy all the inhabitants of the land from before you, therefore we were sore afraid of our lives because of you, and have done this thing.
 25. And now, behold, we /are/ in thine hand: as it seemeth good and right unto thee to do unto us, do.
 26. And so did he unto them, and delivered them out of the hand of the children of Israel, that they slew them not.
-27. And Joshua made them that day hewers of wood and drawers of water for the congregation, and for the altar of the LORD, even unto this day, in the place which he should choose. 
+27. And Joshua made them that day hewers of wood and drawers of water for the congregation, and for the altar of the LORD, even unto this day, in the place which he should choose.
 * 10
 1. Now it came to pass, when Adoni–zedek king of Jerusalem had heard how Joshua had taken Ai, and had utterly destroyed it; as he had done to Jericho and her king, so he had done to Ai and her king; and how the inhabitants of Gibeon had made peace with Israel, and were among them;
 2. That they feared greatly, because Gibeon /was/ a great city, as one of the royal cities, and because it /was/ greater than Ai, and all the men thereof /were/ mighty.
@@ -307,7 +307,7 @@
 40. So Joshua smote all the country of the hills, and of the south, and of the vale, and of the springs, and all their kings: he left none remaining, but utterly destroyed all that breathed, as the LORD God of Israel commanded.
 41. And Joshua smote them from Kadesh–barnea even unto Gaza, and all the country of Goshen, even unto Gibeon.
 42. And all these kings and their land did Joshua take at one time, because the LORD God of Israel fought for Israel.
-43. And Joshua returned, and all Israel with him, unto the camp to Gilgal. 
+43. And Joshua returned, and all Israel with him, unto the camp to Gilgal.
 * 11
 1. And it came to pass, when Jabin king of Hazor had heard /those things/, that he sent to Jobab king of Madon, and to the king of Shimron, and to the king of Achshaph,
 2. And to the kings that /were/ on the north of the mountains, and of the plains south of Chinneroth, and in the valley, and in the borders of Dor on the west,
@@ -335,7 +335,7 @@
 
 21. And at that time came Joshua, and cut off the Anakims from the mountains, from Hebron, from Debir, from Anab, and from all the mountains of Judah, and from all the mountains of Israel: Joshua destroyed them utterly with their cities.
 22. There was none of the Anakims left in the land of the children of Israel: only in Gaza, in Gath, and in Ashdod, there remained.
-23. So Joshua took the whole land, according to all that the LORD said unto Moses; and Joshua gave it for an inheritance unto Israel according to their divisions by their tribes. And the land rested from war. 
+23. So Joshua took the whole land, according to all that the LORD said unto Moses; and Joshua gave it for an inheritance unto Israel according to their divisions by their tribes. And the land rested from war.
 * 12
 1. Now these /are/ the kings of the land, which the children of Israel smote, and possessed their land on the other side Jordan toward the rising of the sun, from the river Arnon unto mount Hermon, and all the plain on the east:
 2. Sihon king of the Amorites, who dwelt in Heshbon, /and/ ruled from Aroer, which /is/ upon the bank of the river Arnon, and from the middle of the river, and from half Gilead, even unto the river Jabbok, /which is/ the border of the children of Ammon;
@@ -363,7 +363,7 @@
 21. The king of Taanach, one; the king of Megiddo, one;
 22. The king of Kedesh, one; the king of Jokneam of Carmel, one;
 23. The king of Dor in the coast of Dor, one; the king of the nations of Gilgal, one;
-24. The king of Tirzah, one: all the kings thirty and one. 
+24. The king of Tirzah, one: all the kings thirty and one.
 * 13
 1. Now Joshua was old /and/ stricken in years; and the LORD said unto him, Thou art old /and/ stricken in years, and there remaineth yet very much land to be possessed.
 2. This /is/ the land that yet remaineth: all the borders of the Philistines, and all Geshuri,
@@ -400,7 +400,7 @@
 30. And their coast was from Mahanaim, all Bashan, all the kingdom of Og king of Bashan, and all the towns of Jair, which /are/ in Bashan, threescore cities:
 31. And half Gilead, and Ashtaroth, and Edrei, cities of the kingdom of Og in Bashan, /were pertaining/ unto the children of Machir the son of Manasseh, /even/ to the one half of the children of Machir by their families.
 32. These /are the countries/ which Moses did distribute for inheritance in the plains of Moab, on the other side Jordan, by Jericho, eastward.
-33. But unto the tribe of Levi Moses gave not /any/ inheritance: the LORD God of Israel /was/ their inheritance, as he said unto them. 
+33. But unto the tribe of Levi Moses gave not /any/ inheritance: the LORD God of Israel /was/ their inheritance, as he said unto them.
 * 14
 1. And these /are the countries/ which the children of Israel inherited in the land of Canaan, which Eleazar the priest, and Joshua the son of Nun, and the heads of the fathers of the tribes of the children of Israel, distributed for inheritance to them.
 2. By lot /was/ their inheritance, as the LORD commanded by the hand of Moses, for the nine tribes, and /for/ the half tribe.
@@ -417,7 +417,7 @@
 12. Now therefore give me this mountain, whereof the LORD spake in that day; for thou heardest in that day how the Anakims /were/ there, and /that/ the cities /were/ great /and/ fenced: if so be the LORD /will be/ with me, then I shall be able to drive them out, as the LORD said.
 13. And Joshua blessed him, and gave unto Caleb the son of Jephunneh Hebron for an inheritance.
 14. Hebron therefore became the inheritance of Caleb the son of Jephunneh the Kenezite unto this day, because that he wholly followed the LORD God of Israel.
-15. And the name of Hebron before /was/ Kirjath–arba; /which Arba was/ a great man among the Anakims. And the land had rest from war. 
+15. And the name of Hebron before /was/ Kirjath–arba; /which Arba was/ a great man among the Anakims. And the land had rest from war.
 * 15
 1. /This/ then was the lot of the tribe of the children of Judah by their families; /even/ to the border of Edom the wilderness of Zin southward /was/ the uttermost part of the south coast.
 2. And their south border was from the shore of the salt sea, from the bay that looketh southward:
@@ -485,7 +485,7 @@
 61. In the wilderness, Beth–arabah, Middin, and Secacah,
 62. And Nibshan, and the city of Salt, and En–gedi; six cities with their villages.
 
-63. As for the Jebusites the inhabitants of Jerusalem, the children of Judah could not drive them out: but the Jebusites dwell with the children of Judah at Jerusalem unto this day. 
+63. As for the Jebusites the inhabitants of Jerusalem, the children of Judah could not drive them out: but the Jebusites dwell with the children of Judah at Jerusalem unto this day.
 * 16
 1. And the lot of the children of Joseph fell from Jordan by Jericho, unto the water of Jericho on the east, to the wilderness that goeth up from Jericho throughout mount Beth–el,
 2. And goeth out from Beth–el to Luz, and passeth along unto the borders of Archi to Ataroth,
@@ -497,7 +497,7 @@
 7. And it went down from Janohah to Ataroth, and to Naarath, and came to Jericho, and went out at Jordan.
 8. The border went out from Tappuah westward unto the river Kanah; and the goings out thereof were at the sea. This /is/ the inheritance of the tribe of the children of Ephraim by their families.
 9. And the separate cities for the children of Ephraim /were/ among the inheritance of the children of Manasseh, all the cities with their villages.
-10. And they drave not out the Canaanites that dwelt in Gezer: but the Canaanites dwell among the Ephraimites unto this day, and serve under tribute. 
+10. And they drave not out the Canaanites that dwelt in Gezer: but the Canaanites dwell among the Ephraimites unto this day, and serve under tribute.
 * 17
 1. There was also a lot for the tribe of Manasseh; for he /was/ the firstborn of Joseph; /to wit/, for Machir the firstborn of Manasseh, the father of Gilead: because he was a man of war, therefore he had Gilead and Bashan.
 2. There was also /a lot/ for the rest of the children of Manasseh by their families; for the children of Abiezer, and for the children of Helek, and for the children of Asriel, and for the children of Shechem, and for the children of Hepher, and for the children of Shemida: these /were/ the male children of Manasseh the son of Joseph by their families.
@@ -518,7 +518,7 @@
 15. And Joshua answered them, If thou /be/ a great people, /then/ get thee up to the wood /country/, and cut down for thyself there in the land of the Perizzites and of the giants, if mount Ephraim be too narrow for thee.
 16. And the children of Joseph said, The hill is not enough for us: and all the Canaanites that dwell in the land of the valley have chariots of iron, /both they/ who /are/ of Beth–shean and her towns, and /they/ who /are/ of the valley of Jezreel.
 17. And Joshua spake unto the house of Joseph, /even/ to Ephraim and to Manasseh, saying, Thou /art/ a great people, and hast great power: thou shalt not have one lot /only/:
-18. But the mountain shall be thine; for it /is/ a wood, and thou shalt cut it down: and the outgoings of it shall be thine: for thou shalt drive out the Canaanites, though they have iron chariots, /and/ though they /be/ strong. 
+18. But the mountain shall be thine; for it /is/ a wood, and thou shalt cut it down: and the outgoings of it shall be thine: for thou shalt drive out the Canaanites, though they have iron chariots, /and/ though they /be/ strong.
 * 18
 1. And the whole congregation of the children of Israel assembled together at Shiloh, and set up the tabernacle of the congregation there. And the land was subdued before them.
 2. And there remained among the children of Israel seven tribes, which had not yet received their inheritance.
@@ -550,7 +550,7 @@
 25. Gibeon, and Ramah, and Beeroth,
 26. And Mizpeh, and Chephirah, and Mozah,
 27. And Rekem, and Irpeel, and Taralah,
-28. And Zelah, Eleph, and Jebusi, which /is/ Jerusalem, Gibeath, /and/ Kirjath; fourteen cities with their villages. This /is/ the inheritance of the children of Benjamin according to their families. 
+28. And Zelah, Eleph, and Jebusi, which /is/ Jerusalem, Gibeath, /and/ Kirjath; fourteen cities with their villages. This /is/ the inheritance of the children of Benjamin according to their families.
 * 19
 1. And the second lot came forth to Simeon, /even/ for the tribe of the children of Simeon according to their families: and their inheritance was within the inheritance of the children of Judah.
 2. And they had in their inheritance Beer–sheba, or Sheba, and Moladah,
@@ -608,7 +608,7 @@
 
 49. When they had made an end of dividing the land for inheritance by their coasts, the children of Israel gave an inheritance to Joshua the son of Nun among them:
 50. According to the word of the LORD they gave him the city which he asked, /even/ Timnath–serah in mount Ephraim: and he built the city, and dwelt therein.
-51. These /are/ the inheritances, which Eleazar the priest, and Joshua the son of Nun, and the heads of the fathers of the tribes of the children of Israel, divided for an inheritance by lot in Shiloh before the LORD, at the door of the tabernacle of the congregation. So they made an end of dividing the country. 
+51. These /are/ the inheritances, which Eleazar the priest, and Joshua the son of Nun, and the heads of the fathers of the tribes of the children of Israel, divided for an inheritance by lot in Shiloh before the LORD, at the door of the tabernacle of the congregation. So they made an end of dividing the country.
 * 20
 1. The LORD also spake unto Joshua, saying,
 2. Speak to the children of Israel, saying, Appoint out for you cities of refuge, whereof I spake unto you by the hand of Moses:
@@ -619,7 +619,7 @@
 
 7. And they appointed Kedesh in Galilee in mount Naphtali, and Shechem in mount Ephraim, and Kirjath–arba, which /is/ Hebron, in the mountain of Judah.
 8. And on the other side Jordan by Jericho eastward, they assigned Bezer in the wilderness upon the plain out of the tribe of Reuben, and Ramoth in Gilead out of the tribe of Gad, and Golan in Bashan out of the tribe of Manasseh.
-9. These were the cities appointed for all the children of Israel, and for the stranger that sojourneth among them, that whosoever killeth /any/ person at unawares might flee thither, and not die by the hand of the avenger of blood, until he stood before the congregation. 
+9. These were the cities appointed for all the children of Israel, and for the stranger that sojourneth among them, that whosoever killeth /any/ person at unawares might flee thither, and not die by the hand of the avenger of blood, until he stood before the congregation.
 * 21
 1. Then came near the heads of the fathers of the Levites unto Eleazar the priest, and unto Joshua the son of Nun, and unto the heads of the fathers of the tribes of the children of Israel;
 2. And they spake unto them at Shiloh in the land of Canaan, saying, The LORD commanded by the hand of Moses to give us cities to dwell in, with the suburbs thereof for our cattle.
@@ -671,7 +671,7 @@
 
 43. And the LORD gave unto Israel all the land which he sware to give unto their fathers; and they possessed it, and dwelt therein.
 44. And the LORD gave them rest round about, according to all that he sware unto their fathers: and there stood not a man of all their enemies before them; the LORD delivered all their enemies into their hand.
-45. There failed not ought of any good thing which the LORD had spoken unto the house of Israel; all came to pass. 
+45. There failed not ought of any good thing which the LORD had spoken unto the house of Israel; all came to pass.
 * 22
 1. Then Joshua called the Reubenites, and the Gadites, and the half tribe of Manasseh,
 2. And said unto them, Ye have kept all that Moses the servant of the LORD commanded you, and have obeyed my voice in all that I commanded you:
@@ -714,7 +714,7 @@
 
 32. And Phinehas the son of Eleazar the priest, and the princes, returned from the children of Reuben, and from the children of Gad, out of the land of Gilead, unto the land of Canaan, to the children of Israel, and brought them word again.
 33. And the thing pleased the children of Israel; and the children of Israel blessed God, and did not intend to go up against them in battle, to destroy the land wherein the children of Reuben and Gad dwelt.
-34. And the children of Reuben and the children of Gad called the altar /Ed/: for it /shall be/ a witness between us that the LORD /is/ God. 
+34. And the children of Reuben and the children of Gad called the altar /Ed/: for it /shall be/ a witness between us that the LORD /is/ God.
 * 23
 1. And it came to pass a long time after that the LORD had given rest unto Israel from all their enemies round about, that Joshua waxed old /and/ stricken in age.
 2. And Joshua called for all Israel, /and/ for their elders, and for their heads, and for their judges, and for their officers, and said unto them, I am old /and/ stricken in age:
@@ -731,7 +731,7 @@
 13. Know for a certainty that the LORD your God will no more drive out /any of/ these nations from before you; but they shall be snares and traps unto you, and scourges in your sides, and thorns in your eyes, until ye perish from off this good land which the LORD your God hath given you.
 14. And, behold, this day I /am/ going the way of all the earth: and ye know in all your hearts and in all your souls, that not one thing hath failed of all the good things which the LORD your God spake concerning you; all are come to pass unto you, /and/ not one thing hath failed thereof.
 15. Therefore it shall come to pass, /that/ as all good things are come upon you, which the LORD your God promised you; so shall the LORD bring upon you all evil things, until he have destroyed you from off this good land which the LORD your God hath given you.
-16. When ye have transgressed the covenant of the LORD your God, which he commanded you, and have gone and served other gods, and bowed yourselves to them; then shall the anger of the LORD be kindled against you, and ye shall perish quickly from off the good land which he hath given unto you. 
+16. When ye have transgressed the covenant of the LORD your God, which he commanded you, and have gone and served other gods, and bowed yourselves to them; then shall the anger of the LORD be kindled against you, and ye shall perish quickly from off the good land which he hath given unto you.
 * 24
 1. And Joshua gathered all the tribes of Israel to Shechem, and called for the elders of Israel, and for their heads, and for their judges, and for their officers; and they presented themselves before God.
 2. And Joshua said unto all the people, Thus saith the LORD God of Israel, Your fathers dwelt on the other side of the flood in old time, /even/ Terah, the father of Abraham, and the father of Nachor: and they served other gods.
@@ -769,4 +769,4 @@
 31. And Israel served the LORD all the days of Joshua, and all the days of the elders that overlived Joshua, and which had known all the works of the LORD, that he had done for Israel.
 
 32. And the bones of Joseph, which the children of Israel brought up out of Egypt, buried they in Shechem, in a parcel of ground which Jacob bought of the sons of Hamor the father of Shechem for an hundred pieces of silver: and it became the inheritance of the children of Joseph.
-33. And Eleazar the son of Aaron died; and they buried him in a hill /that pertained to/ Phinehas his son, which was given him in mount Ephraim.  
+33. And Eleazar the son of Aaron died; and they buried him in a hill /that pertained to/ Phinehas his son, which was given him in mount Ephraim.

--- a/07_JDG.org
+++ b/07_JDG.org
@@ -43,7 +43,7 @@
 33. Neither did Naphtali drive out the inhabitants of Beth–shemesh, nor the inhabitants of Beth–anath; but he dwelt among the Canaanites, the inhabitants of the land: nevertheless the inhabitants of Beth–shemesh and of Beth–anath became tributaries unto them.
 34. And the Amorites forced the children of Dan into the mountain: for they would not suffer them to come down to the valley:
 35. But the Amorites would dwell in mount Heres in Aijalon, and in Shaalbim: yet the hand of the house of Joseph prevailed, so that they became tributaries.
-36. And the coast of the Amorites /was/ from the going up to Akrabbim, from the rock, and upward. 
+36. And the coast of the Amorites /was/ from the going up to Akrabbim, from the rock, and upward.
 * 2
 1. And an angel of the LORD came up from Gilgal to Bochim, and said, I made you to go up out of Egypt, and have brought you unto the land which I sware unto your fathers; and I said, I will never break my covenant with you.
 2. And ye shall make no league with the inhabitants of this land; ye shall throw down their altars: but ye have not obeyed my voice: why have ye done this?
@@ -72,7 +72,7 @@
 20. And the anger of the LORD was hot against Israel; and he said, Because that this people hath transgressed my covenant which I commanded their fathers, and have not hearkened unto my voice;
 21. I also will not henceforth drive out any from before them of the nations which Joshua left when he died:
 22. That through them I may prove Israel, whether they will keep the way of the LORD to walk therein, as their fathers did keep /it/, or not.
-23. Therefore the LORD left those nations, without driving them out hastily; neither delivered he them into the hand of Joshua. 
+23. Therefore the LORD left those nations, without driving them out hastily; neither delivered he them into the hand of Joshua.
 * 3
 1. Now these /are/ the nations which the LORD left, to prove Israel by them, /even/ as many /of Israel/ as had not known all the wars of Canaan;
 2. Only that the generations of the children of Israel might know, to teach them war, at the least such as before knew nothing thereof;
@@ -108,7 +108,7 @@
 29. And they slew of Moab at that time about ten thousand men, all lusty, and all men of valour; and there escaped not a man.
 30. So Moab was subdued that day under the hand of Israel. And the land had rest fourscore years.
 
-31. And after him was Shamgar the son of Anath, which slew of the Philistines six hundred men with an ox goad: and he also delivered Israel. 
+31. And after him was Shamgar the son of Anath, which slew of the Philistines six hundred men with an ox goad: and he also delivered Israel.
 * 4
 1. And the children of Israel again did evil in the sight of the LORD, when Ehud was dead.
 2. And the LORD sold them into the hand of Jabin king of Canaan, that reigned in Hazor; the captain of whose host /was/ Sisera, which dwelt in Harosheth of the Gentiles.
@@ -136,7 +136,7 @@
 21. Then Jael Heber's wife took a nail of the tent, and took an hammer in her hand, and went softly unto him, and smote the nail into his temples, and fastened it into the ground: for he was fast asleep and weary. So he died.
 22. And, behold, as Barak pursued Sisera, Jael came out to meet him, and said unto him, Come, and I will shew thee the man whom thou seekest. And when he came into her /tent/, behold, Sisera lay dead, and the nail /was/ in his temples.
 23. So God subdued on that day Jabin the king of Canaan before the children of Israel.
-24. And the hand of the children of Israel prospered, and prevailed against Jabin the king of Canaan, until they had destroyed Jabin king of Canaan. 
+24. And the hand of the children of Israel prospered, and prevailed against Jabin the king of Canaan, until they had destroyed Jabin king of Canaan.
 * 5
 1. Then sang Deborah and Barak the son of Abinoam on that day, saying,
 2. Praise ye the LORD for the avenging of Israel, when the people willingly offered themselves.
@@ -168,7 +168,7 @@
 28. The mother of Sisera looked out at a window, and cried through the lattice, Why is his chariot /so/ long in coming? why tarry the wheels of his chariots?
 29. Her wise ladies answered her, yea, she returned answer to herself,
 30. Have they not sped? have they /not/ divided the prey; to every man a damsel /or/ two; to Sisera a prey of divers colours, a prey of divers colours of needlework, of divers colours of needlework on both sides, /meet/ for the necks of /them that take/ the spoil?
-31. So let all thine enemies perish, O LORD: but /let/ them that love him /be/ as the sun when he goeth forth in his might. And the land had rest forty years. 
+31. So let all thine enemies perish, O LORD: but /let/ them that love him /be/ as the sun when he goeth forth in his might. And the land had rest forty years.
 * 6
 1. And the children of Israel did evil in the sight of the LORD: and the LORD delivered them into the hand of Midian seven years.
 2. And the hand of Midian prevailed against Israel: /and/ because of the Midianites the children of Israel made them the dens which /are/ in the mountains, and caves, and strong holds.
@@ -217,7 +217,7 @@
 37. Behold, I will put a fleece of wool in the floor; /and/ if the dew be on the fleece only, and /it be/ dry upon all the earth /beside/, then shall I know that thou wilt save Israel by mine hand, as thou hast said.
 38. And it was so: for he rose up early on the morrow, and thrust the fleece together, and wringed the dew out of the fleece, a bowl full of water.
 39. And Gideon said unto God, Let not thine anger be hot against me, and I will speak but this once: let me prove, I pray thee, but this once with the fleece; let it now be dry only upon the fleece, and upon all the ground let there be dew.
-40. And God did so that night: for it was dry upon the fleece only, and there was dew on all the ground. 
+40. And God did so that night: for it was dry upon the fleece only, and there was dew on all the ground.
 * 7
 1. Then Jerubbaal, who /is/ Gideon, and all the people that /were/ with him, rose up early, and pitched beside the well of Harod: so that the host of the Midianites were on the north side of them, by the hill of Moreh, in the valley.
 2. And the LORD said unto Gideon, The people that /are/ with thee /are/ too many for me to give the Midianites into their hands, lest Israel vaunt themselves against me, saying, Mine own hand hath saved me.
@@ -247,7 +247,7 @@
 23. And the men of Israel gathered themselves together out of Naphtali, and out of Asher, and out of all Manasseh, and pursued after the Midianites.
 
 24. And Gideon sent messengers throughout all mount Ephraim, saying, Come down against the Midianites, and take before them the waters unto Beth–barah and Jordan. Then all the men of Ephraim gathered themselves together, and took the waters unto Beth–barah and Jordan.
-25. And they took two princes of the Midianites, Oreb and Zeeb; and they slew Oreb upon the rock Oreb, and Zeeb they slew at the winepress of Zeeb, and pursued Midian, and brought the heads of Oreb and Zeeb to Gideon on the other side Jordan. 
+25. And they took two princes of the Midianites, Oreb and Zeeb; and they slew Oreb upon the rock Oreb, and Zeeb they slew at the winepress of Zeeb, and pursued Midian, and brought the heads of Oreb and Zeeb to Gideon on the other side Jordan.
 * 8
 1. And the men of Ephraim said unto him, Why hast thou served us thus, that thou calledst us not, when thou wentest to fight with the Midianites? And they did chide with him sharply.
 2. And he said unto them, What have I done now in comparison of you? /Is/ not the gleaning of the grapes of Ephraim better than the vintage of Abi–ezer?
@@ -295,7 +295,7 @@
 32. And Gideon the son of Joash died in a good old age, and was buried in the sepulchre of Joash his father, in Ophrah of the Abi–ezrites.
 33. And it came to pass, as soon as Gideon was dead, that the children of Israel turned again, and went a whoring after Baalim, and made Baal–berith their god.
 34. And the children of Israel remembered not the LORD their God, who had delivered them out of the hands of all their enemies on every side:
-35. Neither shewed they kindness to the house of Jerubbaal, /namely/, Gideon, according to all the goodness which he had shewed unto Israel. 
+35. Neither shewed they kindness to the house of Jerubbaal, /namely/, Gideon, according to all the goodness which he had shewed unto Israel.
 * 9
 1. And Abimelech the son of Jerubbaal went to Shechem unto his mother's brethren, and communed with them, and with all the family of the house of his mother's father, saying,
 2. Speak, I pray you, in the ears of all the men of Shechem, Whether /is/ better for you, either that all the sons of Jerubbaal, /which are/ threescore and ten persons, reign over you, or that one reign over you? remember also that I /am/ your bone and your flesh.
@@ -360,7 +360,7 @@
 55. And when the men of Israel saw that Abimelech was dead, they departed every man unto his place.
 
 56. Thus God rendered the wickedness of Abimelech, which he did unto his father, in slaying his seventy brethren:
-57. And all the evil of the men of Shechem did God render upon their heads: and upon them came the curse of Jotham the son of Jerubbaal. 
+57. And all the evil of the men of Shechem did God render upon their heads: and upon them came the curse of Jotham the son of Jerubbaal.
 * 10
 1. And after Abimelech there arose to defend Israel Tola the son of Puah, the son of Dodo, a man of Issachar; and he dwelt in Shamir in mount Ephraim.
 2. And he judged Israel twenty and three years, and died, and was buried in Shamir.
@@ -383,7 +383,7 @@
 15. And the children of Israel said unto the LORD, We have sinned: do thou unto us whatsoever seemeth good unto thee; deliver us only, we pray thee, this day.
 16. And they put away the strange gods from among them, and served the LORD: and his soul was grieved for the misery of Israel.
 17. Then the children of Ammon were gathered together, and encamped in Gilead. And the children of Israel assembled themselves together, and encamped in Mizpeh.
-18. And the people /and/ princes of Gilead said one to another, What man /is he/ that will begin to fight against the children of Ammon? he shall be head over all the inhabitants of Gilead. 
+18. And the people /and/ princes of Gilead said one to another, What man /is he/ that will begin to fight against the children of Ammon? he shall be head over all the inhabitants of Gilead.
 * 11
 1. Now Jephthah the Gileadite was a mighty man of valour, and he /was/ the son of an harlot: and Gilead begat Jephthah.
 2. And Gilead's wife bare him sons; and his wife's sons grew up, and they thrust out Jephthah, and said unto him, Thou shalt not inherit in our father's house; for thou /art/ the son of a strange woman.
@@ -429,7 +429,7 @@
 37. And she said unto her father, Let this thing be done for me: let me alone two months, that I may go up and down upon the mountains, and bewail my virginity, I and my fellows.
 38. And he said, Go. And he sent her away /for/ two months: and she went with her companions, and bewailed her virginity upon the mountains.
 39. And it came to pass at the end of two months, that she returned unto her father, who did with her /according/ to his vow which he had vowed: and she knew no man. And it was a custom in Israel,
-40. /That/ the daughters of Israel went yearly to lament the daughter of Jephthah the Gileadite four days in a year. 
+40. /That/ the daughters of Israel went yearly to lament the daughter of Jephthah the Gileadite four days in a year.
 * 12
 1. And the men of Ephraim gathered themselves together, and went northward, and said unto Jephthah, Wherefore passedst thou over to fight against the children of Ammon, and didst not call us to go with thee? we will burn thine house upon thee with fire.
 2. And Jephthah said unto them, I and my people were at great strife with the children of Ammon; and when I called you, ye delivered me not out of their hands.
@@ -448,7 +448,7 @@
 
 13. And after him Abdon the son of Hillel, a Pirathonite, judged Israel.
 14. And he had forty sons and thirty nephews, that rode on threescore and ten ass colts: and he judged Israel eight years.
-15. And Abdon the son of Hillel the Pirathonite died, and was buried in Pirathon in the land of Ephraim, in the mount of the Amalekites. 
+15. And Abdon the son of Hillel the Pirathonite died, and was buried in Pirathon in the land of Ephraim, in the mount of the Amalekites.
 * 13
 1. And the children of Israel did evil again in the sight of the LORD; and the LORD delivered them into the hand of the Philistines forty years.
 
@@ -479,7 +479,7 @@
 23. But his wife said unto him, If the LORD were pleased to kill us, he would not have received a burnt offering and a meat offering at our hands, neither would he have shewed us all these /things/, nor would as at this time have told us /such things/ as these.
 
 24. And the woman bare a son, and called his name Samson: and the child grew, and the LORD blessed him.
-25. And the Spirit of the LORD began to move him at times in the camp of Dan between Zorah and Eshtaol. 
+25. And the Spirit of the LORD began to move him at times in the camp of Dan between Zorah and Eshtaol.
 * 14
 1. And Samson went down to Timnath, and saw a woman in Timnath of the daughters of the Philistines.
 2. And he came up, and told his father and his mother, and said, I have seen a woman in Timnath of the daughters of the Philistines: now therefore get her for me to wife.
@@ -505,7 +505,7 @@
 18. And the men of the city said unto him on the seventh day before the sun went down, What /is/ sweeter than honey? and what /is/ stronger than a lion? And he said unto them, If ye had not plowed with my heifer, ye had not found out my riddle.
 
 19. And the Spirit of the LORD came upon him, and he went down to Ashkelon, and slew thirty men of them, and took their spoil, and gave change of garments unto them which expounded the riddle. And his anger was kindled, and he went up to his father's house.
-20. But Samson's wife was /given/ to his companion, whom he had used as his friend. 
+20. But Samson's wife was /given/ to his companion, whom he had used as his friend.
 * 15
 1. But it came to pass within a while after, in the time of wheat harvest, that Samson visited his wife with a kid; and he said, I will go in to my wife into the chamber. But her father would not suffer him to go in.
 2. And her father said, I verily thought that thou hadst utterly hated her; therefore I gave her to thy companion: /is/ not her younger sister fairer than she? take her, I pray thee, instead of her.
@@ -532,7 +532,7 @@
 
 18. And he was sore athirst, and called on the LORD, and said, Thou hast given this great deliverance into the hand of thy servant: and now shall I die for thirst, and fall into the hand of the uncircumcised?
 19. But God clave an hollow place that /was/ in the jaw, and there came water thereout; and when he had drunk, his spirit came again, and he revived: wherefore he called the name thereof En–hakkore, which /is/ in Lehi unto this day.
-20. And he judged Israel in the days of the Philistines twenty years. 
+20. And he judged Israel in the days of the Philistines twenty years.
 * 16
 1. Then went Samson to Gaza, and saw there an harlot, and went in unto her.
 2. /And it was told/ the Gazites, saying, Samson is come hither. And they compassed /him/ in, and laid wait for him all night in the gate of the city, and were quiet all the night, saying, In the morning, when it is day, we shall kill him.
@@ -568,7 +568,7 @@
 28. And Samson called unto the LORD, and said, O Lord GOD, remember me, I pray thee, and strengthen me, I pray thee, only this once, O God, that I may be at once avenged of the Philistines for my two eyes.
 29. And Samson took hold of the two middle pillars upon which the house stood, and on which it was borne up, of the one with his right hand, and of the other with his left.
 30. And Samson said, Let me die with the Philistines. And he bowed himself with /all his/ might; and the house fell upon the lords, and upon all the people that /were/ therein. So the dead which he slew at his death were more than /they/ which he slew in his life.
-31. Then his brethren and all the house of his father came down, and took him, and brought /him/ up, and buried him between Zorah and Eshtaol in the buryingplace of Manoah his father. And he judged Israel twenty years. 
+31. Then his brethren and all the house of his father came down, and took him, and brought /him/ up, and buried him between Zorah and Eshtaol in the buryingplace of Manoah his father. And he judged Israel twenty years.
 * 17
 1. And there was a man of mount Ephraim, whose name /was/ Micah.
 2. And he said unto his mother, The eleven hundred /shekels/ of silver that were taken from thee, about which thou cursedst, and spakest of also in mine ears, behold, the silver /is/ with me; I took it. And his mother said, Blessed /be thou/ of the LORD, my son.
@@ -583,7 +583,7 @@
 10. And Micah said unto him, Dwell with me, and be unto me a father and a priest, and I will give thee ten /shekels/ of silver by the year, and a suit of apparel, and thy victuals. So the Levite went in.
 11. And the Levite was content to dwell with the man; and the young man was unto him as one of his sons.
 12. And Micah consecrated the Levite; and the young man became his priest, and was in the house of Micah.
-13. Then said Micah, Now know I that the LORD will do me good, seeing I have a Levite to /my/ priest. 
+13. Then said Micah, Now know I that the LORD will do me good, seeing I have a Levite to /my/ priest.
 * 18
 1. In those days /there was/ no king in Israel: and in those days the tribe of the Danites sought them an inheritance to dwell in; for unto that day /all their/ inheritance had not fallen unto them among the tribes of Israel.
 2. And the children of Dan sent of their family five men from their coasts, men of valour, from Zorah, and from Eshtaol, to spy out the land, and to search it; and they said unto them, Go, search the land: who when they came to mount Ephraim, to the house of Micah, they lodged there.
@@ -620,7 +620,7 @@
 29. And they called the name of the city Dan, after the name of Dan their father, who was born unto Israel: howbeit the name of the city /was/ Laish at the first.
 
 30. And the children of Dan set up the graven image: and Jonathan, the son of Gershom, the son of Manasseh, he and his sons were priests to the tribe of Dan until the day of the captivity of the land.
-31. And they set them up Micah's graven image, which he made, all the time that the house of God was in Shiloh. 
+31. And they set them up Micah's graven image, which he made, all the time that the house of God was in Shiloh.
 * 19
 1. And it came to pass in those days, when /there was/ no king in Israel, that there was a certain Levite sojourning on the side of mount Ephraim, who took to him a concubine out of Beth–lehem–judah.
 2. And his concubine played the whore against him, and went away from him unto her father's house to Beth–lehem–judah, and was there four whole months.
@@ -655,7 +655,7 @@
 28. And he said unto her, Up, and let us be going. But none answered. Then the man took her /up/ upon an ass, and the man rose up, and gat him unto his place.
 
 29. And when he was come into his house, he took a knife, and laid hold on his concubine, and divided her, /together/ with her bones, into twelve pieces, and sent her into all the coasts of Israel.
-30. And it was so, that all that saw it said, There was no such deed done nor seen from the day that the children of Israel came up out of the land of Egypt unto this day: consider of it, take advice, and speak /your minds/. 
+30. And it was so, that all that saw it said, There was no such deed done nor seen from the day that the children of Israel came up out of the land of Egypt unto this day: consider of it, take advice, and speak /your minds/.
 * 20
 1. Then all the children of Israel went out, and the congregation was gathered together as one man, from Dan even to Beer–sheba, with the land of Gilead, unto the LORD in Mizpeh.
 2. And the chief of all the people, /even/ of all the tribes of Israel, presented themselves in the assembly of the people of God, four hundred thousand footmen that drew sword.
@@ -708,7 +708,7 @@
 45. And they turned and fled toward the wilderness unto the rock of Rimmon: and they gleaned of them in the highways five thousand men; and pursued hard after them unto Gidom, and slew two thousand men of them.
 46. So that all which fell that day of Benjamin were twenty and five thousand men that drew the sword; all these /were/ men of valour.
 47. But six hundred men turned and fled to the wilderness unto the rock Rimmon, and abode in the rock Rimmon four months.
-48. And the men of Israel turned again upon the children of Benjamin, and smote them with the edge of the sword, as well the men of /every/ city, as the beast, and all that came to hand: also they set on fire all the cities that they came to. 
+48. And the men of Israel turned again upon the children of Benjamin, and smote them with the edge of the sword, as well the men of /every/ city, as the beast, and all that came to hand: also they set on fire all the cities that they came to.
 * 21
 1. Now the men of Israel had sworn in Mizpeh, saying, There shall not any of us give his daughter unto Benjamin to wife.
 2. And the people came to the house of God, and abode there till even before God, and lifted up their voices, and wept sore;
@@ -736,4 +736,4 @@
 22. And it shall be, when their fathers or their brethren come unto us to complain, that we will say unto them, Be favourable unto them for our sakes: because we reserved not to each man his wife in the war: for ye did not give unto them at this time, /that/ ye should be guilty.
 23. And the children of Benjamin did so, and took /them/ wives, according to their number, of them that danced, whom they caught: and they went and returned unto their inheritance, and repaired the cities, and dwelt in them.
 24. And the children of Israel departed thence at that time, every man to his tribe and to his family, and they went out from thence every man to his inheritance.
-25. In those days /there was/ no king in Israel: every man did /that which was/ right in his own eyes.  
+25. In those days /there was/ no king in Israel: every man did /that which was/ right in his own eyes.

--- a/08_RUT.org
+++ b/08_RUT.org
@@ -23,7 +23,7 @@
 19. So they two went until they came to Beth–lehem. And it came to pass, when they were come to Beth–lehem, that all the city was moved about them, and they said, /Is/ this Naomi?
 20. And she said unto them, Call me not Naomi, call me Mara: for the Almighty hath dealt very bitterly with me.
 21. I went out full, and the LORD hath brought me home again empty: why /then/ call ye me Naomi, seeing the LORD hath testified against me, and the Almighty hath afflicted me?
-22. So Naomi returned, and Ruth the Moabitess, her daughter in law, with her, which returned out of the country of Moab: and they came to Beth–lehem in the beginning of barley harvest. 
+22. So Naomi returned, and Ruth the Moabitess, her daughter in law, with her, which returned out of the country of Moab: and they came to Beth–lehem in the beginning of barley harvest.
 * 2
 1. And Naomi had a kinsman of her husband's, a mighty man of wealth, of the family of Elimelech; and his name /was/ Boaz.
 2. And Ruth the Moabitess said unto Naomi, Let me now go to the field, and glean ears of corn after /him/ in whose sight I shall find grace. And she said unto her, Go, my daughter.
@@ -49,7 +49,7 @@
 20. And Naomi said unto her daughter in law, Blessed /be/ he of the LORD, who hath not left off his kindness to the living and to the dead. And Naomi said unto her, The man /is/ near of kin unto us, one of our next kinsmen.
 21. And Ruth the Moabitess said, He said unto me also, Thou shalt keep fast by my young men, until they have ended all my harvest.
 22. And Naomi said unto Ruth her daughter in law, /It is/ good, my daughter, that thou go out with his maidens, that they meet thee not in any other field.
-23. So she kept fast by the maidens of Boaz to glean unto the end of barley harvest and of wheat harvest; and dwelt with her mother in law. 
+23. So she kept fast by the maidens of Boaz to glean unto the end of barley harvest and of wheat harvest; and dwelt with her mother in law.
 * 3
 1. Then Naomi her mother in law said unto her, My daughter, shall I not seek rest for thee, that it may be well with thee?
 2. And now /is/ not Boaz of our kindred, with whose maidens thou wast? Behold, he winnoweth barley to night in the threshingfloor.
@@ -71,7 +71,7 @@
 15. Also he said, Bring the vail that /thou hast/ upon thee, and hold it. And when she held it, he measured six /measures/ of barley, and laid /it/ on her: and she went into the city.
 16. And when she came to her mother in law, she said, Who /art/ thou, my daughter? And she told her all that the man had done to her.
 17. And she said, These six /measures/ of barley gave he me; for he said to me, Go not empty unto thy mother in law.
-18. Then said she, Sit still, my daughter, until thou know how the matter will fall: for the man will not be in rest, until he have finished the thing this day. 
+18. Then said she, Sit still, my daughter, until thou know how the matter will fall: for the man will not be in rest, until he have finished the thing this day.
 * 4
 1. Then went Boaz up to the gate, and sat him down there: and, behold, the kinsman of whom Boaz spake came by; unto whom he said, Ho, such a one! turn aside, sit down here. And he turned aside, and sat down.
 2. And he took ten men of the elders of the city, and said, Sit ye down here. And they sat down.
@@ -98,4 +98,4 @@
 19. And Hezron begat Ram, and Ram begat Amminadab,
 20. And Amminadab begat Nahshon, and Nahshon begat Salmon,
 21. And Salmon begat Boaz, and Boaz begat Obed,
-22. And Obed begat Jesse, and Jesse begat David.  
+22. And Obed begat Jesse, and Jesse begat David.

--- a/09_1SA.org
+++ b/09_1SA.org
@@ -31,7 +31,7 @@
 25. And they slew a bullock, and brought the child to Eli.
 26. And she said, Oh my lord, /as/ thy soul liveth, my lord, I /am/ the woman that stood by thee here, praying unto the LORD.
 27. For this child I prayed; and the LORD hath given me my petition which I asked of him:
-28. Therefore also I have lent him to the LORD; as long as he liveth he shall be lent to the LORD. And he worshipped the LORD there. 
+28. Therefore also I have lent him to the LORD; as long as he liveth he shall be lent to the LORD. And he worshipped the LORD there.
 * 2
 1. And Hannah prayed, and said, My heart rejoiceth in the LORD, mine horn is exalted in the LORD: my mouth is enlarged over mine enemies; because I rejoice in thy salvation.
 2. /There is/ none holy as the LORD: for /there is/ none beside thee: neither /is there/ any rock like our God.
@@ -73,7 +73,7 @@
 33. And the man of thine, /whom/ I shall not cut off from mine altar, /shall be/ to consume thine eyes, and to grieve thine heart: and all the increase of thine house shall die in the flower of their age.
 34. And this /shall be/ a sign unto thee, that shall come upon thy two sons, on Hophni and Phinehas; in one day they shall die both of them.
 35. And I will raise me up a faithful priest, /that/ shall do according to /that/ which /is/ in mine heart and in my mind: and I will build him a sure house; and he shall walk before mine anointed for ever.
-36. And it shall come to pass, /that/ every one that is left in thine house shall come /and/ crouch to him for a piece of silver and a morsel of bread, and shall say, Put me, I pray thee, into one of the priests' offices, that I may eat a piece of bread. 
+36. And it shall come to pass, /that/ every one that is left in thine house shall come /and/ crouch to him for a piece of silver and a morsel of bread, and shall say, Put me, I pray thee, into one of the priests' offices, that I may eat a piece of bread.
 * 3
 1. And the child Samuel ministered unto the LORD before Eli. And the word of the LORD was precious in those days; /there was/ no open vision.
 2. And it came to pass at that time, when Eli /was/ laid down in his place, and his eyes began to wax dim, /that/ he could not see;
@@ -98,7 +98,7 @@
 
 19. And Samuel grew, and the LORD was with him, and did let none of his words fall to the ground.
 20. And all Israel from Dan even to Beer–sheba knew that Samuel /was/ established /to be/ a prophet of the LORD.
-21. And the LORD appeared again in Shiloh: for the LORD revealed himself to Samuel in Shiloh by the word of the LORD. 
+21. And the LORD appeared again in Shiloh: for the LORD revealed himself to Samuel in Shiloh by the word of the LORD.
 * 4
 1. And the word of Samuel came to all Israel. Now Israel went out against the Philistines to battle, and pitched beside Eben–ezer: and the Philistines pitched in Aphek.
 2. And the Philistines put themselves in array against Israel: and when they joined battle, Israel was smitten before the Philistines: and they slew of the army in the field about four thousand men.
@@ -125,7 +125,7 @@
 19. And his daughter in law, Phinehas' wife, was with child, /near/ to be delivered: and when she heard the tidings that the ark of God was taken, and that her father in law and her husband were dead, she bowed herself and travailed; for her pains came upon her.
 20. And about the time of her death the women that stood by her said unto her, Fear not; for thou hast born a son. But she answered not, neither did she regard /it/.
 21. And she named the child I–chabod, saying, The glory is departed from Israel: because the ark of God was taken, and because of her father in law and her husband.
-22. And she said, The glory is departed from Israel: for the ark of God is taken. 
+22. And she said, The glory is departed from Israel: for the ark of God is taken.
 * 5
 1. And the Philistines took the ark of God, and brought it from Eben–ezer unto Ashdod.
 2. When the Philistines took the ark of God, they brought it into the house of Dagon, and set it by Dagon.
@@ -140,7 +140,7 @@
 
 10. Therefore they sent the ark of God to Ekron. And it came to pass, as the ark of God came to Ekron, that the Ekronites cried out, saying, They have brought about the ark of the God of Israel to us, to slay us and our people.
 11. So they sent and gathered together all the lords of the Philistines, and said, Send away the ark of the God of Israel, and let it go again to his own place, that it slay us not, and our people: for there was a deadly destruction throughout all the city; the hand of God was very heavy there.
-12. And the men that died not were smitten with the emerods: and the cry of the city went up to heaven. 
+12. And the men that died not were smitten with the emerods: and the cry of the city went up to heaven.
 * 6
 1. And the ark of the LORD was in the country of the Philistines seven months.
 2. And the Philistines called for the priests and the diviners, saying, What shall we do to the ark of the LORD? tell us wherewith we shall send it to his place.
@@ -165,7 +165,7 @@
 19. And he smote the men of Beth–shemesh, because they had looked into the ark of the LORD, even he smote of the people fifty thousand and threescore and ten men: and the people lamented, because the LORD had smitten /many/ of the people with a great slaughter.
 20. And the men of Beth–shemesh said, Who is able to stand before this holy LORD God? and to whom shall he go up from us?
 
-21. And they sent messengers to the inhabitants of Kirjath–jearim, saying, The Philistines have brought again the ark of the LORD; come ye down, /and/ fetch it up to you. 
+21. And they sent messengers to the inhabitants of Kirjath–jearim, saying, The Philistines have brought again the ark of the LORD; come ye down, /and/ fetch it up to you.
 * 7
 1. And the men of Kirjath–jearim came, and fetched up the ark of the LORD, and brought it into the house of Abinadab in the hill, and sanctified Eleazar his son to keep the ark of the LORD.
 2. And it came to pass, while the ark abode in Kirjath–jearim, that the time was long; for it was twenty years: and all the house of Israel lamented after the LORD.
@@ -186,7 +186,7 @@
 14. And the cities which the Philistines had taken from Israel were restored to Israel, from Ekron even unto Gath; and the coasts thereof did Israel deliver out of the hands of the Philistines. And there was peace between Israel and the Amorites.
 15. And Samuel judged Israel all the days of his life.
 16. And he went from year to year in circuit to Beth–el, and Gilgal, and Mizpeh, and judged Israel in all those places.
-17. And his return /was/ to Ramah; for there /was/ his house; and there he judged Israel; and there he built an altar unto the LORD. 
+17. And his return /was/ to Ramah; for there /was/ his house; and there he judged Israel; and there he built an altar unto the LORD.
 * 8
 1. And it came to pass, when Samuel was old, that he made his sons judges over Israel.
 2. Now the name of his firstborn was Joel; and the name of his second, Abiah: /they were/ judges in Beer–sheba.
@@ -212,7 +212,7 @@
 19. Nevertheless the people refused to obey the voice of Samuel; and they said, Nay; but we will have a king over us;
 20. That we also may be like all the nations; and that our king may judge us, and go out before us, and fight our battles.
 21. And Samuel heard all the words of the people, and he rehearsed them in the ears of the LORD.
-22. And the LORD said to Samuel, Hearken unto their voice, and make them a king. And Samuel said unto the men of Israel, Go ye every man unto his city. 
+22. And the LORD said to Samuel, Hearken unto their voice, and make them a king. And Samuel said unto the men of Israel, Go ye every man unto his city.
 * 9
 1. Now there was a man of Benjamin, whose name /was/ Kish, the son of Abiel, the son of Zeror, the son of Bechorath, the son of Aphiah, a Benjamite, a mighty man of power.
 2. And he had a son, whose name /was/ Saul, a choice young man, and a goodly: and /there was/ not among the children of Israel a goodlier person than he: from his shoulders and upward /he was/ higher than any of the people.
@@ -243,7 +243,7 @@
 
 25. And when they were come down from the high place into the city, /Samuel/ communed with Saul upon the top of the house.
 26. And they arose early: and it came to pass about the spring of the day, that Samuel called Saul to the top of the house, saying, Up, that I may send thee away. And Saul arose, and they went out both of them, he and Samuel, abroad.
-27. /And/ as they were going down to the end of the city, Samuel said to Saul, Bid the servant pass on before us, (and he passed on,) but stand thou still a while, that I may shew thee the word of God. 
+27. /And/ as they were going down to the end of the city, Samuel said to Saul, Bid the servant pass on before us, (and he passed on,) but stand thou still a while, that I may shew thee the word of God.
 * 10
 1. Then Samuel took a vial of oil, and poured /it/ upon his head, and kissed him, and said, /Is it/ not because the LORD hath anointed thee /to be/ captain over his inheritance?
 2. When thou art departed from me to day, then thou shalt find two men by Rachel's sepulchre in the border of Benjamin at Zelzah; and they will say unto thee, The asses which thou wentest to seek are found: and, lo, thy father hath left the care of the asses, and sorroweth for you, saying, What shall I do for my son?
@@ -275,7 +275,7 @@
 25. Then Samuel told the people the manner of the kingdom, and wrote /it/ in a book, and laid /it/ up before the LORD. And Samuel sent all the people away, every man to his house.
 
 26. And Saul also went home to Gibeah; and there went with him a band of men, whose hearts God had touched.
-27. But the children of Belial said, How shall this man save us? And they despised him, and brought him no presents. But he held his peace. 
+27. But the children of Belial said, How shall this man save us? And they despised him, and brought him no presents. But he held his peace.
 * 11
 1. Then Nahash the Ammonite came up, and encamped against Jabesh–gilead: and all the men of Jabesh said unto Nahash, Make a covenant with us, and we will serve thee.
 2. And Nahash the Ammonite answered them, On this /condition/ will I make /a covenant/ with you, that I may thrust out all your right eyes, and lay it /for/ a reproach upon all Israel.
@@ -293,7 +293,7 @@
 12. And the people said unto Samuel, Who /is/ he that said, Shall Saul reign over us? bring the men, that we may put them to death.
 13. And Saul said, There shall not a man be put to death this day: for to day the LORD hath wrought salvation in Israel.
 14. Then said Samuel to the people, Come, and let us go to Gilgal, and renew the kingdom there.
-15. And all the people went to Gilgal; and there they made Saul king before the LORD in Gilgal; and there they sacrificed sacrifices of peace offerings before the LORD; and there Saul and all the men of Israel rejoiced greatly. 
+15. And all the people went to Gilgal; and there they made Saul king before the LORD in Gilgal; and there they sacrificed sacrifices of peace offerings before the LORD; and there Saul and all the men of Israel rejoiced greatly.
 * 12
 1. And Samuel said unto all Israel, Behold, I have hearkened unto your voice in all that ye said unto me, and have made a king over you.
 2. And now, behold, the king walketh before you: and I am old and grayheaded; and, behold, my sons /are/ with you: and I have walked before you from my childhood unto this day.
@@ -322,7 +322,7 @@
 22. For the LORD will not forsake his people for his great name's sake: because it hath pleased the LORD to make you his people.
 23. Moreover as for me, God forbid that I should sin against the LORD in ceasing to pray for you: but I will teach you the good and the right way:
 24. Only fear the LORD, and serve him in truth with all your heart: for consider how great /things/ he hath done for you.
-25. But if ye shall still do wickedly, ye shall be consumed, both ye and your king. 
+25. But if ye shall still do wickedly, ye shall be consumed, both ye and your king.
 * 13
 1. Saul reigned one year; and when he had reigned two years over Israel,
 2. Saul chose him three thousand /men/ of Israel; /whereof/ two thousand were with Saul in Michmash and in mount Beth–el, and a thousand were with Jonathan in Gibeah of Benjamin: and the rest of the people he sent every man to his tent.
@@ -351,7 +351,7 @@
 20. But all the Israelites went down to the Philistines, to sharpen every man his share, and his coulter, and his axe, and his mattock.
 21. Yet they had a file for the mattocks, and for the coulters, and for the forks, and for the axes, and to sharpen the goads.
 22. So it came to pass in the day of battle, that there was neither sword nor spear found in the hand of any of the people that /were/ with Saul and Jonathan: but with Saul and with Jonathan his son was there found.
-23. And the garrison of the Philistines went out to the passage of Michmash. 
+23. And the garrison of the Philistines went out to the passage of Michmash.
 * 14
 1. Now it came to pass upon a day, that Jonathan the son of Saul said unto the young man that bare his armour, Come, and let us go over to the Philistines' garrison, that /is/ on the other side. But he told not his father.
 2. And Saul tarried in the uttermost part of Gibeah under a pomegranate tree which /is/ in Migron: and the people that /were/ with him /were/ about six hundred men;
@@ -410,7 +410,7 @@
 49. Now the sons of Saul were Jonathan, and Ishui, and Melchi–shua: and the names of his two daughters /were these/; the name of the firstborn Merab, and the name of the younger Michal:
 50. And the name of Saul's wife /was/ Ahinoam, the daughter of Ahimaaz: and the name of the captain of his host /was/ Abner, the son of Ner, Saul's uncle.
 51. And Kish /was/ the father of Saul; and Ner the father of Abner /was/ the son of Abiel.
-52. And there was sore war against the Philistines all the days of Saul: and when Saul saw any strong man, or any valiant man, he took him unto him. 
+52. And there was sore war against the Philistines all the days of Saul: and when Saul saw any strong man, or any valiant man, he took him unto him.
 * 15
 1. Samuel also said unto Saul, The LORD sent me to anoint thee /to be/ king over his people, over Israel: now therefore hearken thou unto the voice of the words of the LORD.
 2. Thus saith the LORD of hosts, I remember /that/ which Amalek did to Israel, how he laid /wait/ for him in the way, when he came up from Egypt.
@@ -451,7 +451,7 @@
 33. And Samuel said, As thy sword hath made women childless, so shall thy mother be childless among women. And Samuel hewed Agag in pieces before the LORD in Gilgal.
 
 34. Then Samuel went to Ramah; and Saul went up to his house to Gibeah of Saul.
-35. And Samuel came no more to see Saul until the day of his death: nevertheless Samuel mourned for Saul: and the LORD repented that he had made Saul king over Israel. 
+35. And Samuel came no more to see Saul until the day of his death: nevertheless Samuel mourned for Saul: and the LORD repented that he had made Saul king over Israel.
 * 16
 1. And the LORD said unto Samuel, How long wilt thou mourn for Saul, seeing I have rejected him from reigning over Israel? fill thine horn with oil, and go, I will send thee to Jesse the Beth–lehemite: for I have provided me a king among his sons.
 2. And Samuel said, How can I go? if Saul hear /it/, he will kill me. And the LORD said, Take an heifer with thee, and say, I am come to sacrifice to the LORD.
@@ -478,7 +478,7 @@
 20. And Jesse took an ass /laden/ with bread, and a bottle of wine, and a kid, and sent /them/ by David his son unto Saul.
 21. And David came to Saul, and stood before him: and he loved him greatly; and he became his armourbearer.
 22. And Saul sent to Jesse, saying, Let David, I pray thee, stand before me; for he hath found favour in my sight.
-23. And it came to pass, when the /evil/ spirit from God was upon Saul, that David took an harp, and played with his hand: so Saul was refreshed, and was well, and the evil spirit departed from him. 
+23. And it came to pass, when the /evil/ spirit from God was upon Saul, that David took an harp, and played with his hand: so Saul was refreshed, and was well, and the evil spirit departed from him.
 * 17
 1. Now the Philistines gathered together their armies to battle, and were gathered together at Shochoh, which /belongeth/ to Judah, and pitched between Shochoh and Azekah, in Ephes–dammim.
 2. And Saul and the men of Israel were gathered together, and pitched by the valley of Elah, and set the battle in array against the Philistines.
@@ -545,7 +545,7 @@
 55. And when Saul saw David go forth against the Philistine, he said unto Abner, the captain of the host, Abner, whose son /is/ this youth? And Abner said, /As/ thy soul liveth, O king, I cannot tell.
 56. And the king said, Enquire thou whose son the stripling /is/.
 57. And as David returned from the slaughter of the Philistine, Abner took him, and brought him before Saul with the head of the Philistine in his hand.
-58. And Saul said to him, Whose son /art/ thou, /thou/ young man? And David answered, I /am/ the son of thy servant Jesse the Beth–lehemite. 
+58. And Saul said to him, Whose son /art/ thou, /thou/ young man? And David answered, I /am/ the son of thy servant Jesse the Beth–lehemite.
 * 18
 1. And it came to pass, when he had made an end of speaking unto Saul, that the soul of Jonathan was knit with the soul of David, and Jonathan loved him as his own soul.
 2. And Saul took him that day, and would let him go no more home to his father's house.
@@ -582,7 +582,7 @@
 
 28. And Saul saw and knew that the LORD /was/ with David, and /that/ Michal Saul's daughter loved him.
 29. And Saul was yet the more afraid of David; and Saul became David's enemy continually.
-30. Then the princes of the Philistines went forth: and it came to pass, after they went forth, /that/ David behaved himself more wisely than all the servants of Saul; so that his name was much set by. 
+30. Then the princes of the Philistines went forth: and it came to pass, after they went forth, /that/ David behaved himself more wisely than all the servants of Saul; so that his name was much set by.
 * 19
 1. And Saul spake to Jonathan his son, and to all his servants, that they should kill David.
 2. But Jonathan Saul's son delighted much in David: and Jonathan told David, saying, Saul my father seeketh to kill thee: now therefore, I pray thee, take heed to thyself until the morning, and abide in a secret /place/, and hide thyself:
@@ -611,7 +611,7 @@
 21. And when it was told Saul, he sent other messengers, and they prophesied likewise. And Saul sent messengers again the third time, and they prophesied also.
 22. Then went he also to Ramah, and came to a great well that /is/ in Sechu: and he asked and said, Where /are/ Samuel and David? And /one/ said, Behold, /they be/ at Naioth in Ramah.
 23. And he went thither to Naioth in Ramah: and the Spirit of God was upon him also, and he went on, and prophesied, until he came to Naioth in Ramah.
-24. And he stripped off his clothes also, and prophesied before Samuel in like manner, and lay down naked all that day and all that night. Wherefore they say, /Is/ Saul also among the prophets? 
+24. And he stripped off his clothes also, and prophesied before Samuel in like manner, and lay down naked all that day and all that night. Wherefore they say, /Is/ Saul also among the prophets?
 * 20
 1. And David fled from Naioth in Ramah, and came and said before Jonathan, What have I done? what /is/ mine iniquity? and what /is/ my sin before thy father, that he seeketh my life?
 2. And he said unto him, God forbid; thou shalt not die: behold, my father will do nothing either great or small, but that he will shew it me: and why should my father hide this thing from me? it /is/ not /so/.
@@ -658,7 +658,7 @@
 40. And Jonathan gave his artillery unto his lad, and said unto him, Go, carry /them/ to the city.
 
 41. /And/ as soon as the lad was gone, David arose out of /a place/ toward the south, and fell on his face to the ground, and bowed himself three times: and they kissed one another, and wept one with another, until David exceeded.
-42. And Jonathan said to David, Go in peace, forasmuch as we have sworn both of us in the name of the LORD, saying, The LORD be between me and thee, and between my seed and thy seed for ever. And he arose and departed: and Jonathan went into the city. 
+42. And Jonathan said to David, Go in peace, forasmuch as we have sworn both of us in the name of the LORD, saying, The LORD be between me and thee, and between my seed and thy seed for ever. And he arose and departed: and Jonathan went into the city.
 * 21
 1. Then came David to Nob to Ahimelech the priest: and Ahimelech was afraid at the meeting of David, and said unto him, Why /art/ thou alone, and no man with thee?
 2. And David said unto Ahimelech the priest, The king hath commanded me a business, and hath said unto me, Let no man know any thing of the business whereabout I send thee, and what I have commanded thee: and I have appointed /my/ servants to such and such a place.
@@ -676,7 +676,7 @@
 12. And David laid up these words in his heart, and was sore afraid of Achish the king of Gath.
 13. And he changed his behaviour before them, and feigned himself mad in their hands, and scrabbled on the doors of the gate, and let his spittle fall down upon his beard.
 14. Then said Achish unto his servants, Lo, ye see the man is mad: wherefore /then/ have ye brought him to me?
-15. Have I need of mad men, that ye have brought this /fellow/ to play the mad man in my presence? shall this /fellow/ come into my house? 
+15. Have I need of mad men, that ye have brought this /fellow/ to play the mad man in my presence? shall this /fellow/ come into my house?
 * 22
 1. David therefore departed thence, and escaped to the cave Adullam: and when his brethren and all his father's house heard /it/, they went down thither to him.
 2. And every one /that was/ in distress, and every one that /was/ in debt, and every one /that was/ discontented, gathered themselves unto him; and he became a captain over them: and there were with him about four hundred men.
@@ -706,7 +706,7 @@
 20. And one of the sons of Ahimelech the son of Ahitub, named Abiathar, escaped, and fled after David.
 21. And Abiathar shewed David that Saul had slain the LORD's priests.
 22. And David said unto Abiathar, I knew /it/ that day, when Doeg the Edomite /was/ there, that he would surely tell Saul: I have occasioned /the death/ of all the persons of thy father's house.
-23. Abide thou with me, fear not: for he that seeketh my life seeketh thy life: but with me thou /shalt be/ in safeguard. 
+23. Abide thou with me, fear not: for he that seeketh my life seeketh thy life: but with me thou /shalt be/ in safeguard.
 * 23
 1. Then they told David, saying, Behold, the Philistines fight against Keilah, and they rob the threshingfloors.
 2. Therefore David enquired of the LORD, saying, Shall I go and smite these Philistines? And the LORD said unto David, Go, and smite the Philistines, and save Keilah.
@@ -743,7 +743,7 @@
 27. But there came a messenger unto Saul, saying, Haste thee, and come; for the Philistines have invaded the land.
 28. Wherefore Saul returned from pursuing after David, and went against the Philistines: therefore they called that place Sela–hammahlekoth.
 
-29. And David went up from thence, and dwelt in strong holds at En–gedi. 
+29. And David went up from thence, and dwelt in strong holds at En–gedi.
 * 24
 1. And it came to pass, when Saul was returned from following the Philistines, that it was told him, saying, Behold, David /is/ in the wilderness of En–gedi.
 2. Then Saul took three thousand chosen men out of all Israel, and went to seek David and his men upon the rocks of the wild goats.
@@ -768,7 +768,7 @@
 19. For if a man find his enemy, will he let him go well away? wherefore the LORD reward thee good for that thou hast done unto me this day.
 20. And now, behold, I know well that thou shalt surely be king, and that the kingdom of Israel shall be established in thine hand.
 21. Swear now therefore unto me by the LORD, that thou wilt not cut off my seed after me, and that thou wilt not destroy my name out of my father's house.
-22. And David sware unto Saul. And Saul went home; but David and his men gat them up unto the hold. 
+22. And David sware unto Saul. And Saul went home; but David and his men gat them up unto the hold.
 * 25
 1. And Samuel died; and all the Israelites were gathered together, and lamented him, and buried him in his house at Ramah. And David arose, and went down to the wilderness of Paran.
 2. And /there was/ a man in Maon, whose possessions /were/ in Carmel; and the man /was/ very great, and he had three thousand sheep, and a thousand goats: and he was shearing his sheep in Carmel.
@@ -821,7 +821,7 @@
 42. And Abigail hasted, and arose, and rode upon an ass, with five damsels of hers that went after her; and she went after the messengers of David, and became his wife.
 43. David also took Ahinoam of Jezreel; and they were also both of them his wives.
 
-44. But Saul had given Michal his daughter, David's wife, to Phalti the son of Laish, which /was/ of Gallim. 
+44. But Saul had given Michal his daughter, David's wife, to Phalti the son of Laish, which /was/ of Gallim.
 * 26
 1. And the Ziphites came unto Saul to Gibeah, saying, Doth not David hide himself in the hill of Hachilah, /which is/ before Jeshimon?
 2. Then Saul arose, and went down to the wilderness of Ziph, having three thousand chosen men of Israel with him, to seek David in the wilderness of Ziph.
@@ -850,7 +850,7 @@
 22. And David answered and said, Behold the king's spear! and let one of the young men come over and fetch it.
 23. The LORD render to every man his righteousness and his faithfulness: for the LORD delivered thee into /my/ hand to day, but I would not stretch forth mine hand against the LORD's anointed.
 24. And, behold, as thy life was much set by this day in mine eyes, so let my life be much set by in the eyes of the LORD, and let him deliver me out of all tribulation.
-25. Then Saul said to David, Blessed /be/ thou, my son David: thou shalt both do great /things/, and also shalt still prevail. So David went on his way, and Saul returned to his place. 
+25. Then Saul said to David, Blessed /be/ thou, my son David: thou shalt both do great /things/, and also shalt still prevail. So David went on his way, and Saul returned to his place.
 * 27
 1. And David said in his heart, I shall now perish one day by the hand of Saul: /there is/ nothing better for me than that I should speedily escape into the land of the Philistines; and Saul shall despair of me, to seek me any more in any coast of Israel: so shall I escape out of his hand.
 2. And David arose, and he passed over with the six hundred men that /were/ with him unto Achish, the son of Maoch, king of Gath.
@@ -865,7 +865,7 @@
 9. And David smote the land, and left neither man nor woman alive, and took away the sheep, and the oxen, and the asses, and the camels, and the apparel, and returned, and came to Achish.
 10. And Achish said, Whither have ye made a road to day? And David said, Against the south of Judah, and against the south of the Jerahmeelites, and against the south of the Kenites.
 11. And David saved neither man nor woman alive, to bring /tidings/ to Gath, saying, Lest they should tell on us, saying, So did David, and so /will be/ his manner all the while he dwelleth in the country of the Philistines.
-12. And Achish believed David, saying, He hath made his people Israel utterly to abhor him; therefore he shall be my servant for ever. 
+12. And Achish believed David, saying, He hath made his people Israel utterly to abhor him; therefore he shall be my servant for ever.
 * 28
 1. And it came to pass in those days, that the Philistines gathered their armies together for warfare, to fight with Israel. And Achish said unto David, Know thou assuredly, that thou shalt go out with me to battle, thou and thy men.
 2. And David said to Achish, Surely thou shalt know what thy servant can do. And Achish said to David, Therefore will I make thee keeper of mine head for ever.
@@ -895,7 +895,7 @@
 22. Now therefore, I pray thee, hearken thou also unto the voice of thine handmaid, and let me set a morsel of bread before thee; and eat, that thou mayest have strength, when thou goest on thy way.
 23. But he refused, and said, I will not eat. But his servants, together with the woman, compelled him; and he hearkened unto their voice. So he arose from the earth, and sat upon the bed.
 24. And the woman had a fat calf in the house; and she hasted, and killed it, and took flour, and kneaded /it/, and did bake unleavened bread thereof:
-25. And she brought /it/ before Saul, and before his servants; and they did eat. Then they rose up, and went away that night. 
+25. And she brought /it/ before Saul, and before his servants; and they did eat. Then they rose up, and went away that night.
 * 29
 1. Now the Philistines gathered together all their armies to Aphek: and the Israelites pitched by a fountain which /is/ in Jezreel.
 2. And the lords of the Philistines passed on by hundreds, and by thousands: but David and his men passed on in the rereward with Achish.
@@ -909,7 +909,7 @@
 8. And David said unto Achish, But what have I done? and what hast thou found in thy servant so long as I have been with thee unto this day, that I may not go fight against the enemies of my lord the king?
 9. And Achish answered and said to David, I know that thou /art/ good in my sight, as an angel of God: notwithstanding the princes of the Philistines have said, He shall not go up with us to the battle.
 10. Wherefore now rise up early in the morning with thy master's servants that are come with thee: and as soon as ye be up early in the morning, and have light, depart.
-11. So David and his men rose up early to depart in the morning, to return into the land of the Philistines. And the Philistines went up to Jezreel. 
+11. So David and his men rose up early to depart in the morning, to return into the land of the Philistines. And the Philistines went up to Jezreel.
 * 30
 1. And it came to pass, when David and his men were come to Ziklag on the third day, that the Amalekites had invaded the south, and Ziklag, and smitten Ziklag, and burned it with fire;
 2. And had taken the women captives, that /were/ therein: they slew not any, either great or small, but carried /them/ away, and went on their way.
@@ -946,7 +946,7 @@
 28. And to /them/ which /were/ in Aroer, and to /them/ which /were/ in Siphmoth, and to /them/ which /were/ in Eshtemoa,
 29. And to /them/ which /were/ in Rachal, and to /them/ which /were/ in the cities of the Jerahmeelites, and to /them/ which /were/ in the cities of the Kenites,
 30. And to /them/ which /were/ in Hormah, and to /them/ which /were/ in Chor–ashan, and to /them/ which /were/ in Athach,
-31. And to /them/ which /were/ in Hebron, and to all the places where David himself and his men were wont to haunt. 
+31. And to /them/ which /were/ in Hebron, and to all the places where David himself and his men were wont to haunt.
 * 31
 1. Now the Philistines fought against Israel: and the men of Israel fled from before the Philistines, and fell down slain in mount Gilboa.
 2. And the Philistines followed hard upon Saul and upon his sons; and the Philistines slew Jonathan, and Abinadab, and Malchi–shua, Saul's sons.
@@ -962,4 +962,4 @@
 
 11. And when the inhabitants of Jabesh–gilead heard of that which the Philistines had done to Saul;
 12. All the valiant men arose, and went all night, and took the body of Saul and the bodies of his sons from the wall of Beth–shan, and came to Jabesh, and burnt them there.
-13. And they took their bones, and buried /them/ under a tree at Jabesh, and fasted seven days.  
+13. And they took their bones, and buried /them/ under a tree at Jabesh, and fasted seven days.

--- a/10_2SA.org
+++ b/10_2SA.org
@@ -28,7 +28,7 @@
 24. Ye daughters of Israel, weep over Saul, who clothed you in scarlet, with /other/ delights, who put on ornaments of gold upon your apparel.
 25. How are the mighty fallen in the midst of the battle! O Jonathan, /thou wast/ slain in thine high places.
 26. I am distressed for thee, my brother Jonathan: very pleasant hast thou been unto me: thy love to me was wonderful, passing the love of women.
-27. How are the mighty fallen, and the weapons of war perished! 
+27. How are the mighty fallen, and the weapons of war perished!
 * 2
 1. And it came to pass after this, that David enquired of the LORD, saying, Shall I go up into any of the cities of Judah? And the LORD said unto him, Go up. And David said, Whither shall I go up? And he said, Unto Hebron.
 2. So David went up thither, and his two wives also, Ahinoam the Jezreelitess, and Abigail Nabal's wife the Carmelite.
@@ -67,7 +67,7 @@
 30. And Joab returned from following Abner: and when he had gathered all the people together, there lacked of David's servants nineteen men and Asahel.
 31. But the servants of David had smitten of Benjamin, and of Abner's men, /so that/ three hundred and threescore men died.
 
-32. And they took up Asahel, and buried him in the sepulchre of his father, which /was in/ Beth–lehem. And Joab and his men went all night, and they came to Hebron at break of day. 
+32. And they took up Asahel, and buried him in the sepulchre of his father, which /was in/ Beth–lehem. And Joab and his men went all night, and they came to Hebron at break of day.
 * 3
 1. Now there was long war between the house of Saul and the house of David: but David waxed stronger and stronger, and the house of Saul waxed weaker and weaker.
 
@@ -115,7 +115,7 @@
 36. And all the people took notice /of it/, and it pleased them: as whatsoever the king did pleased all the people.
 37. For all the people and all Israel understood that day that it was not of the king to slay Abner the son of Ner.
 38. And the king said unto his servants, Know ye not that there is a prince and a great man fallen this day in Israel?
-39. And I /am/ this day weak, though anointed king; and these men the sons of Zeruiah /be/ too hard for me: the LORD shall reward the doer of evil according to his wickedness. 
+39. And I /am/ this day weak, though anointed king; and these men the sons of Zeruiah /be/ too hard for me: the LORD shall reward the doer of evil according to his wickedness.
 * 4
 1. And when Saul's son heard that Abner was dead in Hebron, his hands were feeble, and all the Israelites were troubled.
 2. And Saul's son had two men /that were/ captains of bands: the name of the one /was/ Baanah, and the name of the other Rechab, the sons of Rimmon a Beerothite, of the children of Benjamin: (for Beeroth also was reckoned to Benjamin:
@@ -129,7 +129,7 @@
 9. And David answered Rechab and Baanah his brother, the sons of Rimmon the Beerothite, and said unto them, /As/ the LORD liveth, who hath redeemed my soul out of all adversity,
 10. When one told me, saying, Behold, Saul is dead, thinking to have brought good tidings, I took hold of him, and slew him in Ziklag, who /thought/ that I would have given him a reward for his tidings:
 11. How much more, when wicked men have slain a righteous person in his own house upon his bed? shall I not therefore now require his blood of your hand, and take you away from the earth?
-12. And David commanded his young men, and they slew them, and cut off their hands and their feet, and hanged /them/ up over the pool in Hebron. But they took the head of Ish–bosheth, and buried /it/ in the sepulchre of Abner in Hebron. 
+12. And David commanded his young men, and they slew them, and cut off their hands and their feet, and hanged /them/ up over the pool in Hebron. But they took the head of Ish–bosheth, and buried /it/ in the sepulchre of Abner in Hebron.
 * 5
 1. Then came all the tribes of Israel to David unto Hebron, and spake, saying, Behold, we /are/ thy bone and thy flesh.
 2. Also in time past, when Saul was king over us, thou wast he that leddest out and broughtest in Israel: and the LORD said to thee, Thou shalt feed my people Israel, and thou shalt be a captain over Israel.
@@ -161,7 +161,7 @@
 22. And the Philistines came up yet again, and spread themselves in the valley of Rephaim.
 23. And when David enquired of the LORD, he said, Thou shalt not go up; /but/ fetch a compass behind them, and come upon them over against the mulberry trees.
 24. And let it be, when thou hearest the sound of a going in the tops of the mulberry trees, that then thou shalt bestir thyself: for then shall the LORD go out before thee, to smite the host of the Philistines.
-25. And David did so, as the LORD had commanded him; and smote the Philistines from Geba until thou come to Gazer. 
+25. And David did so, as the LORD had commanded him; and smote the Philistines from Geba until thou come to Gazer.
 * 6
 1. Again, David gathered together all /the/ chosen /men/ of Israel, thirty thousand.
 2. And David arose, and went with all the people that /were/ with him from Baale of Judah, to bring up from thence the ark of God, whose name is called by the name of the LORD of hosts that dwelleth /between/ the cherubims.
@@ -189,7 +189,7 @@
 20. Then David returned to bless his household. And Michal the daughter of Saul came out to meet David, and said, How glorious was the king of Israel to day, who uncovered himself to day in the eyes of the handmaids of his servants, as one of the vain fellows shamelessly uncovereth himself!
 21. And David said unto Michal, /It was/ before the LORD, which chose me before thy father, and before all his house, to appoint me ruler over the people of the LORD, over Israel: therefore will I play before the LORD.
 22. And I will yet be more vile than thus, and will be base in mine own sight: and of the maidservants which thou hast spoken of, of them shall I be had in honour.
-23. Therefore Michal the daughter of Saul had no child unto the day of her death. 
+23. Therefore Michal the daughter of Saul had no child unto the day of her death.
 * 7
 1. And it came to pass, when the king sat in his house, and the LORD had given him rest round about from all his enemies;
 2. That the king said unto Nathan the prophet, See now, I dwell in an house of cedar, but the ark of God dwelleth within curtains.
@@ -222,7 +222,7 @@
 26. And let thy name be magnified for ever, saying, The LORD of hosts /is/ the God over Israel: and let the house of thy servant David be established before thee.
 27. For thou, O LORD of hosts, God of Israel, hast revealed to thy servant, saying, I will build thee an house: therefore hath thy servant found in his heart to pray this prayer unto thee.
 28. And now, O Lord GOD, thou /art/ that God, and thy words be true, and thou hast promised this goodness unto thy servant:
-29. Therefore now let it please thee to bless the house of thy servant, that it may continue for ever before thee: for thou, O Lord GOD, hast spoken /it/: and with thy blessing let the house of thy servant be blessed for ever. 
+29. Therefore now let it please thee to bless the house of thy servant, that it may continue for ever before thee: for thou, O Lord GOD, hast spoken /it/: and with thy blessing let the house of thy servant be blessed for ever.
 * 8
 1. And after this it came to pass, that David smote the Philistines, and subdued them: and David took Metheg–ammah out of the hand of the Philistines.
 2. And he smote Moab, and measured them with a line, casting them down to the ground; even with two lines measured he to put to death, and with one full line to keep alive. And /so/ the Moabites became David's servants, /and/ brought gifts.
@@ -244,7 +244,7 @@
 15. And David reigned over all Israel; and David executed judgment and justice unto all his people.
 16. And Joab the son of Zeruiah /was/ over the host; and Jehoshaphat the son of Ahilud /was/ recorder;
 17. And Zadok the son of Ahitub, and Ahimelech the son of Abiathar, /were/ the priests; and Seraiah /was/ the scribe;
-18. And Benaiah the son of Jehoiada /was over/ both the Cherethites and the Pelethites; and David's sons were chief rulers. 
+18. And Benaiah the son of Jehoiada /was over/ both the Cherethites and the Pelethites; and David's sons were chief rulers.
 * 9
 1. And David said, Is there yet any that is left of the house of Saul, that I may shew him kindness for Jonathan's sake?
 2. And /there was/ of the house of Saul a servant whose name /was/ Ziba. And when they had called him unto David, the king said unto him, /Art/ thou Ziba? And he said, Thy servant /is he/.
@@ -261,7 +261,7 @@
 10. Thou therefore, and thy sons, and thy servants, shall till the land for him, and thou shalt bring in /the fruits/, that thy master's son may have food to eat: but Mephibosheth thy master's son shall eat bread alway at my table. Now Ziba had fifteen sons and twenty servants.
 11. Then said Ziba unto the king, According to all that my lord the king hath commanded his servant, so shall thy servant do. As for Mephibosheth, /said the king/, he shall eat at my table, as one of the king's sons.
 12. And Mephibosheth had a young son, whose name /was/ Micha. And all that dwelt in the house of Ziba /were/ servants unto Mephibosheth.
-13. So Mephibosheth dwelt in Jerusalem: for he did eat continually at the king's table; and was lame on both his feet. 
+13. So Mephibosheth dwelt in Jerusalem: for he did eat continually at the king's table; and was lame on both his feet.
 * 10
 1. And it came to pass after this, that the king of the children of Ammon died, and Hanun his son reigned in his stead.
 2. Then said David, I will shew kindness unto Hanun the son of Nahash, as his father shewed kindness unto me. And David sent to comfort him by the hand of his servants for his father. And David's servants came into the land of the children of Ammon.
@@ -283,7 +283,7 @@
 16. And Hadarezer sent, and brought out the Syrians that /were/ beyond the river: and they came to Helam; and Shobach the captain of the host of Hadarezer /went/ before them.
 17. And when it was told David, he gathered all Israel together, and passed over Jordan, and came to Helam. And the Syrians set themselves in array against David, and fought with him.
 18. And the Syrians fled before Israel; and David slew /the men of/ seven hundred chariots of the Syrians, and forty thousand horsemen, and smote Shobach the captain of their host, who died there.
-19. And when all the kings /that were/ servants to Hadarezer saw that they were smitten before Israel, they made peace with Israel, and served them. So the Syrians feared to help the children of Ammon any more. 
+19. And when all the kings /that were/ servants to Hadarezer saw that they were smitten before Israel, they made peace with Israel, and served them. So the Syrians feared to help the children of Ammon any more.
 * 11
 1. And it came to pass, after the year was expired, at the time when kings go forth /to battle/, that David sent Joab, and his servants with him, and all Israel; and they destroyed the children of Ammon, and besieged Rabbah. But David tarried still at Jerusalem.
 
@@ -317,7 +317,7 @@
 25. Then David said unto the messenger, Thus shalt thou say unto Joab, Let not this thing displease thee, for the sword devoureth one as well as another: make thy battle more strong against the city, and overthrow it: and encourage thou him.
 
 26. And when the wife of Uriah heard that Uriah her husband was dead, she mourned for her husband.
-27. And when the mourning was past, David sent and fetched her to his house, and she became his wife, and bare him a son. But the thing that David had done displeased the LORD. 
+27. And when the mourning was past, David sent and fetched her to his house, and she became his wife, and bare him a son. But the thing that David had done displeased the LORD.
 * 12
 1. And the LORD sent Nathan unto David. And he came unto him, and said unto him, There were two men in one city; the one rich, and the other poor.
 2. The rich /man/ had exceeding many flocks and herds:
@@ -353,7 +353,7 @@
 28. Now therefore gather the rest of the people together, and encamp against the city, and take it: lest I take the city, and it be called after my name.
 29. And David gathered all the people together, and went to Rabbah, and fought against it, and took it.
 30. And he took their king's crown from off his head, the weight whereof /was/ a talent of gold with the precious stones: and it was /set/ on David's head. And he brought forth the spoil of the city in great abundance.
-31. And he brought forth the people that /were/ therein, and put /them/ under saws, and under harrows of iron, and under axes of iron, and made them pass through the brickkiln: and thus did he unto all the cities of the children of Ammon. So David and all the people returned unto Jerusalem. 
+31. And he brought forth the people that /were/ therein, and put /them/ under saws, and under harrows of iron, and under axes of iron, and made them pass through the brickkiln: and thus did he unto all the cities of the children of Ammon. So David and all the people returned unto Jerusalem.
 * 13
 1. And it came to pass after this, that Absalom the son of David had a fair sister, whose name /was/ Tamar; and Amnon the son of David loved her.
 2. And Amnon was so vexed, that he fell sick for his sister Tamar; for she /was/ a virgin; and Amnon thought it hard for him to do any thing to her.
@@ -401,7 +401,7 @@
 
 37. But Absalom fled, and went to Talmai, the son of Ammihud, king of Geshur. And /David/ mourned for his son every day.
 38. So Absalom fled, and went to Geshur, and was there three years.
-39. And /the soul of/ king David longed to go forth unto Absalom: for he was comforted concerning Amnon, seeing he was dead. 
+39. And /the soul of/ king David longed to go forth unto Absalom: for he was comforted concerning Amnon, seeing he was dead.
 * 14
 1. Now Joab the son of Zeruiah perceived that the king's heart /was/ toward Absalom.
 2. And Joab sent to Tekoah, and fetched thence a wise woman, and said unto her, I pray thee, feign thyself to be a mourner, and put on now mourning apparel, and anoint not thyself with oil, but be as a woman that had a long time mourned for the dead:
@@ -439,7 +439,7 @@
 30. Therefore he said unto his servants, See, Joab's field is near mine, and he hath barley there; go and set it on fire. And Absalom's servants set the field on fire.
 31. Then Joab arose, and came to Absalom unto /his/ house, and said unto him, Wherefore have thy servants set my field on fire?
 32. And Absalom answered Joab, Behold, I sent unto thee, saying, Come hither, that I may send thee to the king, to say, Wherefore am I come from Geshur? /it had been/ good for me /to have been/ there still: now therefore let me see the king's face; and if there be /any/ iniquity in me, let him kill me.
-33. So Joab came to the king, and told him: and when he had called for Absalom, he came to the king, and bowed himself on his face to the ground before the king: and the king kissed Absalom. 
+33. So Joab came to the king, and told him: and when he had called for Absalom, he came to the king, and bowed himself on his face to the ground before the king: and the king kissed Absalom.
 * 15
 1. And it came to pass after this, that Absalom prepared him chariots and horses, and fifty men to run before him.
 2. And Absalom rose up early, and stood beside the way of the gate: and it was /so/, that when any man that had a controversy came to the king for judgment, then Absalom called unto him, and said, Of what city /art/ thou? And he said, Thy servant /is/ of one of the tribes of Israel.
@@ -485,7 +485,7 @@
 34. But if thou return to the city, and say unto Absalom, I will be thy servant, O king; /as/ I /have been/ thy father's servant hitherto, so /will/ I now also /be/ thy servant: then mayest thou for me defeat the counsel of Ahithophel.
 35. And /hast thou/ not there with thee Zadok and Abiathar the priests? therefore it shall be, /that/ what thing soever thou shalt hear out of the king's house, thou shalt tell /it/ to Zadok and Abiathar the priests.
 36. Behold, /they have/ there with them their two sons, Ahimaaz Zadok's /son/, and Jonathan Abiathar's /son/; and by them ye shall send unto me every thing that ye can hear.
-37. So Hushai David's friend came into the city, and Absalom came into Jerusalem. 
+37. So Hushai David's friend came into the city, and Absalom came into Jerusalem.
 * 16
 1. And when David was a little past the top /of the hill/, behold, Ziba the servant of Mephibosheth met him, with a couple of asses saddled, and upon them two hundred /loaves/ of bread, and an hundred bunches of raisins, and an hundred of summer fruits, and a bottle of wine.
 2. And the king said unto Ziba, What meanest thou by these? And Ziba said, The asses /be/ for the king's household to ride on; and the bread and summer fruit for the young men to eat; and the wine, that such as be faint in the wilderness may drink.
@@ -513,7 +513,7 @@
 20. Then said Absalom to Ahithophel, Give counsel among you what we shall do.
 21. And Ahithophel said unto Absalom, Go in unto thy father's concubines, which he hath left to keep the house; and all Israel shall hear that thou art abhorred of thy father: then shall the hands of all that /are/ with thee be strong.
 22. So they spread Absalom a tent upon the top of the house; and Absalom went in unto his father's concubines in the sight of all Israel.
-23. And the counsel of Ahithophel, which he counselled in those days, /was/ as if a man had enquired at the oracle of God: so /was/ all the counsel of Ahithophel both with David and with Absalom. 
+23. And the counsel of Ahithophel, which he counselled in those days, /was/ as if a man had enquired at the oracle of God: so /was/ all the counsel of Ahithophel both with David and with Absalom.
 * 17
 1. Moreover Ahithophel said unto Absalom, Let me now choose out twelve thousand men, and I will arise and pursue after David this night:
 2. And I will come upon him while he /is/ weary and weak handed, and will make him afraid: and all the people that /are/ with him shall flee; and I will smite the king only:
@@ -547,7 +547,7 @@
 
 27. And it came to pass, when David was come to Mahanaim, that Shobi the son of Nahash of Rabbah of the children of Ammon, and Machir the son of Ammiel of Lo–debar, and Barzillai the Gileadite of Rogelim,
 28. Brought beds, and basons, and earthen vessels, and wheat, and barley, and flour, and parched /corn/, and beans, and lentiles, and parched /pulse/,
-29. And honey, and butter, and sheep, and cheese of kine, for David, and for the people that /were/ with him, to eat: for they said, The people /is/ hungry, and weary, and thirsty, in the wilderness. 
+29. And honey, and butter, and sheep, and cheese of kine, for David, and for the people that /were/ with him, to eat: for they said, The people /is/ hungry, and weary, and thirsty, in the wilderness.
 * 18
 1. And David numbered the people that /were/ with him, and set captains of thousands and captains of hundreds over them.
 2. And David sent forth a third part of the people under the hand of Joab, and a third part under the hand of Abishai the son of Zeruiah, Joab's brother, and a third part under the hand of Ittai the Gittite. And the king said unto the people, I will surely go forth with you myself also.
@@ -586,7 +586,7 @@
 31. And, behold, Cushi came; and Cushi said, Tidings, my lord the king: for the LORD hath avenged thee this day of all them that rose up against thee.
 32. And the king said unto Cushi, Is the young man Absalom safe? And Cushi answered, The enemies of my lord the king, and all that rise against thee to do /thee/ hurt, be as /that/ young man /is/.
 
-33. And the king was much moved, and went up to the chamber over the gate, and wept: and as he went, thus he said, O my son Absalom, my son, my son Absalom! would God I had died for thee, O Absalom, my son, my son! 
+33. And the king was much moved, and went up to the chamber over the gate, and wept: and as he went, thus he said, O my son Absalom, my son, my son Absalom! would God I had died for thee, O Absalom, my son, my son!
 * 19
 1. And it was told Joab, Behold, the king weepeth and mourneth for Absalom.
 2. And the victory that day was /turned/ into mourning unto all the people: for the people heard say that day how the king was grieved for his son.
@@ -636,7 +636,7 @@
 
 41. And, behold, all the men of Israel came to the king, and said unto the king, Why have our brethren the men of Judah stolen thee away, and have brought the king, and his household, and all David's men with him, over Jordan?
 42. And all the men of Judah answered the men of Israel, Because the king /is/ near of kin to us: wherefore then be ye angry for this matter? have we eaten at all of the king's /cost/? or hath he given us any gift?
-43. And the men of Israel answered the men of Judah, and said, We have ten parts in the king, and we have also more /right/ in David than ye: why then did ye despise us, that our advice should not be first had in bringing back our king? And the words of the men of Judah were fiercer than the words of the men of Israel. 
+43. And the men of Israel answered the men of Judah, and said, We have ten parts in the king, and we have also more /right/ in David than ye: why then did ye despise us, that our advice should not be first had in bringing back our king? And the words of the men of Judah were fiercer than the words of the men of Israel.
 * 20
 1. And there happened to be there a man of Belial, whose name /was/ Sheba, the son of Bichri, a Benjamite: and he blew a trumpet, and said, We have no part in David, neither have we inheritance in the son of Jesse: every man to his tents, O Israel.
 2. So every man of Israel went up from after David, /and/ followed Sheba the son of Bichri: but the men of Judah clave unto their king, from Jordan even to Jerusalem.
@@ -668,7 +668,7 @@
 23. Now Joab /was/ over all the host of Israel: and Benaiah the son of Jehoiada /was/ over the Cherethites and over the Pelethites:
 24. And Adoram /was/ over the tribute: and Jehoshaphat the son of Ahilud /was/ recorder:
 25. And Sheva /was/ scribe: and Zadok and Abiathar /were/ the priests:
-26. And Ira also the Jairite was a chief ruler about David. 
+26. And Ira also the Jairite was a chief ruler about David.
 * 21
 1. Then there was a famine in the days of David three years, year after year; and David enquired of the LORD. And the LORD answered, /It is/ for Saul, and for /his/ bloody house, because he slew the Gibeonites.
 2. And the king called the Gibeonites, and said unto them; (now the Gibeonites /were/ not of the children of Israel, but of the remnant of the Amorites; and the children of Israel had sworn unto them: and Saul sought to slay them in his zeal to the children of Israel and Judah.)
@@ -694,7 +694,7 @@
 19. And there was again a battle in Gob with the Philistines, where Elhanan the son of Jaare–oregim, a Beth–lehemite, slew /the brother of/ Goliath the Gittite, the staff of whose spear /was/ like a weaver's beam.
 20. And there was yet a battle in Gath, where was a man of /great/ stature, that had on every hand six fingers, and on every foot six toes, four and twenty in number; and he also was born to the giant.
 21. And when he defied Israel, Jonathan the son of Shimea the brother of David slew him.
-22. These four were born to the giant in Gath, and fell by the hand of David, and by the hand of his servants. 
+22. These four were born to the giant in Gath, and fell by the hand of David, and by the hand of his servants.
 * 22
 1. And David spake unto the LORD the words of this song in the day /that/ the LORD had delivered him out of the hand of all his enemies, and out of the hand of Saul:
 2. And he said, The LORD /is/ my rock, and my fortress, and my deliverer;
@@ -746,7 +746,7 @@
 48. It /is/ God that avengeth me, and that bringeth down the people under me,
 49. And that bringeth me forth from mine enemies: thou also hast lifted me up on high above them that rose up against me: thou hast delivered me from the violent man.
 50. Therefore I will give thanks unto thee, O LORD, among the heathen, and I will sing praises unto thy name.
-51. /He is/ the tower of salvation for his king: and sheweth mercy to his anointed, unto David, and to his seed for evermore. 
+51. /He is/ the tower of salvation for his king: and sheweth mercy to his anointed, unto David, and to his seed for evermore.
 * 23
 1. Now these /be/ the last words of David. David the son of Jesse said, and the man /who was/ raised up on high, the anointed of the God of Jacob, and the sweet psalmist of Israel, said,
 2. The Spirit of the LORD spake by me, and his word /was/ in my tongue.
@@ -788,7 +788,7 @@
 36. Igal the son of Nathan of Zobah, Bani the Gadite,
 37. Zelek the Ammonite, Naharai the Beerothite, armourbearer to Joab the son of Zeruiah,
 38. Ira an Ithrite, Gareb an Ithrite,
-39. Uriah the Hittite: thirty and seven in all. 
+39. Uriah the Hittite: thirty and seven in all.
 * 24
 1. And again the anger of the LORD was kindled against Israel, and he moved David against them to say, Go, number Israel and Judah.
 2. For the king said to Joab the captain of the host, which /was/ with him, Go now through all the tribes of Israel, from Dan even to Beer–sheba, and number ye the people, that I may know the number of the people.
@@ -818,4 +818,4 @@
 22. And Araunah said unto David, Let my lord the king take and offer up what /seemeth/ good unto him: behold, /here be/ oxen for burnt sacrifice, and threshing instruments and /other/ instruments of the oxen for wood.
 23. All these /things/ did Araunah, /as/ a king, give unto the king. And Araunah said unto the king, The LORD thy God accept thee.
 24. And the king said unto Araunah, Nay; but I will surely buy /it/ of thee at a price: neither will I offer burnt offerings unto the LORD my God of that which doth cost me nothing. So David bought the threshingfloor and the oxen for fifty shekels of silver.
-25. And David built there an altar unto the LORD, and offered burnt offerings and peace offerings. So the LORD was intreated for the land, and the plague was stayed from Israel.  
+25. And David built there an altar unto the LORD, and offered burnt offerings and peace offerings. So the LORD was intreated for the land, and the plague was stayed from Israel.

--- a/11_1KI.org
+++ b/11_1KI.org
@@ -60,7 +60,7 @@
 50. And Adonijah feared because of Solomon, and arose, and went, and caught hold on the horns of the altar.
 51. And it was told Solomon, saying, Behold, Adonijah feareth king Solomon: for, lo, he hath caught hold on the horns of the altar, saying, Let king Solomon swear unto me to day that he will not slay his servant with the sword.
 52. And Solomon said, If he will shew himself a worthy man, there shall not an hair of him fall to the earth: but if wickedness shall be found in him, he shall die.
-53. So king Solomon sent, and they brought him down from the altar. And he came and bowed himself to king Solomon: and Solomon said unto him, Go to thine house. 
+53. So king Solomon sent, and they brought him down from the altar. And he came and bowed himself to king Solomon: and Solomon said unto him, Go to thine house.
 * 2
 1. Now the days of David drew nigh that he should die; and he charged Solomon his son, saying,
 2. I go the way of all the earth: be thou strong therefore, and shew thyself a man;
@@ -114,7 +114,7 @@
 43. Why then hast thou not kept the oath of the LORD, and the commandment that I have charged thee with?
 44. The king said moreover to Shimei, Thou knowest all the wickedness which thine heart is privy to, that thou didst to David my father: therefore the LORD shall return thy wickedness upon thine own head;
 45. And king Solomon /shall be/ blessed, and the throne of David shall be established before the LORD for ever.
-46. So the king commanded Benaiah the son of Jehoiada; which went out, and fell upon him, that he died. And the kingdom was established in the hand of Solomon. 
+46. So the king commanded Benaiah the son of Jehoiada; which went out, and fell upon him, that he died. And the kingdom was established in the hand of Solomon.
 * 3
 1. And Solomon made affinity with Pharaoh king of Egypt, and took Pharaoh's daughter, and brought her into the city of David, until he had made an end of building his own house, and the house of the LORD, and the wall of Jerusalem round about.
 2. Only the people sacrificed in high places, because there was no house built unto the name of the LORD, until those days.
@@ -145,7 +145,7 @@
 25. And the king said, Divide the living child in two, and give half to the one, and half to the other.
 26. Then spake the woman whose the living child /was/ unto the king, for her bowels yearned upon her son, and she said, O my lord, give her the living child, and in no wise slay it. But the other said, Let it be neither mine nor thine, /but/ divide /it/.
 27. Then the king answered and said, Give her the living child, and in no wise slay it: she /is/ the mother thereof.
-28. And all Israel heard of the judgment which the king had judged; and they feared the king: for they saw that the wisdom of God /was/ in him, to do judgment. 
+28. And all Israel heard of the judgment which the king had judged; and they feared the king: for they saw that the wisdom of God /was/ in him, to do judgment.
 * 4
 1. So king Solomon was king over all Israel.
 2. And these /were/ the princes which he had; Azariah the son of Zadok the priest,
@@ -185,7 +185,7 @@
 31. For he was wiser than all men; than Ethan the Ezrahite, and Heman, and Chalcol, and Darda, the sons of Mahol: and his fame was in all nations round about.
 32. And he spake three thousand proverbs: and his songs were a thousand and five.
 33. And he spake of trees, from the cedar tree that /is/ in Lebanon even unto the hyssop that springeth out of the wall: he spake also of beasts, and of fowl, and of creeping things, and of fishes.
-34. And there came of all people to hear the wisdom of Solomon, from all kings of the earth, which had heard of his wisdom. 
+34. And there came of all people to hear the wisdom of Solomon, from all kings of the earth, which had heard of his wisdom.
 * 5
 1. And Hiram king of Tyre sent his servants unto Solomon; for he had heard that they had anointed him king in the room of his father: for Hiram was ever a lover of David.
 2. And Solomon sent to Hiram, saying,
@@ -206,7 +206,7 @@
 15. And Solomon had threescore and ten thousand that bare burdens, and fourscore thousand hewers in the mountains;
 16. Beside the chief of Solomon's officers which /were/ over the work, three thousand and three hundred, which ruled over the people that wrought in the work.
 17. And the king commanded, and they brought great stones, costly stones, /and/ hewed stones, to lay the foundation of the house.
-18. And Solomon's builders and Hiram's builders did hew /them/, and the stonesquarers: so they prepared timber and stones to build the house. 
+18. And Solomon's builders and Hiram's builders did hew /them/, and the stonesquarers: so they prepared timber and stones to build the house.
 * 6
 1. And it came to pass in the four hundred and eightieth year after the children of Israel were come out of the land of Egypt, in the fourth year of Solomon's reign over Israel, in the month Zif, which /is/ the second month, that he began to build the house of the LORD.
 2. And the house which king Solomon built for the LORD, the length thereof /was/ threescore cubits, and the breadth thereof twenty /cubits/, and the height thereof thirty cubits.
@@ -251,7 +251,7 @@
 36. And he built the inner court with three rows of hewed stone, and a row of cedar beams.
 
 37. In the fourth year was the foundation of the house of the LORD laid, in the month Zif:
-38. And in the eleventh year, in the month Bul, which /is/ the eighth month, was the house finished throughout all the parts thereof, and according to all the fashion of it. So was he seven years in building it. 
+38. And in the eleventh year, in the month Bul, which /is/ the eighth month, was the house finished throughout all the parts thereof, and according to all the fashion of it. So was he seven years in building it.
 * 7
 1. But Solomon was building his own house thirteen years, and he finished all his house.
 
@@ -312,7 +312,7 @@
 48. And Solomon made all the vessels that /pertained/ unto the house of the LORD: the altar of gold, and the table of gold, whereupon the shewbread /was/,
 49. And the candlesticks of pure gold, five on the right /side/, and five on the left, before the oracle, with the flowers, and the lamps, and the tongs /of/ gold,
 50. And the bowls, and the snuffers, and the basons, and the spoons, and the censers /of/ pure gold; and the hinges /of/ gold, /both/ for the doors of the inner house, the most holy /place, and/ for the doors of the house, /to wit/, of the temple.
-51. So was ended all the work that king Solomon made for the house of the LORD. And Solomon brought in the things which David his father had dedicated; /even/ the silver, and the gold, and the vessels, did he put among the treasures of the house of the LORD. 
+51. So was ended all the work that king Solomon made for the house of the LORD. And Solomon brought in the things which David his father had dedicated; /even/ the silver, and the gold, and the vessels, did he put among the treasures of the house of the LORD.
 * 8
 1. Then Solomon assembled the elders of Israel, and all the heads of the tribes, the chief of the fathers of the children of Israel, unto king Solomon in Jerusalem, that they might bring up the ark of the covenant of the LORD out of the city of David, which /is/ Zion.
 2. And all the men of Israel assembled themselves unto king Solomon at the feast in the month Ethanim, which /is/ the seventh month.
@@ -387,7 +387,7 @@
 63. And Solomon offered a sacrifice of peace offerings, which he offered unto the LORD, two and twenty thousand oxen, and an hundred and twenty thousand sheep. So the king and all the children of Israel dedicated the house of the LORD.
 64. The same day did the king hallow the middle of the court that /was/ before the house of the LORD: for there he offered burnt offerings, and meat offerings, and the fat of the peace offerings: because the brasen altar that /was/ before the LORD /was/ too little to receive the burnt offerings, and meat offerings, and the fat of the peace offerings.
 65. And at that time Solomon held a feast, and all Israel with him, a great congregation, from the entering in of Hamath unto the river of Egypt, before the LORD our God, seven days and seven days, /even/ fourteen days.
-66. On the eighth day he sent the people away: and they blessed the king, and went unto their tents joyful and glad of heart for all the goodness that the LORD had done for David his servant, and for Israel his people. 
+66. On the eighth day he sent the people away: and they blessed the king, and went unto their tents joyful and glad of heart for all the goodness that the LORD had done for David his servant, and for Israel his people.
 * 9
 1. And it came to pass, when Solomon had finished the building of the house of the LORD, and the king's house, and all Solomon's desire which he was pleased to do,
 2. That the LORD appeared to Solomon the second time, as he had appeared unto him at Gibeon.
@@ -421,7 +421,7 @@
 
 26. And king Solomon made a navy of ships in Ezion–geber, which /is/ beside Eloth, on the shore of the Red sea, in the land of Edom.
 27. And Hiram sent in the navy his servants, shipmen that had knowledge of the sea, with the servants of Solomon.
-28. And they came to Ophir, and fetched from thence gold, four hundred and twenty talents, and brought /it/ to king Solomon. 
+28. And they came to Ophir, and fetched from thence gold, four hundred and twenty talents, and brought /it/ to king Solomon.
 * 10
 1. And when the queen of Sheba heard of the fame of Solomon concerning the name of the LORD, she came to prove him with hard questions.
 2. And she came to Jerusalem with a very great train, with camels that bare spices, and very much gold, and precious stones: and when she was come to Solomon, she communed with him of all that was in her heart.
@@ -458,7 +458,7 @@
 27. And the king made silver /to be/ in Jerusalem as stones, and cedars made he /to be/ as the sycomore trees that /are/ in the vale, for abundance.
 
 28. And Solomon had horses brought out of Egypt, and linen yarn: the king's merchants received the linen yarn at a price.
-29. And a chariot came up and went out of Egypt for six hundred /shekels/ of silver, and an horse for an hundred and fifty: and so for all the kings of the Hittites, and for the kings of Syria, did they bring /them/ out by their means. 
+29. And a chariot came up and went out of Egypt for six hundred /shekels/ of silver, and an horse for an hundred and fifty: and so for all the kings of the Hittites, and for the kings of Syria, did they bring /them/ out by their means.
 * 11
 1. But king Solomon loved many strange women, together with the daughter of Pharaoh, women of the Moabites, Ammonites, Edomites, Zidonians, /and/ Hittites;
 2. Of the nations /concerning/ which the LORD said unto the children of Israel, Ye shall not go in to them, neither shall they come in unto you: /for/ surely they will turn away your heart after their gods: Solomon clave unto these in love.
@@ -507,7 +507,7 @@
 
 41. And the rest of the acts of Solomon, and all that he did, and his wisdom, /are/ they not written in the book of the acts of Solomon?
 42. And the time that Solomon reigned in Jerusalem over all Israel /was/ forty years.
-43. And Solomon slept with his fathers, and was buried in the city of David his father: and Rehoboam his son reigned in his stead. 
+43. And Solomon slept with his fathers, and was buried in the city of David his father: and Rehoboam his son reigned in his stead.
 * 12
 1. And Rehoboam went to Shechem: for all Israel were come to Shechem to make him king.
 2. And it came to pass, when Jeroboam the son of Nebat, who was yet in Egypt, heard /of it/, (for he was fled from the presence of king Solomon, and Jeroboam dwelt in Egypt;)
@@ -546,7 +546,7 @@
 30. And this thing became a sin: for the people went /to worship/ before the one, /even/ unto Dan.
 31. And he made an house of high places, and made priests of the lowest of the people, which were not of the sons of Levi.
 32. And Jeroboam ordained a feast in the eighth month, on the fifteenth day of the month, like unto the feast that /is/ in Judah, and he offered upon the altar. So did he in Beth–el, sacrificing unto the calves that he had made: and he placed in Beth–el the priests of the high places which he had made.
-33. So he offered upon the altar which he had made in Beth–el the fifteenth day of the eighth month, /even/ in the month which he had devised of his own heart; and ordained a feast unto the children of Israel: and he offered upon the altar, and burnt incense. 
+33. So he offered upon the altar which he had made in Beth–el the fifteenth day of the eighth month, /even/ in the month which he had devised of his own heart; and ordained a feast unto the children of Israel: and he offered upon the altar, and burnt incense.
 * 13
 1. And, behold, there came a man of God out of Judah by the word of the LORD unto Beth–el: and Jeroboam stood by the altar to burn incense.
 2. And he cried against the altar in the word of the LORD, and said, O altar, altar, thus saith the LORD; Behold, a child shall be born unto the house of David, Josiah by name; and upon thee shall he offer the priests of the high places that burn incense upon thee, and men's bones shall be burnt upon thee.
@@ -585,7 +585,7 @@
 32. For the saying which he cried by the word of the LORD against the altar in Beth–el, and against all the houses of the high places which /are/ in the cities of Samaria, shall surely come to pass.
 
 33. After this thing Jeroboam returned not from his evil way, but made again of the lowest of the people priests of the high places: whosoever would, he consecrated him, and he became /one/ of the priests of the high places.
-34. And this thing became sin unto the house of Jeroboam, even to cut /it/ off, and to destroy /it/ from off the face of the earth. 
+34. And this thing became sin unto the house of Jeroboam, even to cut /it/ off, and to destroy /it/ from off the face of the earth.
 * 14
 1. At that time Abijah the son of Jeroboam fell sick.
 2. And Jeroboam said to his wife, Arise, I pray thee, and disguise thyself, that thou be not known to be the wife of Jeroboam; and get thee to Shiloh: behold, there /is/ Ahijah the prophet, which told me that /I should be/ king over this people.
@@ -622,7 +622,7 @@
 
 29. Now the rest of the acts of Rehoboam, and all that he did, /are/ they not written in the book of the chronicles of the kings of Judah?
 30. And there was war between Rehoboam and Jeroboam all /their/ days.
-31. And Rehoboam slept with his fathers, and was buried with his fathers in the city of David. And his mother's name /was/ Naamah an Ammonitess. And Abijam his son reigned in his stead. 
+31. And Rehoboam slept with his fathers, and was buried with his fathers in the city of David. And his mother's name /was/ Naamah an Ammonitess. And Abijam his son reigned in his stead.
 * 15
 1. Now in the eighteenth year of king Jeroboam the son of Nebat reigned Abijam over Judah.
 2. Three years reigned he in Jerusalem. And his mother's name /was/ Maachah, the daughter of Abishalom.
@@ -662,7 +662,7 @@
 31. Now the rest of the acts of Nadab, and all that he did, /are/ they not written in the book of the chronicles of the kings of Israel?
 32. And there was war between Asa and Baasha king of Israel all their days.
 33. In the third year of Asa king of Judah began Baasha the son of Ahijah to reign over all Israel in Tirzah, twenty and four years.
-34. And he did evil in the sight of the LORD, and walked in the way of Jeroboam, and in his sin wherewith he made Israel to sin. 
+34. And he did evil in the sight of the LORD, and walked in the way of Jeroboam, and in his sin wherewith he made Israel to sin.
 * 16
 1. Then the word of the LORD came to Jehu the son of Hanani against Baasha, saying,
 2. Forasmuch as I exalted thee out of the dust, and made thee prince over my people Israel; and thou hast walked in the way of Jeroboam, and hast made my people Israel to sin, to provoke me to anger with their sins;
@@ -705,7 +705,7 @@
 32. And he reared up an altar for Baal in the house of Baal, which he had built in Samaria.
 33. And Ahab made a grove; and Ahab did more to provoke the LORD God of Israel to anger than all the kings of Israel that were before him.
 
-34. In his days did Hiel the Beth–elite build Jericho: he laid the foundation thereof in Abiram his firstborn, and set up the gates thereof in his youngest /son/ Segub, according to the word of the LORD, which he spake by Joshua the son of Nun. 
+34. In his days did Hiel the Beth–elite build Jericho: he laid the foundation thereof in Abiram his firstborn, and set up the gates thereof in his youngest /son/ Segub, according to the word of the LORD, which he spake by Joshua the son of Nun.
 * 17
 1. And Elijah the Tishbite, /who was/ of the inhabitants of Gilead, said unto Ahab, /As/ the LORD God of Israel liveth, before whom I stand, there shall not be dew nor rain these years, but according to my word.
 2. And the word of the LORD came unto him, saying,
@@ -733,7 +733,7 @@
 22. And the LORD heard the voice of Elijah; and the soul of the child came into him again, and he revived.
 23. And Elijah took the child, and brought him down out of the chamber into the house, and delivered him unto his mother: and Elijah said, See, thy son liveth.
 
-24. And the woman said to Elijah, Now by this I know that thou /art/ a man of God, /and/ that the word of the LORD in thy mouth /is/ truth. 
+24. And the woman said to Elijah, Now by this I know that thou /art/ a man of God, /and/ that the word of the LORD in thy mouth /is/ truth.
 * 18
 1. And it came to pass /after/ many days, that the word of the LORD came to Elijah in the third year, saying, Go, shew thyself unto Ahab; and I will send rain upon the earth.
 2. And Elijah went to shew himself unto Ahab. And /there was/ a sore famine in Samaria.
@@ -783,7 +783,7 @@
 43. And said to his servant, Go up now, look toward the sea. And he went up, and looked, and said, /There is/ nothing. And he said, Go again seven times.
 44. And it came to pass at the seventh time, that he said, Behold, there ariseth a little cloud out of the sea, like a man's hand. And he said, Go up, say unto Ahab, Prepare /thy chariot/, and get thee down, that the rain stop thee not.
 45. And it came to pass in the mean while, that the heaven was black with clouds and wind, and there was a great rain. And Ahab rode, and went to Jezreel.
-46. And the hand of the LORD was on Elijah; and he girded up his loins, and ran before Ahab to the entrance of Jezreel. 
+46. And the hand of the LORD was on Elijah; and he girded up his loins, and ran before Ahab to the entrance of Jezreel.
 * 19
 1. And Ahab told Jezebel all that Elijah had done, and withal how he had slain all the prophets with the sword.
 2. Then Jezebel sent a messenger unto Elijah, saying, So let the gods do /to me/, and more also, if I make not thy life as the life of one of them by to morrow about this time.
@@ -808,7 +808,7 @@
 
 19. So he departed thence, and found Elisha the son of Shaphat, who /was/ plowing /with/ twelve yoke /of oxen/ before him, and he with the twelfth: and Elijah passed by him, and cast his mantle upon him.
 20. And he left the oxen, and ran after Elijah, and said, Let me, I pray thee, kiss my father and my mother, and /then/ I will follow thee. And he said unto him, Go back again: for what have I done to thee?
-21. And he returned back from him, and took a yoke of oxen, and slew them, and boiled their flesh with the instruments of the oxen, and gave unto the people, and they did eat. Then he arose, and went after Elijah, and ministered unto him. 
+21. And he returned back from him, and took a yoke of oxen, and slew them, and boiled their flesh with the instruments of the oxen, and gave unto the people, and they did eat. Then he arose, and went after Elijah, and ministered unto him.
 * 20
 1. And Ben–hadad the king of Syria gathered all his host together: and /there were/ thirty and two kings with him, and horses, and chariots: and he went up and besieged Samaria, and warred against it.
 2. And he sent messengers to Ahab king of Israel into the city, and said unto him, Thus saith Ben–hadad,
@@ -857,7 +857,7 @@
 40. And as thy servant was busy here and there, he was gone. And the king of Israel said unto him, So /shall/ thy judgment /be/; thyself hast decided /it/.
 41. And he hasted, and took the ashes away from his face; and the king of Israel discerned him that he /was/ of the prophets.
 42. And he said unto him, Thus saith the LORD, Because thou hast let go out of /thy/ hand a man whom I appointed to utter destruction, therefore thy life shall go for his life, and thy people for his people.
-43. And the king of Israel went to his house heavy and displeased, and came to Samaria. 
+43. And the king of Israel went to his house heavy and displeased, and came to Samaria.
 * 21
 1. And it came to pass after these things, /that/ Naboth the Jezreelite had a vineyard, which /was/ in Jezreel, hard by the palace of Ahab king of Samaria.
 2. And Ahab spake unto Naboth, saying, Give me thy vineyard, that I may have it for a garden of herbs, because it /is/ near unto my house: and I will give thee for it a better vineyard than it; /or/, if it seem good to thee, I will give thee the worth of it in money.
@@ -891,7 +891,7 @@
 26. And he did very abominably in following idols, according to all /things/ as did the Amorites, whom the LORD cast out before the children of Israel.
 27. And it came to pass, when Ahab heard those words, that he rent his clothes, and put sackcloth upon his flesh, and fasted, and lay in sackcloth, and went softly.
 28. And the word of the LORD came to Elijah the Tishbite, saying,
-29. Seest thou how Ahab humbleth himself before me? because he humbleth himself before me, I will not bring the evil in his days: /but/ in his son's days will I bring the evil upon his house. 
+29. Seest thou how Ahab humbleth himself before me? because he humbleth himself before me, I will not bring the evil in his days: /but/ in his son's days will I bring the evil upon his house.
 * 22
 1. And they continued three years without war between Syria and Israel.
 2. And it came to pass in the third year, that Jehoshaphat the king of Judah came down to the king of Israel.
@@ -950,4 +950,4 @@
 
 51. Ahaziah the son of Ahab began to reign over Israel in Samaria the seventeenth year of Jehoshaphat king of Judah, and reigned two years over Israel.
 52. And he did evil in the sight of the LORD, and walked in the way of his father, and in the way of his mother, and in the way of Jeroboam the son of Nebat, who made Israel to sin:
-53. For he served Baal, and worshipped him, and provoked to anger the LORD God of Israel, according to all that his father had done.  
+53. For he served Baal, and worshipped him, and provoked to anger the LORD God of Israel, according to all that his father had done.

--- a/12_2KI.org
+++ b/12_2KI.org
@@ -20,7 +20,7 @@
 16. And he said unto him, Thus saith the LORD, Forasmuch as thou hast sent messengers to enquire of Baal–zebub the god of Ekron, /is it/ not because /there is/ no God in Israel to enquire of his word? therefore thou shalt not come down off that bed on which thou art gone up, but shalt surely die.
 
 17. So he died according to the word of the LORD which Elijah had spoken. And Jehoram reigned in his stead in the second year of Jehoram the son of Jehoshaphat king of Judah; because he had no son.
-18. Now the rest of the acts of Ahaziah which he did, /are/ they not written in the book of the chronicles of the kings of Israel? 
+18. Now the rest of the acts of Ahaziah which he did, /are/ they not written in the book of the chronicles of the kings of Israel?
 * 2
 1. And it came to pass, when the LORD would take up Elijah into heaven by a whirlwind, that Elijah went with Elisha from Gilgal.
 2. And Elijah said unto Elisha, Tarry here, I pray thee; for the LORD hath sent me to Beth–el. And Elisha said /unto him, As/ the LORD liveth, and /as/ thy soul liveth, I will not leave thee. So they went down to Beth–el.
@@ -51,7 +51,7 @@
 
 23. And he went up from thence unto Beth–el: and as he was going up by the way, there came forth little children out of the city, and mocked him, and said unto him, Go up, thou bald head; go up, thou bald head.
 24. And he turned back, and looked on them, and cursed them in the name of the LORD. And there came forth two she bears out of the wood, and tare forty and two children of them.
-25. And he went from thence to mount Carmel, and from thence he returned to Samaria. 
+25. And he went from thence to mount Carmel, and from thence he returned to Samaria.
 * 3
 1. Now Jehoram the son of Ahab began to reign over Israel in Samaria the eighteenth year of Jehoshaphat king of Judah, and reigned twelve years.
 2. And he wrought evil in the sight of the LORD; but not like his father, and like his mother: for he put away the image of Baal that his father had made.
@@ -83,7 +83,7 @@
 25. And they beat down the cities, and on every good piece of land cast every man his stone, and filled it; and they stopped all the wells of water, and felled all the good trees: only in Kir–haraseth left they the stones thereof; howbeit the slingers went about /it/, and smote it.
 
 26. And when the king of Moab saw that the battle was too sore for him, he took with him seven hundred men that drew swords, to break through /even/ unto the king of Edom: but they could not.
-27. Then he took his eldest son that should have reigned in his stead, and offered him /for/ a burnt offering upon the wall. And there was great indignation against Israel: and they departed from him, and returned to /their own/ land. 
+27. Then he took his eldest son that should have reigned in his stead, and offered him /for/ a burnt offering upon the wall. And there was great indignation against Israel: and they departed from him, and returned to /their own/ land.
 * 4
 1. Now there cried a certain woman of the wives of the sons of the prophets unto Elisha, saying, Thy servant my husband is dead; and thou knowest that thy servant did fear the LORD: and the creditor is come to take unto him my two sons to be bondmen.
 2. And Elisha said unto her, What shall I do for thee? tell me, what hast thou in the house? And she said, Thine handmaid hath not any thing in the house, save a pot of oil.
@@ -132,7 +132,7 @@
 
 42. And there came a man from Baal–shalisha, and brought the man of God bread of the firstfruits, twenty loaves of barley, and full ears of corn in the husk thereof. And he said, Give unto the people, that they may eat.
 43. And his servitor said, What, should I set this before an hundred men? He said again, Give the people, that they may eat: for thus saith the LORD, They shall eat, and shall leave /thereof/.
-44. So he set /it/ before them, and they did eat, and left /thereof/, according to the word of the LORD. 
+44. So he set /it/ before them, and they did eat, and left /thereof/, according to the word of the LORD.
 * 5
 1. Now Naaman, captain of the host of the king of Syria, was a great man with his master, and honourable, because by him the LORD had given deliverance unto Syria: he was also a mighty man in valour, /but he was/ a leper.
 2. And the Syrians had gone out by companies, and had brought away captive out of the land of Israel a little maid; and she waited on Naaman's wife.
@@ -163,7 +163,7 @@
 24. And when he came to the tower, he took /them/ from their hand, and bestowed /them/ in the house: and he let the men go, and they departed.
 25. But he went in, and stood before his master. And Elisha said unto him, Whence /comest thou/, Gehazi? And he said, Thy servant went no whither.
 26. And he said unto him, Went not mine heart /with thee/, when the man turned again from his chariot to meet thee? /Is it/ a time to receive money, and to receive garments, and oliveyards, and vineyards, and sheep, and oxen, and menservants, and maidservants?
-27. The leprosy therefore of Naaman shall cleave unto thee, and unto thy seed for ever. And he went out from his presence a leper /as white/ as snow. 
+27. The leprosy therefore of Naaman shall cleave unto thee, and unto thy seed for ever. And he went out from his presence a leper /as white/ as snow.
 * 6
 1. And the sons of the prophets said unto Elisha, Behold now, the place where we dwell with thee is too strait for us.
 2. Let us go, we pray thee, unto Jordan, and take thence every man a beam, and let us make us a place there, where we may dwell. And he answered, Go ye.
@@ -202,7 +202,7 @@
 30. And it came to pass, when the king heard the words of the woman, that he rent his clothes; and he passed by upon the wall, and the people looked, and, behold, /he had/ sackcloth within upon his flesh.
 31. Then he said, God do so and more also to me, if the head of Elisha the son of Shaphat shall stand on him this day.
 32. But Elisha sat in his house, and the elders sat with him; and /the king/ sent a man from before him: but ere the messenger came to him, he said to the elders, See ye how this son of a murderer hath sent to take away mine head? look, when the messenger cometh, shut the door, and hold him fast at the door: /is/ not the sound of his master's feet behind him?
-33. And while he yet talked with them, behold, the messenger came down unto him: and he said, Behold, this evil /is/ of the LORD; what should I wait for the LORD any longer? 
+33. And while he yet talked with them, behold, the messenger came down unto him: and he said, Behold, this evil /is/ of the LORD; what should I wait for the LORD any longer?
 * 7
 1. Then Elisha said, Hear ye the word of the LORD; Thus saith the LORD, To morrow about this time /shall/ a measure of fine flour /be sold/ for a shekel, and two measures of barley for a shekel, in the gate of Samaria.
 2. Then a lord on whose hand the king leaned answered the man of God, and said, Behold, /if/ the LORD would make windows in heaven, might this thing be? And he said, Behold, thou shalt see /it/ with thine eyes, but shalt not eat thereof.
@@ -226,7 +226,7 @@
 17. And the king appointed the lord on whose hand he leaned to have the charge of the gate: and the people trode upon him in the gate, and he died, as the man of God had said, who spake when the king came down to him.
 18. And it came to pass as the man of God had spoken to the king, saying, Two measures of barley for a shekel, and a measure of fine flour for a shekel, shall be to morrow about this time in the gate of Samaria:
 19. And that lord answered the man of God, and said, Now, behold, /if/ the LORD should make windows in heaven, might such a thing be? And he said, Behold, thou shalt see it with thine eyes, but shalt not eat thereof.
-20. And so it fell out unto him: for the people trode upon him in the gate, and he died. 
+20. And so it fell out unto him: for the people trode upon him in the gate, and he died.
 * 8
 1. Then spake Elisha unto the woman, whose son he had restored to life, saying, Arise, and go thou and thine household, and sojourn wheresoever thou canst sojourn: for the LORD hath called for a famine; and it shall also come upon the land seven years.
 2. And the woman arose, and did after the saying of the man of God: and she went with her household, and sojourned in the land of the Philistines seven years.
@@ -261,7 +261,7 @@
 27. And he walked in the way of the house of Ahab, and did evil in the sight of the LORD, as /did/ the house of Ahab: for he /was/ the son in law of the house of Ahab.
 
 28. And he went with Joram the son of Ahab to the war against Hazael king of Syria in Ramoth–gilead; and the Syrians wounded Joram.
-29. And king Joram went back to be healed in Jezreel of the wounds which the Syrians had given him at Ramah, when he fought against Hazael king of Syria. And Ahaziah the son of Jehoram king of Judah went down to see Joram the son of Ahab in Jezreel, because he was sick. 
+29. And king Joram went back to be healed in Jezreel of the wounds which the Syrians had given him at Ramah, when he fought against Hazael king of Syria. And Ahaziah the son of Jehoram king of Judah went down to see Joram the son of Ahab in Jezreel, because he was sick.
 * 9
 1. And Elisha the prophet called one of the children of the prophets, and said unto him, Gird up thy loins, and take this box of oil in thine hand, and go to Ramoth–gilead:
 2. And when thou comest thither, look out there Jehu the son of Jehoshaphat the son of Nimshi, and go in, and make him arise up from among his brethren, and carry him to an inner chamber;
@@ -303,7 +303,7 @@
 34. And when he was come in, he did eat and drink, and said, Go, see now this cursed /woman/, and bury her: for she /is/ a king's daughter.
 35. And they went to bury her: but they found no more of her than the skull, and the feet, and the palms of /her/ hands.
 36. Wherefore they came again, and told him. And he said, This /is/ the word of the LORD, which he spake by his servant Elijah the Tishbite, saying, In the portion of Jezreel shall dogs eat the flesh of Jezebel:
-37. And the carcase of Jezebel shall be as dung upon the face of the field in the portion of Jezreel; /so/ that they shall not say, This /is/ Jezebel. 
+37. And the carcase of Jezebel shall be as dung upon the face of the field in the portion of Jezreel; /so/ that they shall not say, This /is/ Jezebel.
 * 10
 1. And Ahab had seventy sons in Samaria. And Jehu wrote letters, and sent to Samaria, unto the rulers of Jezreel, to the elders, and to them that brought up Ahab's /children/, saying,
 2. Now as soon as this letter cometh to you, seeing your master's sons /are/ with you, and /there are/ with you chariots and horses, a fenced city also, and armour;
@@ -346,7 +346,7 @@
 33. From Jordan eastward, all the land of Gilead, the Gadites, and the Reubenites, and the Manassites, from Aroer, which /is/ by the river Arnon, even Gilead and Bashan.
 34. Now the rest of the acts of Jehu, and all that he did, and all his might, /are/ they not written in the book of the chronicles of the kings of Israel?
 35. And Jehu slept with his fathers: and they buried him in Samaria. And Jehoahaz his son reigned in his stead.
-36. And the time that Jehu reigned over Israel in Samaria /was/ twenty and eight years. 
+36. And the time that Jehu reigned over Israel in Samaria /was/ twenty and eight years.
 * 11
 1. And when Athaliah the mother of Ahaziah saw that her son was dead, she arose and destroyed all the seed royal.
 2. But Jehosheba, the daughter of king Joram, sister of Ahaziah, took Joash the son of Ahaziah, and stole him from among the king's sons /which were/ slain; and they hid him, /even/ him and his nurse, in the bedchamber from Athaliah, so that he was not slain.
@@ -371,7 +371,7 @@
 18. And all the people of the land went into the house of Baal, and brake it down; his altars and his images brake they in pieces thoroughly, and slew Mattan the priest of Baal before the altars. And the priest appointed officers over the house of the LORD.
 19. And he took the rulers over hundreds, and the captains, and the guard, and all the people of the land; and they brought down the king from the house of the LORD, and came by the way of the gate of the guard to the king's house. And he sat on the throne of the kings.
 20. And all the people of the land rejoiced, and the city was in quiet: and they slew Athaliah with the sword /beside/ the king's house.
-21. Seven years old /was/ Jehoash when he began to reign. 
+21. Seven years old /was/ Jehoash when he began to reign.
 * 12
 1. In the seventh year of Jehu Jehoash began to reign; and forty years reigned he in Jerusalem. And his mother's name /was/ Zibiah of Beer–sheba.
 2. And Jehoash did /that which was/ right in the sight of the LORD all his days wherein Jehoiada the priest instructed him.
@@ -396,7 +396,7 @@
 
 19. And the rest of the acts of Joash, and all that he did, /are/ they not written in the book of the chronicles of the kings of Judah?
 20. And his servants arose, and made a conspiracy, and slew Joash in the house of Millo, which goeth down to Silla.
-21. For Jozachar the son of Shimeath, and Jehozabad the son of Shomer, his servants, smote him, and he died; and they buried him with his fathers in the city of David: and Amaziah his son reigned in his stead. 
+21. For Jozachar the son of Shimeath, and Jehozabad the son of Shomer, his servants, smote him, and he died; and they buried him with his fathers in the city of David: and Amaziah his son reigned in his stead.
 * 13
 1. In the three and twentieth year of Joash the son of Ahaziah king of Judah Jehoahaz the son of Jehu began to reign over Israel in Samaria, /and reigned/ seventeen years.
 2. And he did /that which was/ evil in the sight of the LORD, and followed the sins of Jeroboam the son of Nebat, which made Israel to sin; he departed not therefrom.
@@ -428,7 +428,7 @@
 22. But Hazael king of Syria oppressed Israel all the days of Jehoahaz.
 23. And the LORD was gracious unto them, and had compassion on them, and had respect unto them, because of his covenant with Abraham, Isaac, and Jacob, and would not destroy them, neither cast he them from his presence as yet.
 24. So Hazael king of Syria died; and Ben–hadad his son reigned in his stead.
-25. And Jehoash the son of Jehoahaz took again out of the hand of Ben–hadad the son of Hazael the cities, which he had taken out of the hand of Jehoahaz his father by war. Three times did Joash beat him, and recovered the cities of Israel. 
+25. And Jehoash the son of Jehoahaz took again out of the hand of Ben–hadad the son of Hazael the cities, which he had taken out of the hand of Jehoahaz his father by war. Three times did Joash beat him, and recovered the cities of Israel.
 * 14
 1. In the second year of Joash son of Jehoahaz king of Israel reigned Amaziah the son of Joash king of Judah.
 2. He was twenty and five years old when he began to reign, and reigned twenty and nine years in Jerusalem. And his mother's name /was/ Jehoaddan of Jerusalem.
@@ -465,7 +465,7 @@
 27. And the LORD said not that he would blot out the name of Israel from under heaven: but he saved them by the hand of Jeroboam the son of Joash.
 
 28. Now the rest of the acts of Jeroboam, and all that he did, and his might, how he warred, and how he recovered Damascus, and Hamath, /which belonged/ to Judah, for Israel, are they not written in the book of the chronicles of the kings of Israel?
-29. And Jeroboam slept with his fathers, /even/ with the kings of Israel; and Zachariah his son reigned in his stead. 
+29. And Jeroboam slept with his fathers, /even/ with the kings of Israel; and Zachariah his son reigned in his stead.
 * 15
 1. In the twenty and seventh year of Jeroboam king of Israel began Azariah son of Amaziah king of Judah to reign.
 2. Sixteen years old was he when he began to reign, and he reigned two and fifty years in Jerusalem. And his mother's name /was/ Jecholiah of Jerusalem.
@@ -514,7 +514,7 @@
 
 36. Now the rest of the acts of Jotham, and all that he did, /are/ they not written in the book of the chronicles of the kings of Judah?
 37. In those days the LORD began to send against Judah Rezin the king of Syria, and Pekah the son of Remaliah.
-38. And Jotham slept with his fathers, and was buried with his fathers in the city of David his father: and Ahaz his son reigned in his stead. 
+38. And Jotham slept with his fathers, and was buried with his fathers in the city of David his father: and Ahaz his son reigned in his stead.
 * 16
 1. In the seventeenth year of Pekah the son of Remaliah Ahaz the son of Jotham king of Judah began to reign.
 2. Twenty years old /was/ Ahaz when he began to reign, and reigned sixteen years in Jerusalem, and did not /that which was/ right in the sight of the LORD his God, like David his father.
@@ -539,7 +539,7 @@
 18. And the covert for the sabbath that they had built in the house, and the king's entry without, turned he from the house of the LORD for the king of Assyria.
 
 19. Now the rest of the acts of Ahaz which he did, /are/ they not written in the book of the chronicles of the kings of Judah?
-20. And Ahaz slept with his fathers, and was buried with his fathers in the city of David: and Hezekiah his son reigned in his stead. 
+20. And Ahaz slept with his fathers, and was buried with his fathers in the city of David: and Hezekiah his son reigned in his stead.
 * 17
 1. In the twelfth year of Ahaz king of Judah began Hoshea the son of Elah to reign in Samaria over Israel nine years.
 2. And he did /that which was/ evil in the sight of the LORD, but not as the kings of Israel that were before him.
@@ -585,7 +585,7 @@
 38. And the covenant that I have made with you ye shall not forget; neither shall ye fear other gods.
 39. But the LORD your God ye shall fear; and he shall deliver you out of the hand of all your enemies.
 40. Howbeit they did not hearken, but they did after their former manner.
-41. So these nations feared the LORD, and served their graven images, both their children, and their children's children: as did their fathers, so do they unto this day. 
+41. So these nations feared the LORD, and served their graven images, both their children, and their children's children: as did their fathers, so do they unto this day.
 * 18
 1. Now it came to pass in the third year of Hoshea son of Elah king of Israel, /that/ Hezekiah the son of Ahaz king of Judah began to reign.
 2. Twenty and five years old was he when he began to reign; and he reigned twenty and nine years in Jerusalem. His mother's name also /was/ Abi, the daughter of Zachariah.
@@ -627,7 +627,7 @@
 34. Where /are/ the gods of Hamath, and of Arpad? where /are/ the gods of Sepharvaim, Hena, and Ivah? have they delivered Samaria out of mine hand?
 35. Who /are/ they among all the gods of the countries, that have delivered their country out of mine hand, that the LORD should deliver Jerusalem out of mine hand?
 36. But the people held their peace, and answered him not a word: for the king's commandment was, saying, Answer him not.
-37. Then came Eliakim the son of Hilkiah, which /was/ over the household, and Shebna the scribe, and Joah the son of Asaph the recorder, to Hezekiah with /their/ clothes rent, and told him the words of Rab–shakeh. 
+37. Then came Eliakim the son of Hilkiah, which /was/ over the household, and Shebna the scribe, and Joah the son of Asaph the recorder, to Hezekiah with /their/ clothes rent, and told him the words of Rab–shakeh.
 * 19
 1. And it came to pass, when king Hezekiah heard /it/, that he rent his clothes, and covered himself with sackcloth, and went into the house of the LORD.
 2. And he sent Eliakim, which /was/ over the household, and Shebna the scribe, and the elders of the priests, covered with sackcloth, to Isaiah the prophet the son of Amoz.
@@ -670,7 +670,7 @@
 
 35. And it came to pass that night, that the angel of the LORD went out, and smote in the camp of the Assyrians an hundred fourscore and five thousand: and when they arose early in the morning, behold, they /were/ all dead corpses.
 36. So Sennacherib king of Assyria departed, and went and returned, and dwelt at Nineveh.
-37. And it came to pass, as he was worshipping in the house of Nisroch his god, that Adrammelech and Sharezer his sons smote him with the sword: and they escaped into the land of Armenia. And Esar–haddon his son reigned in his stead. 
+37. And it came to pass, as he was worshipping in the house of Nisroch his god, that Adrammelech and Sharezer his sons smote him with the sword: and they escaped into the land of Armenia. And Esar–haddon his son reigned in his stead.
 * 20
 1. In those days was Hezekiah sick unto death. And the prophet Isaiah the son of Amoz came to him, and said unto him, Thus saith the LORD, Set thine house in order; for thou shalt die, and not live.
 2. Then he turned his face to the wall, and prayed unto the LORD, saying,
@@ -696,7 +696,7 @@
 19. Then said Hezekiah unto Isaiah, Good /is/ the word of the LORD which thou hast spoken. And he said, /Is it/ not /good/, if peace and truth be in my days?
 
 20. And the rest of the acts of Hezekiah, and all his might, and how he made a pool, and a conduit, and brought water into the city, /are/ they not written in the book of the chronicles of the kings of Judah?
-21. And Hezekiah slept with his fathers: and Manasseh his son reigned in his stead. 
+21. And Hezekiah slept with his fathers: and Manasseh his son reigned in his stead.
 * 21
 1. Manasseh /was/ twelve years old when he began to reign, and reigned fifty and five years in Jerusalem. And his mother's name /was/ Hephzi–bah.
 2. And he did /that which was/ evil in the sight of the LORD, after the abominations of the heathen, whom the LORD cast out before the children of Israel.
@@ -727,7 +727,7 @@
 23. And the servants of Amon conspired against him, and slew the king in his own house.
 24. And the people of the land slew all them that had conspired against king Amon; and the people of the land made Josiah his son king in his stead.
 25. Now the rest of the acts of Amon which he did, /are/ they not written in the book of the chronicles of the kings of Judah?
-26. And he was buried in his sepulchre in the garden of Uzza: and Josiah his son reigned in his stead. 
+26. And he was buried in his sepulchre in the garden of Uzza: and Josiah his son reigned in his stead.
 * 22
 1. Josiah /was/ eight years old when he began to reign, and he reigned thirty and one years in Jerusalem. And his mother's name /was/ Jedidah, the daughter of Adaiah of Boscath.
 2. And he did /that which was/ right in the sight of the LORD, and walked in all the way of David his father, and turned not aside to the right hand or to the left.
@@ -751,7 +751,7 @@
 17. Because they have forsaken me, and have burned incense unto other gods, that they might provoke me to anger with all the works of their hands; therefore my wrath shall be kindled against this place, and shall not be quenched.
 18. But to the king of Judah which sent you to enquire of the LORD, thus shall ye say to him, Thus saith the LORD God of Israel, /As touching/ the words which thou hast heard;
 19. Because thine heart was tender, and thou hast humbled thyself before the LORD, when thou heardest what I spake against this place, and against the inhabitants thereof, that they should become a desolation and a curse, and hast rent thy clothes, and wept before me; I also have heard /thee/, saith the LORD.
-20. Behold therefore, I will gather thee unto thy fathers, and thou shalt be gathered into thy grave in peace; and thine eyes shall not see all the evil which I will bring upon this place. And they brought the king word again. 
+20. Behold therefore, I will gather thee unto thy fathers, and thou shalt be gathered into thy grave in peace; and thine eyes shall not see all the evil which I will bring upon this place. And they brought the king word again.
 * 23
 1. And the king sent, and they gathered unto him all the elders of Judah and of Jerusalem.
 2. And the king went up into the house of the LORD, and all the men of Judah and all the inhabitants of Jerusalem with him, and the priests, and the prophets, and all the people, both small and great: and he read in their ears all the words of the book of the covenant which was found in the house of the LORD.
@@ -797,7 +797,7 @@
 35. And Jehoiakim gave the silver and the gold to Pharaoh; but he taxed the land to give the money according to the commandment of Pharaoh: he exacted the silver and the gold of the people of the land, of every one according to his taxation, to give /it/ unto Pharaoh–nechoh.
 
 36. Jehoiakim /was/ twenty and five years old when he began to reign; and he reigned eleven years in Jerusalem. And his mother's name /was/ Zebudah, the daughter of Pedaiah of Rumah.
-37. And he did /that which was/ evil in the sight of the LORD, according to all that his fathers had done. 
+37. And he did /that which was/ evil in the sight of the LORD, according to all that his fathers had done.
 * 24
 1. In his days Nebuchadnezzar king of Babylon came up, and Jehoiakim became his servant three years: then he turned and rebelled against him.
 2. And the LORD sent against him bands of the Chaldees, and bands of the Syrians, and bands of the Moabites, and bands of the children of Ammon, and sent them against Judah to destroy it, according to the word of the LORD, which he spake by his servants the prophets.
@@ -822,7 +822,7 @@
 17. And the king of Babylon made Mattaniah his father's brother king in his stead, and changed his name to Zedekiah.
 18. Zedekiah /was/ twenty and one years old when he began to reign, and he reigned eleven years in Jerusalem. And his mother's name /was/ Hamutal, the daughter of Jeremiah of Libnah.
 19. And he did /that which was/ evil in the sight of the LORD, according to all that Jehoiakim had done.
-20. For through the anger of the LORD it came to pass in Jerusalem and Judah, until he had cast them out from his presence, that Zedekiah rebelled against the king of Babylon. 
+20. For through the anger of the LORD it came to pass in Jerusalem and Judah, until he had cast them out from his presence, that Zedekiah rebelled against the king of Babylon.
 * 25
 1. And it came to pass in the ninth year of his reign, in the tenth month, in the tenth /day/ of the month, /that/ Nebuchadnezzar king of Babylon came, he, and all his host, against Jerusalem, and pitched against it; and they built forts against it round about.
 2. And the city was besieged unto the eleventh year of king Zedekiah.
@@ -858,4 +858,4 @@
 27. And it came to pass in the seven and thirtieth year of the captivity of Jehoiachin king of Judah, in the twelfth month, on the seven and twentieth /day/ of the month, /that/ Evil–merodach king of Babylon in the year that he began to reign did lift up the head of Jehoiachin king of Judah out of prison;
 28. And he spake kindly to him, and set his throne above the throne of the kings that /were/ with him in Babylon;
 29. And changed his prison garments: and he did eat bread continually before him all the days of his life.
-30. And his allowance /was/ a continual allowance given him of the king, a daily rate for every day, all the days of his life.  
+30. And his allowance /was/ a continual allowance given him of the king, a daily rate for every day, all the days of his life.

--- a/13_1CH.org
+++ b/13_1CH.org
@@ -62,7 +62,7 @@
 51. Hadad died also. And the dukes of Edom were; duke Timnah, duke Aliah, duke Jetheth,
 52. Duke Aholibamah, duke Elah, duke Pinon,
 53. Duke Kenaz, duke Teman, duke Mibzar,
-54. Duke Magdiel, duke Iram. These /are/ the dukes of Edom. 
+54. Duke Magdiel, duke Iram. These /are/ the dukes of Edom.
 * 2
 1. These /are/ the sons of Israel; Reuben, Simeon, Levi, and Judah, Issachar, and Zebulun,
 2. Dan, Joseph, and Benjamin, Naphtali, Gad, and Asher.
@@ -126,7 +126,7 @@
 52. And Shobal the father of Kirjath–jearim had sons; Haroeh, /and/ half of the Manahethites.
 53. And the families of Kirjath–jearim; the Ithrites, and the Puhites, and the Shumathites, and the Mishraites; of them came the Zareathites, and the Eshtaulites.
 54. The sons of Salma; Beth–lehem, and the Netophathites, Ataroth, the house of Joab, and half of the Manahethites, the Zorites.
-55. And the families of the scribes which dwelt at Jabez; the Tirathites, the Shimeathites, /and/ Suchathites. These /are/ the Kenites that came of Hemath, the father of the house of Rechab. 
+55. And the families of the scribes which dwelt at Jabez; the Tirathites, the Shimeathites, /and/ Suchathites. These /are/ the Kenites that came of Hemath, the father of the house of Rechab.
 * 3
 1. Now these were the sons of David, which were born unto him in Hebron; the firstborn Amnon, of Ahinoam the Jezreelitess; the second Daniel, of Abigail the Carmelitess:
 2. The third, Absalom the son of Maachah the daughter of Talmai king of Geshur: the fourth, Adonijah the son of Haggith:
@@ -153,7 +153,7 @@
 21. And the sons of Hananiah; Pelatiah, and Jesaiah: the sons of Rephaiah, the sons of Arnan, the sons of Obadiah, the sons of Shechaniah.
 22. And the sons of Shechaniah; Shemaiah: and the sons of Shemaiah; Hattush, and Igeal, and Bariah, and Neariah, and Shaphat, six.
 23. And the sons of Neariah; Elioenai, and Hezekiah, and Azrikam, three.
-24. And the sons of Elioenai /were/, Hodaiah, and Eliashib, and Pelaiah, and Akkub, and Johanan, and Dalaiah, and Anani, seven. 
+24. And the sons of Elioenai /were/, Hodaiah, and Eliashib, and Pelaiah, and Akkub, and Johanan, and Dalaiah, and Anani, seven.
 * 4
 1. The sons of Judah; Pharez, Hezron, and Carmi, and Hur, and Shobal.
 2. And Reaiah the son of Shobal begat Jahath; and Jahath begat Ahumai, and Lahad. These /are/ the families of the Zorathites.
@@ -203,7 +203,7 @@
 40. And they found fat pasture and good, and the land /was/ wide, and quiet, and peaceable; for /they/ of Ham had dwelt there of old.
 41. And these written by name came in the days of Hezekiah king of Judah, and smote their tents, and the habitations that were found there, and destroyed them utterly unto this day, and dwelt in their rooms: because /there was/ pasture there for their flocks.
 42. And /some/ of them, /even/ of the sons of Simeon, five hundred men, went to mount Seir, having for their captains Pelatiah, and Neariah, and Rephaiah, and Uzziel, the sons of Ishi.
-43. And they smote the rest of the Amalekites that were escaped, and dwelt there unto this day. 
+43. And they smote the rest of the Amalekites that were escaped, and dwelt there unto this day.
 * 5
 1. Now the sons of Reuben the firstborn of Israel, (for he /was/ the firstborn; but, forasmuch as he defiled his father's bed, his birthright was given unto the sons of Joseph the son of Israel: and the genealogy is not to be reckoned after the birthright.
 2. For Judah prevailed above his brethren, and of him /came/ the chief ruler; but the birthright /was/ Joseph's:)
@@ -234,7 +234,7 @@
 24. And these /were/ the heads of the house of their fathers, even Epher, and Ishi, and Eliel, and Azriel, and Jeremiah, and Hodaviah, and Jahdiel, mighty men of valour, famous men, /and/ heads of the house of their fathers.
 
 25. And they transgressed against the God of their fathers, and went a whoring after the gods of the people of the land, whom God destroyed before them.
-26. And the God of Israel stirred up the spirit of Pul king of Assyria, and the spirit of Tilgath–pilneser king of Assyria, and he carried them away, even the Reubenites, and the Gadites, and the half tribe of Manasseh, and brought them unto Halah, and Habor, and Hara, and to the river Gozan, unto this day. 
+26. And the God of Israel stirred up the spirit of Pul king of Assyria, and the spirit of Tilgath–pilneser king of Assyria, and he carried them away, even the Reubenites, and the Gadites, and the half tribe of Manasseh, and brought them unto Halah, and Habor, and Hara, and to the river Gozan, unto this day.
 * 6
 1. The sons of Levi; Gershon, Kohath, and Merari.
 2. And the sons of Kohath; Amram, Izhar, and Hebron, and Uzziel.
@@ -320,7 +320,7 @@
 78. And on the other side Jordan by Jericho, on the east side of Jordan, /were given them/ out of the tribe of Reuben, Bezer in the wilderness with her suburbs, and Jahzah with her suburbs,
 79. Kedemoth also with her suburbs, and Mephaath with her suburbs:
 80. And out of the tribe of Gad; Ramoth in Gilead with her suburbs, and Mahanaim with her suburbs,
-81. And Heshbon with her suburbs, and Jazer with her suburbs. 
+81. And Heshbon with her suburbs, and Jazer with her suburbs.
 * 7
 1. Now the sons of Issachar /were/, Tola, and Puah, Jashub, and Shimron, four.
 2. And the sons of Tola; Uzzi, and Rephaiah, and Jeriel, and Jahmai, and Jibsam, and Shemuel, heads of their father's house, /to wit/, of Tola: /they were/ valiant men of might in their generations; whose number /was/ in the days of David two and twenty thousand and six hundred.
@@ -369,7 +369,7 @@
 37. Bezer, and Hod, and Shamma, and Shilshah, and Ithran, and Beera.
 38. And the sons of Jether; Jephunneh, and Pispah, and Ara.
 39. And the sons of Ulla; Arah, and Haniel, and Rezia.
-40. All these /were/ the children of Asher, heads of /their/ father's house, choice /and/ mighty men of valour, chief of the princes. And the number throughout the genealogy of them that were apt to the war /and/ to battle /was/ twenty and six thousand men. 
+40. All these /were/ the children of Asher, heads of /their/ father's house, choice /and/ mighty men of valour, chief of the princes. And the number throughout the genealogy of them that were apt to the war /and/ to battle /was/ twenty and six thousand men.
 * 8
 1. Now Benjamin begat Bela his firstborn, Ashbel the second, and Aharah the third,
 2. Nohah the fourth, and Rapha the fifth.
@@ -411,7 +411,7 @@
 37. And Moza begat Binea: Rapha /was/ his son, Eleasah his son, Azel his son:
 38. And Azel had six sons, whose names /are/ these, Azrikam, Bocheru, and Ishmael, and Sheariah, and Obadiah, and Hanan. All these /were/ the sons of Azel.
 39. And the sons of Eshek his brother /were/, Ulam his firstborn, Jehush the second, and Eliphelet the third.
-40. And the sons of Ulam were mighty men of valour, archers, and had many sons, and sons' sons, an hundred and fifty. All these /are/ of the sons of Benjamin. 
+40. And the sons of Ulam were mighty men of valour, archers, and had many sons, and sons' sons, an hundred and fifty. All these /are/ of the sons of Benjamin.
 * 9
 1. So all Israel were reckoned by genealogies; and, behold, they /were/ written in the book of the kings of Israel and Judah, /who/ were carried away to Babylon for their transgression.
 
@@ -460,7 +460,7 @@
 41. And the sons of Micah /were/, Pithon, and Melech, and Tahrea, /and Ahaz/.
 42. And Ahaz begat Jarah; and Jarah begat Alemeth, and Azmaveth, and Zimri; and Zimri begat Moza;
 43. And Moza begat Binea; and Rephaiah his son, Eleasah his son, Azel his son.
-44. And Azel had six sons, whose names /are/ these, Azrikam, Bocheru, and Ishmael, and Sheariah, and Obadiah, and Hanan: these /were/ the sons of Azel. 
+44. And Azel had six sons, whose names /are/ these, Azrikam, Bocheru, and Ishmael, and Sheariah, and Obadiah, and Hanan: these /were/ the sons of Azel.
 * 10
 1. Now the Philistines fought against Israel; and the men of Israel fled from before the Philistines, and fell down slain in mount Gilboa.
 2. And the Philistines followed hard after Saul, and after his sons; and the Philistines slew Jonathan, and Abinadab, and Malchi–shua, the sons of Saul.
@@ -478,7 +478,7 @@
 12. They arose, all the valiant men, and took away the body of Saul, and the bodies of his sons, and brought them to Jabesh, and buried their bones under the oak in Jabesh, and fasted seven days.
 
 13. So Saul died for his transgression which he committed against the LORD, /even/ against the word of the LORD, which he kept not, and also for asking /counsel/ of /one that had/ a familiar spirit, to enquire /of it/;
-14. And enquired not of the LORD: therefore he slew him, and turned the kingdom unto David the son of Jesse. 
+14. And enquired not of the LORD: therefore he slew him, and turned the kingdom unto David the son of Jesse.
 * 11
 1. Then all Israel gathered themselves to David unto Hebron, saying, Behold, we /are/ thy bone and thy flesh.
 2. And moreover in time past, even when Saul was king, thou /wast/ he that leddest out and broughtest in Israel: and the LORD thy God said unto thee, Thou shalt feed my people Israel, and thou shalt be ruler over my people Israel.
@@ -531,7 +531,7 @@
 44. Uzzia the Ashterathite, Shama and Jehiel the sons of Hothan the Aroerite,
 45. Jediael the son of Shimri, and Joha his brother, the Tizite,
 46. Eliel the Mahavite, and Jeribai, and Joshaviah, the sons of Elnaam, and Ithmah the Moabite,
-47. Eliel, and Obed, and Jasiel the Mesobaite. 
+47. Eliel, and Obed, and Jasiel the Mesobaite.
 * 12
 1. Now these /are/ they that came to David to Ziklag, while he yet kept himself close because of Saul the son of Kish: and they /were/ among the mighty men, helpers of the war.
 2. /They were/ armed with bows, and could use both the right hand and the left in /hurling/ stones and /shooting/ arrows out of a bow, /even/ of Saul's brethren of Benjamin.
@@ -573,7 +573,7 @@
 37. And on the other side of Jordan, of the Reubenites, and the Gadites, and of the half tribe of Manasseh, with all manner of instruments of war for the battle, an hundred and twenty thousand.
 38. All these men of war, that could keep rank, came with a perfect heart to Hebron, to make David king over all Israel: and all the rest also of Israel /were/ of one heart to make David king.
 39. And there they were with David three days, eating and drinking: for their brethren had prepared for them.
-40. Moreover they that were nigh them, /even/ unto Issachar and Zebulun and Naphtali, brought bread on asses, and on camels, and on mules, and on oxen, /and/ meat, meal, cakes of figs, and bunches of raisins, and wine, and oil, and oxen, and sheep abundantly: for /there was/ joy in Israel. 
+40. Moreover they that were nigh them, /even/ unto Issachar and Zebulun and Naphtali, brought bread on asses, and on camels, and on mules, and on oxen, /and/ meat, meal, cakes of figs, and bunches of raisins, and wine, and oil, and oxen, and sheep abundantly: for /there was/ joy in Israel.
 * 13
 1. And David consulted with the captains of thousands and hundreds, /and/ with every leader.
 2. And David said unto all the congregation of Israel, If /it seem/ good unto you, and /that it be/ of the LORD our God, let us send abroad unto our brethren every where, /that are/ left in all the land of Israel, and with them /also/ to the priests and Levites /which are/ in their cities /and/ suburbs, that they may gather themselves unto us:
@@ -589,7 +589,7 @@
 11. And David was displeased, because the LORD had made a breach upon Uzza: wherefore that place is called Perez–uzza to this day.
 12. And David was afraid of God that day, saying, How shall I bring the ark of God /home/ to me?
 13. So David brought not the ark /home/ to himself to the city of David, but carried it aside into the house of Obed–edom the Gittite.
-14. And the ark of God remained with the family of Obed–edom in his house three months. And the LORD blessed the house of Obed–edom, and all that he had. 
+14. And the ark of God remained with the family of Obed–edom in his house three months. And the LORD blessed the house of Obed–edom, and all that he had.
 * 14
 1. Now Hiram king of Tyre sent messengers to David, and timber of cedars, with masons and carpenters, to build him an house.
 2. And David perceived that the LORD had confirmed him king over Israel, for his kingdom was lifted up on high, because of his people Israel.
@@ -609,7 +609,7 @@
 14. Therefore David enquired again of God; and God said unto him, Go not up after them; turn away from them, and come upon them over against the mulberry trees.
 15. And it shall be, when thou shalt hear a sound of going in the tops of the mulberry trees, /that/ then thou shalt go out to battle: for God is gone forth before thee to smite the host of the Philistines.
 16. David therefore did as God commanded him: and they smote the host of the Philistines from Gibeon even to Gazer.
-17. And the fame of David went out into all lands; and the LORD brought the fear of him upon all nations. 
+17. And the fame of David went out into all lands; and the LORD brought the fear of him upon all nations.
 * 15
 1. And /David/ made him houses in the city of David, and prepared a place for the ark of God, and pitched for it a tent.
 2. Then David said, None ought to carry the ark of God but the Levites: for them hath the LORD chosen to carry the ark of God, and to minister unto him for ever.
@@ -641,7 +641,7 @@
 27. And David /was/ clothed with a robe of fine linen, and all the Levites that bare the ark, and the singers, and Chenaniah the master of the song with the singers: David also /had/ upon him an ephod of linen.
 28. Thus all Israel brought up the ark of the covenant of the LORD with shouting, and with sound of the cornet, and with trumpets, and with cymbals, making a noise with psalteries and harps.
 
-29. And it came to pass, /as/ the ark of the covenant of the LORD came to the city of David, that Michal the daughter of Saul looking out at a window saw king David dancing and playing: and she despised him in her heart. 
+29. And it came to pass, /as/ the ark of the covenant of the LORD came to the city of David, that Michal the daughter of Saul looking out at a window saw king David dancing and playing: and she despised him in her heart.
 * 16
 1. So they brought the ark of God, and set it in the midst of the tent that David had pitched for it: and they offered burnt sacrifices and peace offerings before God.
 2. And when David had made an end of offering the burnt offerings and the peace offerings, he blessed the people in the name of the LORD.
@@ -688,7 +688,7 @@
 40. To offer burnt offerings unto the LORD upon the altar of the burnt offering continually morning and evening, and /to do/ according to all that is written in the law of the LORD, which he commanded Israel;
 41. And with them Heman and Jeduthun, and the rest that were chosen, who were expressed by name, to give thanks to the LORD, because his mercy /endureth/ for ever;
 42. And with them Heman and Jeduthun with trumpets and cymbals for those that should make a sound, and with musical instruments of God. And the sons of Jeduthun /were/ porters.
-43. And all the people departed every man to his house: and David returned to bless his house. 
+43. And all the people departed every man to his house: and David returned to bless his house.
 * 17
 1. Now it came to pass, as David sat in his house, that David said to Nathan the prophet, Lo, I dwell in an house of cedars, but the ark of the covenant of the LORD /remaineth/ under curtains.
 2. Then Nathan said unto David, Do all that /is/ in thine heart; for God /is/ with thee.
@@ -719,7 +719,7 @@
 24. Let it even be established, that thy name may be magnified for ever, saying, The LORD of hosts /is/ the God of Israel, /even/ a God to Israel: and /let/ the house of David thy servant /be/ established before thee.
 25. For thou, O my God, hast told thy servant that thou wilt build him an house: therefore thy servant hath found /in his heart/ to pray before thee.
 26. And now, LORD, thou art God, and hast promised this goodness unto thy servant:
-27. Now therefore let it please thee to bless the house of thy servant, that it may be before thee for ever: for thou blessest, O LORD, and /it shall be/ blessed for ever. 
+27. Now therefore let it please thee to bless the house of thy servant, that it may be before thee for ever: for thou blessest, O LORD, and /it shall be/ blessed for ever.
 * 18
 1. Now after this it came to pass, that David smote the Philistines, and subdued them, and took Gath and her towns out of the hand of the Philistines.
 2. And he smote Moab; and the Moabites became David's servants, /and/ brought gifts.
@@ -742,7 +742,7 @@
 14. So David reigned over all Israel, and executed judgment and justice among all his people.
 15. And Joab the son of Zeruiah /was/ over the host; and Jehoshaphat the son of Ahilud, recorder.
 16. And Zadok the son of Ahitub, and Abimelech the son of Abiathar, /were/ the priests; and Shavsha was scribe;
-17. And Benaiah the son of Jehoiada /was/ over the Cherethites and the Pelethites; and the sons of David /were/ chief about the king. 
+17. And Benaiah the son of Jehoiada /was/ over the Cherethites and the Pelethites; and the sons of David /were/ chief about the king.
 * 19
 1. Now it came to pass after this, that Nahash the king of the children of Ammon died, and his son reigned in his stead.
 2. And David said, I will shew kindness unto Hanun the son of Nahash, because his father shewed kindness to me. And David sent messengers to comfort him concerning his father. So the servants of David came into the land of the children of Ammon to Hanun, to comfort him.
@@ -764,7 +764,7 @@
 16. And when the Syrians saw that they were put to the worse before Israel, they sent messengers, and drew forth the Syrians that /were/ beyond the river: and Shophach the captain of the host of Hadarezer /went/ before them.
 17. And it was told David; and he gathered all Israel, and passed over Jordan, and came upon them, and set /the battle/ in array against them. So when David had put the battle in array against the Syrians, they fought with him.
 18. But the Syrians fled before Israel; and David slew of the Syrians seven thousand /men which fought in/ chariots, and forty thousand footmen, and killed Shophach the captain of the host.
-19. And when the servants of Hadarezer saw that they were put to the worse before Israel, they made peace with David, and became his servants: neither would the Syrians help the children of Ammon any more. 
+19. And when the servants of Hadarezer saw that they were put to the worse before Israel, they made peace with David, and became his servants: neither would the Syrians help the children of Ammon any more.
 * 20
 1. And it came to pass, that after the year was expired, at the time that kings go out /to battle/, Joab led forth the power of the army, and wasted the country of the children of Ammon, and came and besieged Rabbah. But David tarried at Jerusalem. And Joab smote Rabbah, and destroyed it.
 2. And David took the crown of their king from off his head, and found it to weigh a talent of gold, and /there were/ precious stones in it; and it was set upon David's head: and he brought also exceeding much spoil out of the city.
@@ -774,7 +774,7 @@
 5. And there was war again with the Philistines; and Elhanan the son of Jair slew Lahmi the brother of Goliath the Gittite, whose spear staff /was/ like a weaver's beam.
 6. And yet again there was war at Gath, where was a man of /great/ stature, whose fingers and toes /were/ four and twenty, six /on each hand/, and six /on each foot/: and he also was the son of the giant.
 7. But when he defied Israel, Jonathan the son of Shimea David's brother slew him.
-8. These were born unto the giant in Gath; and they fell by the hand of David, and by the hand of his servants. 
+8. These were born unto the giant in Gath; and they fell by the hand of David, and by the hand of his servants.
 * 21
 1. And Satan stood up against Israel, and provoked David to number Israel.
 2. And David said to Joab and to the rulers of the people, Go, number Israel from Beer–sheba even to Dan; and bring the number of them to me, that I may know /it/.
@@ -810,7 +810,7 @@
 
 28. At that time when David saw that the LORD had answered him in the threshingfloor of Ornan the Jebusite, then he sacrificed there.
 29. For the tabernacle of the LORD, which Moses made in the wilderness, and the altar of the burnt offering, /were/ at that season in the high place at Gibeon.
-30. But David could not go before it to enquire of God: for he was afraid because of the sword of the angel of the LORD. 
+30. But David could not go before it to enquire of God: for he was afraid because of the sword of the angel of the LORD.
 * 22
 1. Then David said, This /is/ the house of the LORD God, and this /is/ the altar of the burnt offering for Israel.
 2. And David commanded to gather together the strangers that /were/ in the land of Israel; and he set masons to hew wrought stones to build the house of God.
@@ -832,7 +832,7 @@
 
 17. David also commanded all the princes of Israel to help Solomon his son, /saying/,
 18. /Is/ not the LORD your God with you? and hath he /not/ given you rest on every side? for he hath given the inhabitants of the land into mine hand; and the land is subdued before the LORD, and before his people.
-19. Now set your heart and your soul to seek the LORD your God; arise therefore, and build ye the sanctuary of the LORD God, to bring the ark of the covenant of the LORD, and the holy vessels of God, into the house that is to be built to the name of the LORD. 
+19. Now set your heart and your soul to seek the LORD your God; arise therefore, and build ye the sanctuary of the LORD God, to bring the ark of the covenant of the LORD, and the holy vessels of God, into the house that is to be built to the name of the LORD.
 * 23
 1. So when David was old and full of days, he made Solomon his son king over Israel.
 
@@ -870,7 +870,7 @@
 29. Both for the shewbread, and for the fine flour for meat offering, and for the unleavened cakes, and for /that which is baked in/ the pan, and for that which is fried, and for all manner of measure and size;
 30. And to stand every morning to thank and praise the LORD, and likewise at even;
 31. And to offer all burnt sacrifices unto the LORD in the sabbaths, in the new moons, and on the set feasts, by number, according to the order commanded unto them, continually before the LORD:
-32. And that they should keep the charge of the tabernacle of the congregation, and the charge of the holy /place/, and the charge of the sons of Aaron their brethren, in the service of the house of the LORD. 
+32. And that they should keep the charge of the tabernacle of the congregation, and the charge of the holy /place/, and the charge of the sons of Aaron their brethren, in the service of the house of the LORD.
 * 24
 1. Now /these are/ the divisions of the sons of Aaron. The sons of Aaron; Nadab, and Abihu, Eleazar, and Ithamar.
 2. But Nadab and Abihu died before their father, and had no children: therefore Eleazar and Ithamar executed the priest's office.
@@ -904,7 +904,7 @@
 28. Of Mahli /came/ Eleazar, who had no sons.
 29. Concerning Kish: the son of Kish /was/ Jerahmeel.
 30. The sons also of Mushi; Mahli, and Eder, and Jerimoth. These /were/ the sons of the Levites after the house of their fathers.
-31. These likewise cast lots over against their brethren the sons of Aaron in the presence of David the king, and Zadok, and Ahimelech, and the chief of the fathers of the priests and Levites, even the principal fathers over against their younger brethren. 
+31. These likewise cast lots over against their brethren the sons of Aaron in the presence of David the king, and Zadok, and Ahimelech, and the chief of the fathers of the priests and Levites, even the principal fathers over against their younger brethren.
 * 25
 1. Moreover David and the captains of the host separated to the service of the sons of Asaph, and of Heman, and of Jeduthun, who should prophesy with harps, with psalteries, and with cymbals: and the number of the workmen according to their service was:
 2. Of the sons of Asaph; Zaccur, and Joseph, and Nethaniah, and Asarelah, the sons of Asaph under the hands of Asaph, which prophesied according to the order of the king.
@@ -937,7 +937,7 @@
 28. The one and twentieth to Hothir, /he/, his sons, and his brethren, /were/ twelve:
 29. The two and twentieth to Giddalti, /he/, his sons, and his brethren, /were/ twelve:
 30. The three and twentieth to Mahazioth, /he/, his sons, and his brethren, /were/ twelve:
-31. The four and twentieth to Romamti–ezer, /he/, his sons, and his brethren, /were/ twelve. 
+31. The four and twentieth to Romamti–ezer, /he/, his sons, and his brethren, /were/ twelve.
 * 26
 1. Concerning the divisions of the porters: Of the Korhites /was/ Meshelemiah the son of Kore, of the sons of Asaph.
 2. And the sons of Meshelemiah /were/, Zechariah the firstborn, Jediael the second, Zebadiah the third, Jathniel the fourth,
@@ -973,7 +973,7 @@
 29. Of the Izharites, Chenaniah and his sons /were/ for the outward business over Israel, for officers and judges.
 30. /And/ of the Hebronites, Hashabiah and his brethren, men of valour, a thousand and seven hundred, /were/ officers among them of Israel on this side Jordan westward in all the business of the LORD, and in the service of the king.
 31. Among the Hebronites /was/ Jerijah the chief, /even/ among the Hebronites, according to the generations of his fathers. In the fortieth year of the reign of David they were sought for, and there were found among them mighty men of valour at Jazer of Gilead.
-32. And his brethren, men of valour, /were/ two thousand and seven hundred chief fathers, whom king David made rulers over the Reubenites, the Gadites, and the half tribe of Manasseh, for every matter pertaining to God, and affairs of the king. 
+32. And his brethren, men of valour, /were/ two thousand and seven hundred chief fathers, whom king David made rulers over the Reubenites, the Gadites, and the half tribe of Manasseh, for every matter pertaining to God, and affairs of the king.
 * 27
 1. Now the children of Israel after their number, /to wit/, the chief fathers and captains of thousands and hundreds, and their officers that served the king in any matter of the courses, which came in and went out month by month throughout all the months of the year, of every course /were/ twenty and four thousand.
 2. Over the first course for the first month /was/ Jashobeam the son of Zabdiel: and in his course /were/ twenty and four thousand.
@@ -1011,7 +1011,7 @@
 31. And over the flocks /was/ Jaziz the Hagerite. All these /were/ the rulers of the substance which /was/ king David's.
 32. Also Jonathan David's uncle was a counsellor, a wise man, and a scribe: and Jehiel the son of Hachmoni /was/ with the king's sons:
 33. And Ahithophel /was/ the king's counsellor: and Hushai the Archite /was/ the king's companion:
-34. And after Ahithophel /was/ Jehoiada the son of Benaiah, and Abiathar: and the general of the king's army /was/ Joab. 
+34. And after Ahithophel /was/ Jehoiada the son of Benaiah, and Abiathar: and the general of the king's army /was/ Joab.
 * 28
 1. And David assembled all the princes of Israel, the princes of the tribes, and the captains of the companies that ministered to the king by course, and the captains over the thousands, and captains over the hundreds, and the stewards over all the substance and possession of the king, and of his sons, with the officers, and with the mighty men, and with all the valiant men, unto Jerusalem.
 2. Then David the king stood up upon his feet, and said, Hear me, my brethren, and my people: /As for me/, I /had/ in mine heart to build an house of rest for the ark of the covenant of the LORD, and for the footstool of our God, and had made ready for the building:
@@ -1035,7 +1035,7 @@
 18. And for the altar of incense refined gold by weight; and gold for the pattern of the chariot of the cherubims, that spread out /their wings/, and covered the ark of the covenant of the LORD.
 19. All /this, said David/, the LORD made me understand in writing by /his/ hand upon me, /even/ all the works of this pattern.
 20. And David said to Solomon his son, Be strong and of good courage, and do /it/: fear not, nor be dismayed: for the LORD God, /even/ my God, /will be/ with thee; he will not fail thee, nor forsake thee, until thou hast finished all the work for the service of the house of the LORD.
-21. And, behold, the courses of the priests and the Levites, /even they shall be with thee/ for all the service of the house of God: and /there shall be/ with thee for all manner of workmanship every willing skilful man, for any manner of service: also the princes and all the people /will be/ wholly at thy commandment. 
+21. And, behold, the courses of the priests and the Levites, /even they shall be with thee/ for all the service of the house of God: and /there shall be/ with thee for all manner of workmanship every willing skilful man, for any manner of service: also the princes and all the people /will be/ wholly at thy commandment.
 * 29
 1. Furthermore David the king said unto all the congregation, Solomon my son, whom alone God hath chosen, /is yet/ young and tender, and the work /is/ great: for the palace /is/ not for man, but for the LORD God.
 2. Now I have prepared with all my might for the house of my God the gold for /things to be made/ of gold, and the silver for /things/ of silver, and the brass for /things/ of brass, the iron for /things/ of iron, and wood for /things/ of wood; onyx stones, and /stones/ to be set, glistering stones, and of divers colours, and all manner of precious stones, and marble stones in abundance.
@@ -1070,4 +1070,4 @@
 27. And the time that he reigned over Israel /was/ forty years; seven years reigned he in Hebron, and thirty and three /years/ reigned he in Jerusalem.
 28. And he died in a good old age, full of days, riches, and honour: and Solomon his son reigned in his stead.
 29. Now the acts of David the king, first and last, behold, they /are/ written in the book of Samuel the seer, and in the book of Nathan the prophet, and in the book of Gad the seer,
-30. With all his reign and his might, and the times that went over him, and over Israel, and over all the kingdoms of the countries.  
+30. With all his reign and his might, and the times that went over him, and over Israel, and over all the kingdoms of the countries.

--- a/14_2CH.org
+++ b/14_2CH.org
@@ -18,7 +18,7 @@
 14. And Solomon gathered chariots and horsemen: and he had a thousand and four hundred chariots, and twelve thousand horsemen, which he placed in the chariot cities, and with the king at Jerusalem.
 15. And the king made silver and gold at Jerusalem /as plenteous/ as stones, and cedar trees made he as the sycomore trees that /are/ in the vale for abundance.
 16. And Solomon had horses brought out of Egypt, and linen yarn: the king's merchants received the linen yarn at a price.
-17. And they fetched up, and brought forth out of Egypt a chariot for six hundred /shekels/ of silver, and an horse for an hundred and fifty: and so brought they out /horses/ for all the kings of the Hittites, and for the kings of Syria, by their means. 
+17. And they fetched up, and brought forth out of Egypt a chariot for six hundred /shekels/ of silver, and an horse for an hundred and fifty: and so brought they out /horses/ for all the kings of the Hittites, and for the kings of Syria, by their means.
 * 2
 1. And Solomon determined to build an house for the name of the LORD, and an house for his kingdom.
 2. And Solomon told out threescore and ten thousand men to bear burdens, and fourscore thousand to hew in the mountain, and three thousand and six hundred to oversee them.
@@ -40,7 +40,7 @@
 16. And we will cut wood out of Lebanon, as much as thou shalt need: and we will bring it to thee in floats by sea to Joppa; and thou shalt carry it up to Jerusalem.
 
 17. And Solomon numbered all the strangers that /were/ in the land of Israel, after the numbering wherewith David his father had numbered them; and they were found an hundred and fifty thousand and three thousand and six hundred.
-18. And he set threescore and ten thousand of them /to be/ bearers of burdens, and fourscore thousand /to be/ hewers in the mountain, and three thousand and six hundred overseers to set the people a work. 
+18. And he set threescore and ten thousand of them /to be/ bearers of burdens, and fourscore thousand /to be/ hewers in the mountain, and three thousand and six hundred overseers to set the people a work.
 * 3
 1. Then Solomon began to build the house of the LORD at Jerusalem in mount Moriah, where /the LORD/ appeared unto David his father, in the place that David had prepared in the threshingfloor of Ornan the Jebusite.
 2. And he began to build in the second /day/ of the second month, in the fourth year of his reign.
@@ -61,7 +61,7 @@
 14. And he made the vail /of/ blue, and purple, and crimson, and fine linen, and wrought cherubims thereon.
 15. Also he made before the house two pillars of thirty and five cubits high, and the chapiter that /was/ on the top of each of them /was/ five cubits.
 16. And he made chains, /as/ in the oracle, and put /them/ on the heads of the pillars; and made an hundred pomegranates, and put /them/ on the chains.
-17. And he reared up the pillars before the temple, one on the right hand, and the other on the left; and called the name of that on the right hand Jachin, and the name of that on the left Boaz. 
+17. And he reared up the pillars before the temple, one on the right hand, and the other on the left; and called the name of that on the right hand Jachin, and the name of that on the left Boaz.
 * 4
 1. Moreover he made an altar of brass, twenty cubits the length thereof, and twenty cubits the breadth thereof, and ten cubits the height thereof.
 
@@ -88,7 +88,7 @@
 19. And Solomon made all the vessels that /were for/ the house of God, the golden altar also, and the tables whereon the shewbread /was set/;
 20. Moreover the candlesticks with their lamps, that they should burn after the manner before the oracle, of pure gold;
 21. And the flowers, and the lamps, and the tongs, /made he of/ gold, /and/ that perfect gold;
-22. And the snuffers, and the basons, and the spoons, and the censers, /of/ pure gold: and the entry of the house, the inner doors thereof for the most holy /place/, and the doors of the house of the temple, /were of/ gold. 
+22. And the snuffers, and the basons, and the spoons, and the censers, /of/ pure gold: and the entry of the house, the inner doors thereof for the most holy /place/, and the doors of the house of the temple, /were of/ gold.
 * 5
 1. Thus all the work that Solomon made for the house of the LORD was finished: and Solomon brought in /all/ the things that David his father had dedicated; and the silver, and the gold, and all the instruments, put he among the treasures of the house of God.
 
@@ -105,7 +105,7 @@
 11. And it came to pass, when the priests were come out of the holy /place/: (for all the priests /that were/ present were sanctified, /and/ did not /then/ wait by course:
 12. Also the Levites /which were/ the singers, all of them of Asaph, of Heman, of Jeduthun, with their sons and their brethren, /being/ arrayed in white linen, having cymbals and psalteries and harps, stood at the east end of the altar, and with them an hundred and twenty priests sounding with trumpets:)
 13. It came even to pass, as the trumpeters and singers /were/ as one, to make one sound to be heard in praising and thanking the LORD; and when they lifted up /their/ voice with the trumpets and cymbals and instruments of musick, and praised the LORD, /saying/, For /he is/ good; for his mercy /endureth/ for ever: that /then/ the house was filled with a cloud, /even/ the house of the LORD;
-14. So that the priests could not stand to minister by reason of the cloud: for the glory of the LORD had filled the house of God. 
+14. So that the priests could not stand to minister by reason of the cloud: for the glory of the LORD had filled the house of God.
 * 6
 1. Then said Solomon, The LORD hath said that he would dwell in the thick darkness.
 2. But I have built an house of habitation for thee, and a place for thy dwelling for ever.
@@ -154,7 +154,7 @@
 39. Then hear thou from the heavens, /even/ from thy dwelling place, their prayer and their supplications, and maintain their cause, and forgive thy people which have sinned against thee.
 40. Now, my God, let, I beseech thee, thine eyes be open, and /let/ thine ears /be/ attent unto the prayer /that is made/ in this place.
 41. Now therefore arise, O LORD God, into thy resting place, thou, and the ark of thy strength: let thy priests, O LORD God, be clothed with salvation, and let thy saints rejoice in goodness.
-42. O LORD God, turn not away the face of thine anointed: remember the mercies of David thy servant. 
+42. O LORD God, turn not away the face of thine anointed: remember the mercies of David thy servant.
 * 7
 1. Now when Solomon had made an end of praying, the fire came down from heaven, and consumed the burnt offering and the sacrifices; and the glory of the LORD filled the house.
 2. And the priests could not enter into the house of the LORD, because the glory of the LORD had filled the LORD's house.
@@ -180,7 +180,7 @@
 19. But if ye turn away, and forsake my statutes and my commandments, which I have set before you, and shall go and serve other gods, and worship them;
 20. Then will I pluck them up by the roots out of my land which I have given them; and this house, which I have sanctified for my name, will I cast out of my sight, and will make it /to be/ a proverb and a byword among all nations.
 21. And this house, which is high, shall be an astonishment to every one that passeth by it; so that he shall say, Why hath the LORD done thus unto this land, and unto this house?
-22. And it shall be answered, Because they forsook the LORD God of their fathers, which brought them forth out of the land of Egypt, and laid hold on other gods, and worshipped them, and served them: therefore hath he brought all this evil upon them. 
+22. And it shall be answered, Because they forsook the LORD God of their fathers, which brought them forth out of the land of Egypt, and laid hold on other gods, and worshipped them, and served them: therefore hath he brought all this evil upon them.
 * 8
 1. And it came to pass at the end of twenty years, wherein Solomon had built the house of the LORD, and his own house,
 2. That the cities which Huram had restored to Solomon, Solomon built them, and caused the children of Israel to dwell there.
@@ -204,7 +204,7 @@
 16. Now all the work of Solomon was prepared unto the day of the foundation of the house of the LORD, and until it was finished. /So/ the house of the LORD was perfected.
 
 17. Then went Solomon to Ezion–geber, and to Eloth, at the sea side in the land of Edom.
-18. And Huram sent him by the hands of his servants ships, and servants that had knowledge of the sea; and they went with the servants of Solomon to Ophir, and took thence four hundred and fifty talents of gold, and brought /them/ to king Solomon. 
+18. And Huram sent him by the hands of his servants ships, and servants that had knowledge of the sea; and they went with the servants of Solomon to Ophir, and took thence four hundred and fifty talents of gold, and brought /them/ to king Solomon.
 * 9
 1. And when the queen of Sheba heard of the fame of Solomon, she came to prove Solomon with hard questions at Jerusalem, with a very great company, and camels that bare spices, and gold in abundance, and precious stones: and when she was come to Solomon, she communed with him of all that was in her heart.
 2. And Solomon told her all her questions: and there was nothing hid from Solomon which he told her not.
@@ -243,7 +243,7 @@
 
 29. Now the rest of the acts of Solomon, first and last, /are/ they not written in the book of Nathan the prophet, and in the prophecy of Ahijah the Shilonite, and in the visions of Iddo the seer against Jeroboam the son of Nebat?
 30. And Solomon reigned in Jerusalem over all Israel forty years.
-31. And Solomon slept with his fathers, and he was buried in the city of David his father: and Rehoboam his son reigned in his stead. 
+31. And Solomon slept with his fathers, and he was buried in the city of David his father: and Rehoboam his son reigned in his stead.
 * 10
 1. And Rehoboam went to Shechem: for to Shechem were all Israel come to make him king.
 2. And it came to pass, when Jeroboam the son of Nebat, who /was/ in Egypt, whither he had fled from the presence of Solomon the king, heard /it/, that Jeroboam returned out of Egypt.
@@ -265,7 +265,7 @@
 16. And when all Israel /saw/ that the king would not hearken unto them, the people answered the king, saying, What portion have we in David? and /we have/ none inheritance in the son of Jesse: every man to your tents, O Israel: /and/ now, David, see to thine own house. So all Israel went to their tents.
 17. But /as for/ the children of Israel that dwelt in the cities of Judah, Rehoboam reigned over them.
 18. Then king Rehoboam sent Hadoram that /was/ over the tribute; and the children of Israel stoned him with stones, that he died. But king Rehoboam made speed to get him up to /his/ chariot, to flee to Jerusalem.
-19. And Israel rebelled against the house of David unto this day. 
+19. And Israel rebelled against the house of David unto this day.
 * 11
 1. And when Rehoboam was come to Jerusalem, he gathered of the house of Judah and Benjamin an hundred and fourscore thousand chosen /men/, which were warriors, to fight against Israel, that he might bring the kingdom again to Rehoboam.
 2. But the word of the LORD came to Shemaiah the man of God, saying,
@@ -292,7 +292,7 @@
 20. And after her he took Maachah the daughter of Absalom; which bare him Abijah, and Attai, and Ziza, and Shelomith.
 21. And Rehoboam loved Maachah the daughter of Absalom above all his wives and his concubines: (for he took eighteen wives, and threescore concubines; and begat twenty and eight sons, and threescore daughters.)
 22. And Rehoboam made Abijah the son of Maachah the chief, /to be/ ruler among his brethren: for /he thought/ to make him king.
-23. And he dealt wisely, and dispersed of all his children throughout all the countries of Judah and Benjamin, unto every fenced city: and he gave them victual in abundance. And he desired many wives. 
+23. And he dealt wisely, and dispersed of all his children throughout all the countries of Judah and Benjamin, unto every fenced city: and he gave them victual in abundance. And he desired many wives.
 * 12
 1. And it came to pass, when Rehoboam had established the kingdom, and had strengthened himself, he forsook the law of the LORD, and all Israel with him.
 2. And it came to pass, /that/ in the fifth year of king Rehoboam Shishak king of Egypt came up against Jerusalem, because they had transgressed against the LORD,
@@ -311,7 +311,7 @@
 13. So king Rehoboam strengthened himself in Jerusalem, and reigned: for Rehoboam /was/ one and forty years old when he began to reign, and he reigned seventeen years in Jerusalem, the city which the LORD had chosen out of all the tribes of Israel, to put his name there. And his mother's name /was/ Naamah an Ammonitess.
 14. And he did evil, because he prepared not his heart to seek the LORD.
 15. Now the acts of Rehoboam, first and last, /are/ they not written in the book of Shemaiah the prophet, and of Iddo the seer concerning genealogies? And /there were/ wars between Rehoboam and Jeroboam continually.
-16. And Rehoboam slept with his fathers, and was buried in the city of David: and Abijah his son reigned in his stead. 
+16. And Rehoboam slept with his fathers, and was buried in the city of David: and Abijah his son reigned in his stead.
 * 13
 1. Now in the eighteenth year of king Jeroboam began Abijah to reign over Judah.
 2. He reigned three years in Jerusalem. His mother's name also /was/ Michaiah the daughter of Uriel of Gibeah. And there was war between Abijah and Jeroboam.
@@ -337,7 +337,7 @@
 20. Neither did Jeroboam recover strength again in the days of Abijah: and the LORD struck him, and he died.
 
 21. But Abijah waxed mighty, and married fourteen wives, and begat twenty and two sons, and sixteen daughters.
-22. And the rest of the acts of Abijah, and his ways, and his sayings, /are/ written in the story of the prophet Iddo. 
+22. And the rest of the acts of Abijah, and his ways, and his sayings, /are/ written in the story of the prophet Iddo.
 * 14
 1. So Abijah slept with his fathers, and they buried him in the city of David: and Asa his son reigned in his stead. In his days the land was quiet ten years.
 2. And Asa did /that which was/ good and right in the eyes of the LORD his God:
@@ -355,7 +355,7 @@
 12. So the LORD smote the Ethiopians before Asa, and before Judah; and the Ethiopians fled.
 13. And Asa and the people that /were/ with him pursued them unto Gerar: and the Ethiopians were overthrown, that they could not recover themselves; for they were destroyed before the LORD, and before his host; and they carried away very much spoil.
 14. And they smote all the cities round about Gerar; for the fear of the LORD came upon them: and they spoiled all the cities; for there was exceeding much spoil in them.
-15. They smote also the tents of cattle, and carried away sheep and camels in abundance, and returned to Jerusalem. 
+15. They smote also the tents of cattle, and carried away sheep and camels in abundance, and returned to Jerusalem.
 * 15
 1. And the Spirit of God came upon Azariah the son of Oded:
 2. And he went out to meet Asa, and said unto him, Hear ye me, Asa, and all Judah and Benjamin; The LORD /is/ with you, while ye be with him; and if ye seek him, he will be found of you; but if ye forsake him, he will forsake you.
@@ -377,7 +377,7 @@
 17. But the high places were not taken away out of Israel: nevertheless the heart of Asa was perfect all his days.
 
 18. And he brought into the house of God the things that his father had dedicated, and that he himself had dedicated, silver, and gold, and vessels.
-19. And there was no /more/ war unto the five and thirtieth year of the reign of Asa. 
+19. And there was no /more/ war unto the five and thirtieth year of the reign of Asa.
 * 16
 1. In the six and thirtieth year of the reign of Asa Baasha king of Israel came up against Judah, and built Ramah, to the intent that he might let none go out or come in to Asa king of Judah.
 2. Then Asa brought out silver and gold out of the treasures of the house of the LORD and of the king's house, and sent to Ben–hadad king of Syria, that dwelt at Damascus, saying,
@@ -395,7 +395,7 @@
 12. And Asa in the thirty and ninth year of his reign was diseased in his feet, until his disease /was/ exceeding /great/: yet in his disease he sought not to the LORD, but to the physicians.
 
 13. And Asa slept with his fathers, and died in the one and fortieth year of his reign.
-14. And they buried him in his own sepulchres, which he had made for himself in the city of David, and laid him in the bed which was filled with sweet odours and divers kinds /of spices/ prepared by the apothecaries' art: and they made a very great burning for him. 
+14. And they buried him in his own sepulchres, which he had made for himself in the city of David, and laid him in the bed which was filled with sweet odours and divers kinds /of spices/ prepared by the apothecaries' art: and they made a very great burning for him.
 * 17
 1. And Jehoshaphat his son reigned in his stead, and strengthened himself against Israel.
 2. And he placed forces in all the fenced cities of Judah, and set garrisons in the land of Judah, and in the cities of Ephraim, which Asa his father had taken.
@@ -418,7 +418,7 @@
 16. And next him /was/ Amasiah the son of Zichri, who willingly offered himself unto the LORD; and with him two hundred thousand mighty men of valour.
 17. And of Benjamin; Eliada a mighty man of valour, and with him armed men with bow and shield two hundred thousand.
 18. And next him /was/ Jehozabad, and with him an hundred and fourscore thousand ready prepared for the war.
-19. These waited on the king, beside /those/ whom the king put in the fenced cities throughout all Judah. 
+19. These waited on the king, beside /those/ whom the king put in the fenced cities throughout all Judah.
 * 18
 1. Now Jehoshaphat had riches and honour in abundance, and joined affinity with Ahab.
 2. And after /certain/ years he went down to Ahab to Samaria. And Ahab killed sheep and oxen for him in abundance, and for the people that /he had/ with him, and persuaded him to go up /with him/ to Ramoth–gilead.
@@ -454,7 +454,7 @@
 31. And it came to pass, when the captains of the chariots saw Jehoshaphat, that they said, It /is/ the king of Israel. Therefore they compassed about him to fight: but Jehoshaphat cried out, and the LORD helped him; and God moved them /to depart/ from him.
 32. For it came to pass, that, when the captains of the chariots perceived that it was not the king of Israel, they turned back again from pursuing him.
 33. And a /certain/ man drew a bow at a venture, and smote the king of Israel between the joints of the harness: therefore he said to his chariot man, Turn thine hand, that thou mayest carry me out of the host; for I am wounded.
-34. And the battle increased that day: howbeit the king of Israel stayed /himself/ up in /his/ chariot against the Syrians until the even: and about the time of the sun going down he died. 
+34. And the battle increased that day: howbeit the king of Israel stayed /himself/ up in /his/ chariot against the Syrians until the even: and about the time of the sun going down he died.
 * 19
 1. And Jehoshaphat the king of Judah returned to his house in peace to Jerusalem.
 2. And Jehu the son of Hanani the seer went out to meet him, and said to king Jehoshaphat, Shouldest thou help the ungodly, and love them that hate the LORD? therefore /is/ wrath upon thee from before the LORD.
@@ -468,7 +468,7 @@
 8. Moreover in Jerusalem did Jehoshaphat set of the Levites, and /of/ the priests, and of the chief of the fathers of Israel, for the judgment of the LORD, and for controversies, when they returned to Jerusalem.
 9. And he charged them, saying, Thus shall ye do in the fear of the LORD, faithfully, and with a perfect heart.
 10. And what cause soever shall come to you of your brethren that dwell in their cities, between blood and blood, between law and commandment, statutes and judgments, ye shall even warn them that they trespass not against the LORD, and /so/ wrath come upon you, and upon your brethren: this do, and ye shall not trespass.
-11. And, behold, Amariah the chief priest /is/ over you in all matters of the LORD; and Zebadiah the son of Ishmael, the ruler of the house of Judah, for all the king's matters: also the Levites /shall be/ officers before you. Deal courageously, and the LORD shall be with the good. 
+11. And, behold, Amariah the chief priest /is/ over you in all matters of the LORD; and Zebadiah the son of Ishmael, the ruler of the house of Judah, for all the king's matters: also the Levites /shall be/ officers before you. Deal courageously, and the LORD shall be with the good.
 * 20
 1. It came to pass after this also, /that/ the children of Moab, and the children of Ammon, and with them /other/ beside the Ammonites, came against Jehoshaphat to battle.
 2. Then there came some that told Jehoshaphat, saying, There cometh a great multitude against thee from beyond the sea on this side Syria; and, behold, they /be/ in Hazazon–tamar, which /is/ En–gedi.
@@ -513,7 +513,7 @@
 
 35. And after this did Jehoshaphat king of Judah join himself with Ahaziah king of Israel, who did very wickedly:
 36. And he joined himself with him to make ships to go to Tarshish: and they made the ships in Ezion–geber.
-37. Then Eliezer the son of Dodavah of Mareshah prophesied against Jehoshaphat, saying, Because thou hast joined thyself with Ahaziah, the LORD hath broken thy works. And the ships were broken, that they were not able to go to Tarshish. 
+37. Then Eliezer the son of Dodavah of Mareshah prophesied against Jehoshaphat, saying, Because thou hast joined thyself with Ahaziah, the LORD hath broken thy works. And the ships were broken, that they were not able to go to Tarshish.
 * 21
 1. Now Jehoshaphat slept with his fathers, and was buried with his fathers in the city of David. And Jehoram his son reigned in his stead.
 2. And he had brethren the sons of Jehoshaphat, Azariah, and Jehiel, and Zechariah, and Azariah, and Michael, and Shephatiah: all these /were/ the sons of Jehoshaphat king of Israel.
@@ -539,7 +539,7 @@
 
 18. And after all this the LORD smote him in his bowels with an incurable disease.
 19. And it came to pass, that in process of time, after the end of two years, his bowels fell out by reason of his sickness: so he died of sore diseases. And his people made no burning for him, like the burning of his fathers.
-20. Thirty and two years old was he when he began to reign, and he reigned in Jerusalem eight years, and departed without being desired. Howbeit they buried him in the city of David, but not in the sepulchres of the kings. 
+20. Thirty and two years old was he when he began to reign, and he reigned in Jerusalem eight years, and departed without being desired. Howbeit they buried him in the city of David, but not in the sepulchres of the kings.
 * 22
 1. And the inhabitants of Jerusalem made Ahaziah his youngest son king in his stead: for the band of men that came with the Arabians to the camp had slain all the eldest. So Ahaziah the son of Jehoram king of Judah reigned.
 2. Forty and two years old /was/ Ahaziah when he began to reign, and he reigned one year in Jerusalem. His mother's name also /was/ Athaliah the daughter of Omri.
@@ -554,7 +554,7 @@
 
 10. But when Athaliah the mother of Ahaziah saw that her son was dead, she arose and destroyed all the seed royal of the house of Judah.
 11. But Jehoshabeath, the daughter of the king, took Joash the son of Ahaziah, and stole him from among the king's sons that were slain, and put him and his nurse in a bedchamber. So Jehoshabeath, the daughter of king Jehoram, the wife of Jehoiada the priest, (for she was the sister of Ahaziah,) hid him from Athaliah, so that she slew him not.
-12. And he was with them hid in the house of God six years: and Athaliah reigned over the land. 
+12. And he was with them hid in the house of God six years: and Athaliah reigned over the land.
 * 23
 1. And in the seventh year Jehoiada strengthened himself, and took the captains of hundreds, Azariah the son of Jeroham, and Ishmael the son of Jehohanan, and Azariah the son of Obed, and Maaseiah the son of Adaiah, and Elishaphat the son of Zichri, into covenant with him.
 2. And they went about in Judah, and gathered the Levites out of all the cities of Judah, and the chief of the fathers of Israel, and they came to Jerusalem.
@@ -578,7 +578,7 @@
 18. Also Jehoiada appointed the offices of the house of the LORD by the hand of the priests the Levites, whom David had distributed in the house of the LORD, to offer the burnt offerings of the LORD, as /it is/ written in the law of Moses, with rejoicing and with singing, /as it was ordained/ by David.
 19. And he set the porters at the gates of the house of the LORD, that none /which was/ unclean in any thing should enter in.
 20. And he took the captains of hundreds, and the nobles, and the governors of the people, and all the people of the land, and brought down the king from the house of the LORD: and they came through the high gate into the king's house, and set the king upon the throne of the kingdom.
-21. And all the people of the land rejoiced: and the city was quiet, after that they had slain Athaliah with the sword. 
+21. And all the people of the land rejoiced: and the city was quiet, after that they had slain Athaliah with the sword.
 * 24
 1. Joash /was/ seven years old when he began to reign, and he reigned forty years in Jerusalem. His mother's name also /was/ Zibiah of Beer–sheba.
 2. And Joash did /that which was/ right in the sight of the LORD all the days of Jehoiada the priest.
@@ -610,7 +610,7 @@
 25. And when they were departed from him, (for they left him in great diseases,) his own servants conspired against him for the blood of the sons of Jehoiada the priest, and slew him on his bed, and he died: and they buried him in the city of David, but they buried him not in the sepulchres of the kings.
 26. And these are they that conspired against him; Zabad the son of Shimeath an Ammonitess, and Jehozabad the son of Shimrith a Moabitess.
 
-27. Now /concerning/ his sons, and the greatness of the burdens /laid/ upon him, and the repairing of the house of God, behold, they /are/ written in the story of the book of the kings. And Amaziah his son reigned in his stead. 
+27. Now /concerning/ his sons, and the greatness of the burdens /laid/ upon him, and the repairing of the house of God, behold, they /are/ written in the story of the book of the kings. And Amaziah his son reigned in his stead.
 * 25
 1. Amaziah /was/ twenty and five years old /when/ he began to reign, and he reigned twenty and nine years in Jerusalem. And his mother's name /was/ Jehoaddan of Jerusalem.
 2. And he did /that which was/ right in the sight of the LORD, but not with a perfect heart.
@@ -647,7 +647,7 @@
 26. Now the rest of the acts of Amaziah, first and last, behold, /are/ they not written in the book of the kings of Judah and Israel?
 
 27. Now after the time that Amaziah did turn away from following the LORD they made a conspiracy against him in Jerusalem; and he fled to Lachish: but they sent to Lachish after him, and slew him there.
-28. And they brought him upon horses, and buried him with his fathers in the city of Judah. 
+28. And they brought him upon horses, and buried him with his fathers in the city of Judah.
 * 26
 1. Then all the people of Judah took Uzziah, who /was/ sixteen years old, and made him king in the room of his father Amaziah.
 2. He built Eloth, and restored it to Judah, after that the king slept with his fathers.
@@ -673,7 +673,7 @@
 21. And Uzziah the king was a leper unto the day of his death, and dwelt in a several house, /being/ a leper; for he was cut off from the house of the LORD: and Jotham his son /was/ over the king's house, judging the people of the land.
 
 22. Now the rest of the acts of Uzziah, first and last, did Isaiah the prophet, the son of Amoz, write.
-23. So Uzziah slept with his fathers, and they buried him with his fathers in the field of the burial which /belonged/ to the kings; for they said, He /is/ a leper: and Jotham his son reigned in his stead. 
+23. So Uzziah slept with his fathers, and they buried him with his fathers in the field of the burial which /belonged/ to the kings; for they said, He /is/ a leper: and Jotham his son reigned in his stead.
 * 27
 1. Jotham /was/ twenty and five years old when he began to reign, and he reigned sixteen years in Jerusalem. His mother's name also /was/ Jerushah, the daughter of Zadok.
 2. And he did /that which was/ right in the sight of the LORD, according to all that his father Uzziah did: howbeit he entered not into the temple of the LORD. And the people did yet corruptly.
@@ -686,7 +686,7 @@
 7. Now the rest of the acts of Jotham, and all his wars, and his ways, lo, they /are/ written in the book of the kings of Israel and Judah.
 8. He was five and twenty years old when he began to reign, and reigned sixteen years in Jerusalem.
 
-9. And Jotham slept with his fathers, and they buried him in the city of David: and Ahaz his son reigned in his stead. 
+9. And Jotham slept with his fathers, and they buried him in the city of David: and Ahaz his son reigned in his stead.
 * 28
 1. Ahaz /was/ twenty years old when he began to reign, and he reigned sixteen years in Jerusalem: but he did not /that which was/ right in the sight of the LORD, like David his father:
 2. For he walked in the ways of the kings of Israel, and made also molten images for Baalim.
@@ -718,7 +718,7 @@
 25. And in every several city of Judah he made high places to burn incense unto other gods, and provoked to anger the LORD God of his fathers.
 
 26. Now the rest of his acts and of all his ways, first and last, behold, they /are/ written in the book of the kings of Judah and Israel.
-27. And Ahaz slept with his fathers, and they buried him in the city, /even/ in Jerusalem: but they brought him not into the sepulchres of the kings of Israel: and Hezekiah his son reigned in his stead. 
+27. And Ahaz slept with his fathers, and they buried him in the city, /even/ in Jerusalem: but they brought him not into the sepulchres of the kings of Israel: and Hezekiah his son reigned in his stead.
 * 29
 1. Hezekiah began to reign /when he was/ five and twenty years old, and he reigned nine and twenty years in Jerusalem. And his mother's name /was/ Abijah, the daughter of Zechariah.
 2. And he did /that which was/ right in the sight of the LORD, according to all that David his father had done.
@@ -758,7 +758,7 @@
 33. And the consecrated things /were/ six hundred oxen and three thousand sheep.
 34. But the priests were too few, so that they could not flay all the burnt offerings: wherefore their brethren the Levites did help them, till the work was ended, and until the /other/ priests had sanctified themselves: for the Levites /were/ more upright in heart to sanctify themselves than the priests.
 35. And also the burnt offerings /were/ in abundance, with the fat of the peace offerings, and the drink offerings for /every/ burnt offering. So the service of the house of the LORD was set in order.
-36. And Hezekiah rejoiced, and all the people, that God had prepared the people: for the thing was /done/ suddenly. 
+36. And Hezekiah rejoiced, and all the people, that God had prepared the people: for the thing was /done/ suddenly.
 * 30
 1. And Hezekiah sent to all Israel and Judah, and wrote letters also to Ephraim and Manasseh, that they should come to the house of the LORD at Jerusalem, to keep the passover unto the LORD God of Israel.
 2. For the king had taken counsel, and his princes, and all the congregation in Jerusalem, to keep the passover in the second month.
@@ -788,7 +788,7 @@
 25. And all the congregation of Judah, with the priests and the Levites, and all the congregation that came out of Israel, and the strangers that came out of the land of Israel, and that dwelt in Judah, rejoiced.
 26. So there was great joy in Jerusalem: for since the time of Solomon the son of David king of Israel /there was/ not the like in Jerusalem.
 
-27. Then the priests the Levites arose and blessed the people: and their voice was heard, and their prayer came /up/ to his holy dwelling place, /even/ unto heaven. 
+27. Then the priests the Levites arose and blessed the people: and their voice was heard, and their prayer came /up/ to his holy dwelling place, /even/ unto heaven.
 * 31
 1. Now when all this was finished, all Israel that were present went out to the cities of Judah, and brake the images in pieces, and cut down the groves, and threw down the high places and the altars out of all Judah and Benjamin, in Ephraim also and Manasseh, until they had utterly destroyed them all. Then all the children of Israel returned, every man to his possession, into their own cities.
 
@@ -814,7 +814,7 @@
 19. Also of the sons of Aaron the priests, /which were/ in the fields of the suburbs of their cities, in every several city, the men that were expressed by name, to give portions to all the males among the priests, and to all that were reckoned by genealogies among the Levites.
 
 20. And thus did Hezekiah throughout all Judah, and wrought /that which was/ good and right and truth before the LORD his God.
-21. And in every work that he began in the service of the house of God, and in the law, and in the commandments, to seek his God, he did /it/ with all his heart, and prospered. 
+21. And in every work that he began in the service of the house of God, and in the law, and in the commandments, to seek his God, he did /it/ with all his heart, and prospered.
 * 32
 1. After these things, and the establishment thereof, Sennacherib king of Assyria came, and entered into Judah, and encamped against the fenced cities, and thought to win them for himself.
 2. And when Hezekiah saw that Sennacherib was come, and that he was purposed to fight against Jerusalem,
@@ -854,7 +854,7 @@
 31. Howbeit in /the business of/ the ambassadors of the princes of Babylon, who sent unto him to enquire of the wonder that was /done/ in the land, God left him, to try him, that he might know all /that was/ in his heart.
 
 32. Now the rest of the acts of Hezekiah, and his goodness, behold, they /are/ written in the vision of Isaiah the prophet, the son of Amoz, /and/ in the book of the kings of Judah and Israel.
-33. And Hezekiah slept with his fathers, and they buried him in the chiefest of the sepulchres of the sons of David: and all Judah and the inhabitants of Jerusalem did him honour at his death. And Manasseh his son reigned in his stead. 
+33. And Hezekiah slept with his fathers, and they buried him in the chiefest of the sepulchres of the sons of David: and all Judah and the inhabitants of Jerusalem did him honour at his death. And Manasseh his son reigned in his stead.
 * 33
 1. Manasseh /was/ twelve years old when he began to reign, and he reigned fifty and five years in Jerusalem:
 2. But did /that which was/ evil in the sight of the LORD, like unto the abominations of the heathen, whom the LORD had cast out before the children of Israel.
@@ -886,7 +886,7 @@
 23. And humbled not himself before the LORD, as Manasseh his father had humbled himself; but Amon trespassed more and more.
 24. And his servants conspired against him, and slew him in his own house.
 
-25. But the people of the land slew all them that had conspired against king Amon; and the people of the land made Josiah his son king in his stead. 
+25. But the people of the land slew all them that had conspired against king Amon; and the people of the land made Josiah his son king in his stead.
 * 34
 1. Josiah /was/ eight years old when he began to reign, and he reigned in Jerusalem one and thirty years.
 2. And he did /that which was/ right in the sight of the LORD, and walked in the ways of David his father, and declined /neither/ to the right hand, nor to the left.
@@ -925,7 +925,7 @@
 30. And the king went up into the house of the LORD, and all the men of Judah, and the inhabitants of Jerusalem, and the priests, and the Levites, and all the people, great and small: and he read in their ears all the words of the book of the covenant that was found in the house of the LORD.
 31. And the king stood in his place, and made a covenant before the LORD, to walk after the LORD, and to keep his commandments, and his testimonies, and his statutes, with all his heart, and with all his soul, to perform the words of the covenant which are written in this book.
 32. And he caused all that were present in Jerusalem and Benjamin to stand /to it/. And the inhabitants of Jerusalem did according to the covenant of God, the God of their fathers.
-33. And Josiah took away all the abominations out of all the countries that /pertained/ to the children of Israel, and made all that were present in Israel to serve, /even/ to serve the LORD their God. /And/ all his days they departed not from following the LORD, the God of their fathers. 
+33. And Josiah took away all the abominations out of all the countries that /pertained/ to the children of Israel, and made all that were present in Israel to serve, /even/ to serve the LORD their God. /And/ all his days they departed not from following the LORD, the God of their fathers.
 * 35
 1. Moreover Josiah kept a passover unto the LORD in Jerusalem: and they killed the passover on the fourteenth /day/ of the first month.
 2. And he set the priests in their charges, and encouraged them to the service of the house of the LORD,
@@ -955,7 +955,7 @@
 
 25. And Jeremiah lamented for Josiah: and all the singing men and the singing women spake of Josiah in their lamentations to this day, and made them an ordinance in Israel: and, behold, they /are/ written in the lamentations.
 26. Now the rest of the acts of Josiah, and his goodness, according to /that which was/ written in the law of the LORD,
-27. And his deeds, first and last, behold, they /are/ written in the book of the kings of Israel and Judah. 
+27. And his deeds, first and last, behold, they /are/ written in the book of the kings of Israel and Judah.
 * 36
 1. Then the people of the land took Jehoahaz the son of Josiah, and made him king in his father's stead in Jerusalem.
 2. Jehoahaz /was/ twenty and three years old when he began to reign, and he reigned three months in Jerusalem.
@@ -984,4 +984,4 @@
 21. To fulfil the word of the LORD by the mouth of Jeremiah, until the land had enjoyed her sabbaths: /for/ as long as she lay desolate she kept sabbath, to fulfil threescore and ten years.
 
 22. Now in the first year of Cyrus king of Persia, that the word of the LORD /spoken/ by the mouth of Jeremiah might be accomplished, the LORD stirred up the spirit of Cyrus king of Persia, that he made a proclamation throughout all his kingdom, and /put it/ also in writing, saying,
-23. Thus saith Cyrus king of Persia, All the kingdoms of the earth hath the LORD God of heaven given me; and he hath charged me to build him an house in Jerusalem, which /is/ in Judah. Who /is there/ among you of all his people? The LORD his God /be/ with him, and let him go up.  
+23. Thus saith Cyrus king of Persia, All the kingdoms of the earth hath the LORD God of heaven given me; and he hath charged me to build him an house in Jerusalem, which /is/ in Judah. Who /is there/ among you of all his people? The LORD his God /be/ with him, and let him go up.

--- a/15_EZR.org
+++ b/15_EZR.org
@@ -12,7 +12,7 @@
 8. Even those did Cyrus king of Persia bring forth by the hand of Mithredath the treasurer, and numbered them unto Sheshbazzar, the prince of Judah.
 9. And this /is/ the number of them: thirty chargers of gold, a thousand chargers of silver, nine and twenty knives,
 10. Thirty basons of gold, silver basons of a second /sort/ four hundred and ten, /and/ other vessels a thousand.
-11. All the vessels of gold and of silver /were/ five thousand and four hundred. All /these/ did Sheshbazzar bring up with /them of/ the captivity that were brought up from Babylon unto Jerusalem. 
+11. All the vessels of gold and of silver /were/ five thousand and four hundred. All /these/ did Sheshbazzar bring up with /them of/ the captivity that were brought up from Babylon unto Jerusalem.
 * 2
 1. Now these /are/ the children of the province that went up out of the captivity, of those which had been carried away, whom Nebuchadnezzar the king of Babylon had carried away unto Babylon, and came again unto Jerusalem and Judah, every one unto his city;
 2. Which came with Zerubbabel: Jeshua, Nehemiah, Seraiah, Reelaiah, Mordecai, Bilshan, Mispar, Bigvai, Rehum, Baanah. The number of the men of the people of Israel:
@@ -92,7 +92,7 @@
 
 68. And /some/ of the chief of the fathers, when they came to the house of the LORD which /is/ at Jerusalem, offered freely for the house of God to set it up in his place:
 69. They gave after their ability unto the treasure of the work threescore and one thousand drams of gold, and five thousand pound of silver, and one hundred priests' garments.
-70. So the priests, and the Levites, and /some/ of the people, and the singers, and the porters, and the Nethinims, dwelt in their cities, and all Israel in their cities. 
+70. So the priests, and the Levites, and /some/ of the people, and the singers, and the porters, and the Nethinims, dwelt in their cities, and all Israel in their cities.
 * 3
 1. And when the seventh month was come, and the children of Israel /were/ in the cities, the people gathered themselves together as one man to Jerusalem.
 2. Then stood up Jeshua the son of Jozadak, and his brethren the priests, and Zerubbabel the son of Shealtiel, and his brethren, and builded the altar of the God of Israel, to offer burnt offerings thereon, as /it is/ written in the law of Moses the man of God.
@@ -107,7 +107,7 @@
 10. And when the builders laid the foundation of the temple of the LORD, they set the priests in their apparel with trumpets, and the Levites the sons of Asaph with cymbals, to praise the LORD, after the ordinance of David king of Israel.
 11. And they sang together by course in praising and giving thanks unto the LORD; because /he is/ good, for his mercy /endureth/ for ever toward Israel. And all the people shouted with a great shout, when they praised the LORD, because the foundation of the house of the LORD was laid.
 12. But many of the priests and Levites and chief of the fathers, /who were/ ancient men, that had seen the first house, when the foundation of this house was laid before their eyes, wept with a loud voice; and many shouted aloud for joy:
-13. So that the people could not discern the noise of the shout of joy from the noise of the weeping of the people: for the people shouted with a loud shout, and the noise was heard afar off. 
+13. So that the people could not discern the noise of the shout of joy from the noise of the weeping of the people: for the people shouted with a loud shout, and the noise was heard afar off.
 * 4
 1. Now when the adversaries of Judah and Benjamin heard that the children of the captivity builded the temple unto the LORD God of Israel;
 2. Then they came to Zerubbabel, and to the chief of the fathers, and said unto them, Let us build with you: for we seek your God, as ye /do/; and we do sacrifice unto him since the days of Esar–haddon king of Assur, which brought us up hither.
@@ -136,7 +136,7 @@
 22. Take heed now that ye fail not to do this: why should damage grow to the hurt of the kings?
 
 23. Now when the copy of king Artaxerxes' letter /was/ read before Rehum, and Shimshai the scribe, and their companions, they went up in haste to Jerusalem unto the Jews, and made them to cease by force and power.
-24. Then ceased the work of the house of God which /is/ at Jerusalem. So it ceased unto the second year of the reign of Darius king of Persia. 
+24. Then ceased the work of the house of God which /is/ at Jerusalem. So it ceased unto the second year of the reign of Darius king of Persia.
 * 5
 1. Then the prophets, Haggai the prophet, and Zechariah the son of Iddo, prophesied unto the Jews that /were/ in Judah and Jerusalem in the name of the God of Israel, /even/ unto them.
 2. Then rose up Zerubbabel the son of Shealtiel, and Jeshua the son of Jozadak, and began to build the house of God which /is/ at Jerusalem: and with them /were/ the prophets of God helping them.
@@ -156,7 +156,7 @@
 14. And the vessels also of gold and silver of the house of God, which Nebuchadnezzar took out of the temple that /was/ in Jerusalem, and brought them into the temple of Babylon, those did Cyrus the king take out of the temple of Babylon, and they were delivered unto /one/, whose name /was/ Sheshbazzar, whom he had made governor;
 15. And said unto him, Take these vessels, go, carry them into the temple that /is/ in Jerusalem, and let the house of God be builded in his place.
 16. Then came the same Sheshbazzar, /and/ laid the foundation of the house of God which /is/ in Jerusalem: and since that time even until now hath it been in building, and /yet/ it is not finished.
-17. Now therefore, if /it seem/ good to the king, let there be search made in the king's treasure house, which /is/ there at Babylon, whether it be /so/, that a decree was made of Cyrus the king to build this house of God at Jerusalem, and let the king send his pleasure to us concerning this matter. 
+17. Now therefore, if /it seem/ good to the king, let there be search made in the king's treasure house, which /is/ there at Babylon, whether it be /so/, that a decree was made of Cyrus the king to build this house of God at Jerusalem, and let the king send his pleasure to us concerning this matter.
 * 6
 1. Then Darius the king made a decree, and search was made in the house of the rolls, where the treasures were laid up in Babylon.
 2. And there was found at Achmetha, in the palace that /is/ in the province of the Medes, a roll, and therein /was/ a record thus written:
@@ -181,7 +181,7 @@
 19. And the children of the captivity kept the passover upon the fourteenth /day/ of the first month.
 20. For the priests and the Levites were purified together, all of them /were/ pure, and killed the passover for all the children of the captivity, and for their brethren the priests, and for themselves.
 21. And the children of Israel, which were come again out of captivity, and all such as had separated themselves unto them from the filthiness of the heathen of the land, to seek the LORD God of Israel, did eat,
-22. And kept the feast of unleavened bread seven days with joy: for the LORD had made them joyful, and turned the heart of the king of Assyria unto them, to strengthen their hands in the work of the house of God, the God of Israel. 
+22. And kept the feast of unleavened bread seven days with joy: for the LORD had made them joyful, and turned the heart of the king of Assyria unto them, to strengthen their hands in the work of the house of God, the God of Israel.
 * 7
 1. Now after these things, in the reign of Artaxerxes king of Persia, Ezra the son of Seraiah, the son of Azariah, the son of Hilkiah,
 2. The son of Shallum, the son of Zadok, the son of Ahitub,
@@ -212,7 +212,7 @@
 26. And whosoever will not do the law of thy God, and the law of the king, let judgment be executed speedily upon him, whether /it be/ unto death, or to banishment, or to confiscation of goods, or to imprisonment.
 
 27. Blessed /be/ the LORD God of our fathers, which hath put /such a thing/ as this in the king's heart, to beautify the house of the LORD which /is/ in Jerusalem:
-28. And hath extended mercy unto me before the king, and his counsellors, and before all the king's mighty princes. And I was strengthened as the hand of the LORD my God /was/ upon me, and I gathered together out of Israel chief men to go up with me. 
+28. And hath extended mercy unto me before the king, and his counsellors, and before all the king's mighty princes. And I was strengthened as the hand of the LORD my God /was/ upon me, and I gathered together out of Israel chief men to go up with me.
 * 8
 1. These /are/ now the chief of their fathers, and /this is/ the genealogy of them that went up with me from Babylon, in the reign of Artaxerxes the king.
 2. Of the sons of Phinehas; Gershom: of the sons of Ithamar; Daniel: of the sons of David; Hattush.
@@ -255,7 +255,7 @@
 34. By number /and/ by weight of every one: and all the weight was written at that time.
 35. /Also/ the children of those that had been carried away, which were come out of the captivity, offered burnt offerings unto the God of Israel, twelve bullocks for all Israel, ninety and six rams, seventy and seven lambs, twelve he goats /for/ a sin offering: all /this was/ a burnt offering unto the LORD.
 
-36. And they delivered the king's commissions unto the king's lieutenants, and to the governors on this side the river: and they furthered the people, and the house of God. 
+36. And they delivered the king's commissions unto the king's lieutenants, and to the governors on this side the river: and they furthered the people, and the house of God.
 * 9
 1. Now when these things were done, the princes came to me, saying, The people of Israel, and the priests, and the Levites, have not separated themselves from the people of the lands, /doing/ according to their abominations, /even/ of the Canaanites, the Hittites, the Perizzites, the Jebusites, the Ammonites, the Moabites, the Egyptians, and the Amorites.
 2. For they have taken of their daughters for themselves, and for their sons: so that the holy seed have mingled themselves with the people of /those/ lands: yea, the hand of the princes and rulers hath been chief in this trespass.
@@ -272,7 +272,7 @@
 12. Now therefore give not your daughters unto their sons, neither take their daughters unto your sons, nor seek their peace or their wealth for ever: that ye may be strong, and eat the good of the land, and leave /it/ for an inheritance to your children for ever.
 13. And after all that is come upon us for our evil deeds, and for our great trespass, seeing that thou our God hast punished us less than our iniquities /deserve/, and hast given us /such/ deliverance as this;
 14. Should we again break thy commandments, and join in affinity with the people of these abominations? wouldest not thou be angry with us till thou hadst consumed /us/, so that /there should be/ no remnant nor escaping?
-15. O LORD God of Israel, thou /art/ righteous: for we remain yet escaped, as /it is/ this day: behold, we /are/ before thee in our trespasses: for we cannot stand before thee because of this. 
+15. O LORD God of Israel, thou /art/ righteous: for we remain yet escaped, as /it is/ this day: behold, we /are/ before thee in our trespasses: for we cannot stand before thee because of this.
 * 10
 1. Now when Ezra had prayed, and when he had confessed, weeping and casting himself down before the house of God, there assembled unto him out of Israel a very great congregation of men and women and children: for the people wept very sore.
 2. And Shechaniah the son of Jehiel, /one/ of the sons of Elam, answered and said unto Ezra, We have trespassed against our God, and have taken strange wives of the people of the land: yet now there is hope in Israel concerning this thing.
@@ -321,4 +321,4 @@
 41. Azareel, and Shelemiah, Shemariah,
 42. Shallum, Amariah, /and/ Joseph.
 43. Of the sons of Nebo; Jeiel, Mattithiah, Zabad, Zebina, Jadau, and Joel, Benaiah.
-44. All these had taken strange wives: and /some/ of them had wives by whom they had children.  
+44. All these had taken strange wives: and /some/ of them had wives by whom they had children.

--- a/16_NEH.org
+++ b/16_NEH.org
@@ -11,7 +11,7 @@
 8. Remember, I beseech thee, the word that thou commandedst thy servant Moses, saying, /If/ ye transgress, I will scatter you abroad among the nations:
 9. But /if/ ye turn unto me, and keep my commandments, and do them; though there were of you cast out unto the uttermost part of the heaven, /yet/ will I gather them from thence, and will bring them unto the place that I have chosen to set my name there.
 10. Now these /are/ thy servants and thy people, whom thou hast redeemed by thy great power, and by thy strong hand.
-11. O Lord, I beseech thee, let now thine ear be attentive to the prayer of thy servant, and to the prayer of thy servants, who desire to fear thy name: and prosper, I pray thee, thy servant this day, and grant him mercy in the sight of this man. For I was the king's cupbearer. 
+11. O Lord, I beseech thee, let now thine ear be attentive to the prayer of thy servant, and to the prayer of thy servants, who desire to fear thy name: and prosper, I pray thee, thy servant this day, and grant him mercy in the sight of this man. For I was the king's cupbearer.
 * 2
 1. And it came to pass in the month Nisan, in the twentieth year of Artaxerxes the king, /that/ wine /was/ before him: and I took up the wine, and gave /it/ unto the king. Now I had not been /beforetime/ sad in his presence.
 2. Wherefore the king said unto me, Why /is/ thy countenance sad, seeing thou /art/ not sick? this /is/ nothing /else/ but sorrow of heart. Then I was very sore afraid,
@@ -35,7 +35,7 @@
 17. Then said I unto them, Ye see the distress that we /are/ in, how Jerusalem /lieth/ waste, and the gates thereof are burned with fire: come, and let us build up the wall of Jerusalem, that we be no more a reproach.
 18. Then I told them of the hand of my God which was good upon me; as also the king's words that he had spoken unto me. And they said, Let us rise up and build. So they strengthened their hands for /this/ good /work/.
 19. But when Sanballat the Horonite, and Tobiah the servant, the Ammonite, and Geshem the Arabian, heard /it/, they laughed us to scorn, and despised us, and said, What /is/ this thing that ye do? will ye rebel against the king?
-20. Then answered I them, and said unto them, The God of heaven, he will prosper us; therefore we his servants will arise and build: but ye have no portion, nor right, nor memorial, in Jerusalem. 
+20. Then answered I them, and said unto them, The God of heaven, he will prosper us; therefore we his servants will arise and build: but ye have no portion, nor right, nor memorial, in Jerusalem.
 * 3
 1. Then Eliashib the high priest rose up with his brethren the priests, and they builded the sheep gate; they sanctified it, and set up the doors of it; even unto the tower of Meah they sanctified it, unto the tower of Hananeel.
 2. And next unto him builded the men of Jericho. And next to them builded Zaccur the son of Imri.
@@ -68,7 +68,7 @@
 29. After them repaired Zadok the son of Immer over against his house. After him repaired also Shemaiah the son of Shechaniah, the keeper of the east gate.
 30. After him repaired Hananiah the son of Shelemiah, and Hanun the sixth son of Zalaph, another piece. After him repaired Meshullam the son of Berechiah over against his chamber.
 31. After him repaired Malchiah the goldsmith's son unto the place of the Nethinims, and of the merchants, over against the gate Miphkad, and to the going up of the corner.
-32. And between the going up of the corner unto the sheep gate repaired the goldsmiths and the merchants. 
+32. And between the going up of the corner unto the sheep gate repaired the goldsmiths and the merchants.
 * 4
 1. But it came to pass, that when Sanballat heard that we builded the wall, he was wroth, and took great indignation, and mocked the Jews.
 2. And he spake before his brethren and the army of Samaria, and said, What do these feeble Jews? will they fortify themselves? will they sacrifice? will they make an end in a day? will they revive the stones out of the heaps of the rubbish which are burned?
@@ -95,7 +95,7 @@
 20. In what place /therefore/ ye hear the sound of the trumpet, resort ye thither unto us: our God shall fight for us.
 21. So we laboured in the work: and half of them held the spears from the rising of the morning till the stars appeared.
 22. Likewise at the same time said I unto the people, Let every one with his servant lodge within Jerusalem, that in the night they may be a guard to us, and labour on the day.
-23. So neither I, nor my brethren, nor my servants, nor the men of the guard which followed me, none of us put off our clothes, /saving that/ every one put them off for washing. 
+23. So neither I, nor my brethren, nor my servants, nor the men of the guard which followed me, none of us put off our clothes, /saving that/ every one put them off for washing.
 * 5
 1. And there was a great cry of the people and of their wives against their brethren the Jews.
 2. For there were that said, We, our sons, and our daughters, /are/ many: therefore we take up corn /for them/, that we may eat, and live.
@@ -117,7 +117,7 @@
 16. Yea, also I continued in the work of this wall, neither bought we any land: and all my servants /were/ gathered thither unto the work.
 17. Moreover /there were/ at my table an hundred and fifty of the Jews and rulers, beside those that came unto us from among the heathen that /are/ about us.
 18. Now /that/ which was prepared /for me/ daily /was/ one ox /and/ six choice sheep; also fowls were prepared for me, and once in ten days store of all sorts of wine: yet for all this required not I the bread of the governor, because the bondage was heavy upon this people.
-19. Think upon me, my God, for good, /according/ to all that I have done for this people. 
+19. Think upon me, my God, for good, /according/ to all that I have done for this people.
 * 6
 1. Now it came to pass, when Sanballat, and Tobiah, and Geshem the Arabian, and the rest of our enemies, heard that I had builded the wall, and /that/ there was no breach left therein; (though at that time I had not set up the doors upon the gates;)
 2. That Sanballat and Geshem sent unto me, saying, Come, let us meet together in /some one of/ the villages in the plain of Ono. But they thought to do me mischief.
@@ -139,7 +139,7 @@
 
 17. Moreover in those days the nobles of Judah sent many letters unto Tobiah, and /the letters/ of Tobiah came unto them.
 18. For /there were/ many in Judah sworn unto him, because he /was/ the son in law of Shechaniah the son of Arah; and his son Johanan had taken the daughter of Meshullam the son of Berechiah.
-19. Also they reported his good deeds before me, and uttered my words to him. /And/ Tobiah sent letters to put me in fear. 
+19. Also they reported his good deeds before me, and uttered my words to him. /And/ Tobiah sent letters to put me in fear.
 * 7
 1. Now it came to pass, when the wall was built, and I had set up the doors, and the porters and the singers and the Levites were appointed,
 2. That I gave my brother Hanani, and Hananiah the ruler of the palace, charge over Jerusalem: for he /was/ a faithful man, and feared God above many.
@@ -223,7 +223,7 @@
 70. And some of the chief of the fathers gave unto the work. The Tirshatha gave to the treasure a thousand drams of gold, fifty basons, five hundred and thirty priests' garments.
 71. And /some/ of the chief of the fathers gave to the treasure of the work twenty thousand drams of gold, and two thousand and two hundred pound of silver.
 72. And /that/ which the rest of the people gave /was/ twenty thousand drams of gold, and two thousand pound of silver, and threescore and seven priests' garments.
-73. So the priests, and the Levites, and the porters, and the singers, and /some/ of the people, and the Nethinims, and all Israel, dwelt in their cities; and when the seventh month came, the children of Israel /were/ in their cities. 
+73. So the priests, and the Levites, and the porters, and the singers, and /some/ of the people, and the Nethinims, and all Israel, dwelt in their cities; and when the seventh month came, the children of Israel /were/ in their cities.
 * 8
 1. And all the people gathered themselves together as one man into the street that /was/ before the water gate; and they spake unto Ezra the scribe to bring the book of the law of Moses, which the LORD had commanded to Israel.
 2. And Ezra the priest brought the law before the congregation both of men and women, and all that could hear with understanding, upon the first day of the seventh month.
@@ -245,7 +245,7 @@
 
 16. So the people went forth, and brought /them/, and made themselves booths, every one upon the roof of his house, and in their courts, and in the courts of the house of God, and in the street of the water gate, and in the street of the gate of Ephraim.
 17. And all the congregation of them that were come again out of the captivity made booths, and sat under the booths: for since the days of Jeshua the son of Nun unto that day had not the children of Israel done so. And there was very great gladness.
-18. Also day by day, from the first day unto the last day, he read in the book of the law of God. And they kept the feast seven days; and on the eighth day /was/ a solemn assembly, according unto the manner. 
+18. Also day by day, from the first day unto the last day, he read in the book of the law of God. And they kept the feast seven days; and on the eighth day /was/ a solemn assembly, according unto the manner.
 * 9
 1. Now in the twenty and fourth day of this month the children of Israel were assembled with fasting, and with sackclothes, and earth upon them.
 2. And the seed of Israel separated themselves from all strangers, and stood and confessed their sins, and the iniquities of their fathers.
@@ -285,7 +285,7 @@
 35. For they have not served thee in their kingdom, and in thy great goodness that thou gavest them, and in the large and fat land which thou gavest before them, neither turned they from their wicked works.
 36. Behold, we /are/ servants this day, and /for/ the land that thou gavest unto our fathers to eat the fruit thereof and the good thereof, behold, we /are/ servants in it:
 37. And it yieldeth much increase unto the kings whom thou hast set over us because of our sins: also they have dominion over our bodies, and over our cattle, at their pleasure, and we /are/ in great distress.
-38. And because of all this we make a sure /covenant/, and write /it/; and our princes, Levites, /and/ priests, seal /unto it/. 
+38. And because of all this we make a sure /covenant/, and write /it/; and our princes, Levites, /and/ priests, seal /unto it/.
 * 10
 1. Now those that sealed /were/, Nehemiah, the Tirshatha, the son of Hachaliah, and Zidkijah,
 2. Seraiah, Azariah, Jeremiah,
@@ -326,7 +326,7 @@
 36. Also the firstborn of our sons, and of our cattle, as /it is/ written in the law, and the firstlings of our herds and of our flocks, to bring to the house of our God, unto the priests that minister in the house of our God:
 37. And /that/ we should bring the firstfruits of our dough, and our offerings, and the fruit of all manner of trees, of wine and of oil, unto the priests, to the chambers of the house of our God; and the tithes of our ground unto the Levites, that the same Levites might have the tithes in all the cities of our tillage.
 38. And the priest the son of Aaron shall be with the Levites, when the Levites take tithes: and the Levites shall bring up the tithe of the tithes unto the house of our God, to the chambers, into the treasure house.
-39. For the children of Israel and the children of Levi shall bring the offering of the corn, of the new wine, and the oil, unto the chambers, where /are/ the vessels of the sanctuary, and the priests that minister, and the porters, and the singers: and we will not forsake the house of our God. 
+39. For the children of Israel and the children of Levi shall bring the offering of the corn, of the new wine, and the oil, unto the chambers, where /are/ the vessels of the sanctuary, and the priests that minister, and the porters, and the singers: and we will not forsake the house of our God.
 * 11
 1. And the rulers of the people dwelt at Jerusalem: the rest of the people also cast lots, to bring one of ten to dwell in Jerusalem the holy city, and nine parts /to dwell/ in /other/ cities.
 2. And the people blessed all the men, that willingly offered themselves to dwell at Jerusalem.
@@ -365,7 +365,7 @@
 33. Hazor, Ramah, Gittaim,
 34. Hadid, Zeboim, Neballat,
 35. Lod, and Ono, the valley of craftsmen.
-36. And of the Levites /were/ divisions /in/ Judah, /and/ in Benjamin. 
+36. And of the Levites /were/ divisions /in/ Judah, /and/ in Benjamin.
 * 12
 1. Now these /are/ the priests and the Levites that went up with Zerubbabel the son of Shealtiel, and Jeshua: Seraiah, Jeremiah, Ezra,
 2. Amariah, Malluch, Hattush,
@@ -417,7 +417,7 @@
 44. And at that time were some appointed over the chambers for the treasures, for the offerings, for the firstfruits, and for the tithes, to gather into them out of the fields of the cities the portions of the law for the priests and Levites: for Judah rejoiced for the priests and for the Levites that waited.
 45. And both the singers and the porters kept the ward of their God, and the ward of the purification, according to the commandment of David, /and/ of Solomon his son.
 46. For in the days of David and Asaph of old /there were/ chief of the singers, and songs of praise and thanksgiving unto God.
-47. And all Israel in the days of Zerubbabel, and in the days of Nehemiah, gave the portions of the singers and the porters, every day his portion: and they sanctified /holy things/ unto the Levites; and the Levites sanctified /them/ unto the children of Aaron. 
+47. And all Israel in the days of Zerubbabel, and in the days of Nehemiah, gave the portions of the singers and the porters, every day his portion: and they sanctified /holy things/ unto the Levites; and the Levites sanctified /them/ unto the children of Aaron.
 * 13
 1. On that day they read in the book of Moses in the audience of the people; and therein was found written, that the Ammonite and the Moabite should not come into the congregation of God for ever;
 2. Because they met not the children of Israel with bread and with water, but hired Balaam against them, that he should curse them: howbeit our God turned the curse into a blessing.
@@ -453,4 +453,4 @@
 28. And /one/ of the sons of Joiada, the son of Eliashib the high priest, /was/ son in law to Sanballat the Horonite: therefore I chased him from me.
 29. Remember them, O my God, because they have defiled the priesthood, and the covenant of the priesthood, and of the Levites.
 30. Thus cleansed I them from all strangers, and appointed the wards of the priests and the Levites, every one in his business;
-31. And for the wood offering, at times appointed, and for the firstfruits. Remember me, O my God, for good.  
+31. And for the wood offering, at times appointed, and for the firstfruits. Remember me, O my God, for good.

--- a/17_EST.org
+++ b/17_EST.org
@@ -23,7 +23,7 @@
 19. If it please the king, let there go a royal commandment from him, and let it be written among the laws of the Persians and the Medes, that it be not altered, That Vashti come no more before king Ahasuerus; and let the king give her royal estate unto another that is better than she.
 20. And when the king's decree which he shall make shall be published throughout all his empire, (for it is great,) all the wives shall give to their husbands honour, both to great and small.
 21. And the saying pleased the king and the princes; and the king did according to the word of Memucan:
-22. For he sent letters into all the king's provinces, into every province according to the writing thereof, and to every people after their language, that every man should bear rule in his own house, and that /it/ should be published according to the language of every people. 
+22. For he sent letters into all the king's provinces, into every province according to the writing thereof, and to every people after their language, that every man should bear rule in his own house, and that /it/ should be published according to the language of every people.
 * 2
 1. After these things, when the wrath of king Ahasuerus was appeased, he remembered Vashti, and what she had done, and what was decreed against her.
 2. Then said the king's servants that ministered unto him, Let there be fair young virgins sought for the king:
@@ -52,7 +52,7 @@
 
 21. In those days, while Mordecai sat in the king's gate, two of the king's chamberlains, Bigthan and Teresh, of those which kept the door, were wroth, and sought to lay hand on the king Ahasuerus.
 22. And the thing was known to Mordecai, who told /it/ unto Esther the queen; and Esther certified the king /thereof/ in Mordecai's name.
-23. And when inquisition was made of the matter, it was found out; therefore they were both hanged on a tree: and it was written in the book of the chronicles before the king. 
+23. And when inquisition was made of the matter, it was found out; therefore they were both hanged on a tree: and it was written in the book of the chronicles before the king.
 * 3
 1. After these things did king Ahasuerus promote Haman the son of Hammedatha the Agagite, and advanced him, and set his seat above all the princes that /were/ with him.
 2. And all the king's servants, that /were/ in the king's gate, bowed, and reverenced Haman: for the king had so commanded concerning him. But Mordecai bowed not, nor did /him/ reverence.
@@ -70,7 +70,7 @@
 12. Then were the king's scribes called on the thirteenth day of the first month, and there was written according to all that Haman had commanded unto the king's lieutenants, and to the governors that /were/ over every province, and to the rulers of every people of every province according to the writing thereof, and /to/ every people after their language; in the name of king Ahasuerus was it written, and sealed with the king's ring.
 13. And the letters were sent by posts into all the king's provinces, to destroy, to kill, and to cause to perish, all Jews, both young and old, little children and women, in one day, /even/ upon the thirteenth /day/ of the twelfth month, which is the month Adar, and /to take/ the spoil of them for a prey.
 14. The copy of the writing for a commandment to be given in every province was published unto all people, that they should be ready against that day.
-15. The posts went out, being hastened by the king's commandment, and the decree was given in Shushan the palace. And the king and Haman sat down to drink; but the city Shushan was perplexed. 
+15. The posts went out, being hastened by the king's commandment, and the decree was given in Shushan the palace. And the king and Haman sat down to drink; but the city Shushan was perplexed.
 * 4
 1. When Mordecai perceived all that was done, Mordecai rent his clothes, and put on sackcloth with ashes, and went out into the midst of the city, and cried with a loud and a bitter cry;
 2. And came even before the king's gate: for none /might/ enter into the king's gate clothed with sackcloth.
@@ -91,7 +91,7 @@
 
 15. Then Esther bade /them/ return Mordecai /this answer/,
 16. Go, gather together all the Jews that are present in Shushan, and fast ye for me, and neither eat nor drink three days, night or day: I also and my maidens will fast likewise; and so will I go in unto the king, which /is/ not according to the law: and if I perish, I perish.
-17. So Mordecai went his way, and did according to all that Esther had commanded him. 
+17. So Mordecai went his way, and did according to all that Esther had commanded him.
 * 5
 1. Now it came to pass on the third day, that Esther put on /her/ royal /apparel/, and stood in the inner court of the king's house, over against the king's house: and the king sat upon his royal throne in the royal house, over against the gate of the house.
 2. And it was so, when the king saw Esther the queen standing in the court, /that/ she obtained favour in his sight: and the king held out to Esther the golden sceptre that /was/ in his hand. So Esther drew near, and touched the top of the sceptre.
@@ -109,7 +109,7 @@
 12. Haman said moreover, Yea, Esther the queen did let no man come in with the king unto the banquet that she had prepared but myself; and to morrow am I invited unto her also with the king.
 13. Yet all this availeth me nothing, so long as I see Mordecai the Jew sitting at the king's gate.
 
-14. Then said Zeresh his wife and all his friends unto him, Let a gallows be made of fifty cubits high, and to morrow speak thou unto the king that Mordecai may be hanged thereon: then go thou in merrily with the king unto the banquet. And the thing pleased Haman; and he caused the gallows to be made. 
+14. Then said Zeresh his wife and all his friends unto him, Let a gallows be made of fifty cubits high, and to morrow speak thou unto the king that Mordecai may be hanged thereon: then go thou in merrily with the king unto the banquet. And the thing pleased Haman; and he caused the gallows to be made.
 * 6
 1. On that night could not the king sleep, and he commanded to bring the book of records of the chronicles; and they were read before the king.
 2. And it was found written, that Mordecai had told of Bigthana and Teresh, two of the king's chamberlains, the keepers of the door, who sought to lay hand on the king Ahasuerus.
@@ -126,7 +126,7 @@
 
 12. And Mordecai came again to the king's gate. But Haman hasted to his house mourning, and having his head covered.
 13. And Haman told Zeresh his wife and all his friends every /thing/ that had befallen him. Then said his wise men and Zeresh his wife unto him, If Mordecai /be/ of the seed of the Jews, before whom thou hast begun to fall, thou shalt not prevail against him, but shalt surely fall before him.
-14. And while they /were/ yet talking with him, came the king's chamberlains, and hasted to bring Haman unto the banquet that Esther had prepared. 
+14. And while they /were/ yet talking with him, came the king's chamberlains, and hasted to bring Haman unto the banquet that Esther had prepared.
 * 7
 1. So the king and Haman came to banquet with Esther the queen.
 2. And the king said again unto Esther on the second day at the banquet of wine, What /is/ thy petition, queen Esther? and it shall be granted thee: and what /is/ thy request? and it shall be performed, /even/ to the half of the kingdom.
@@ -139,7 +139,7 @@
 7. And the king arising from the banquet of wine in his wrath /went/ into the palace garden: and Haman stood up to make request for his life to Esther the queen; for he saw that there was evil determined against him by the king.
 8. Then the king returned out of the palace garden into the place of the banquet of wine; and Haman was fallen upon the bed whereon Esther /was/. Then said the king, Will he force the queen also before me in the house? As the word went out of the king's mouth, they covered Haman's face.
 9. And Harbonah, one of the chamberlains, said before the king, Behold also, the gallows fifty cubits high, which Haman had made for Mordecai, who had spoken good for the king, standeth in the house of Haman. Then the king said, Hang him thereon.
-10. So they hanged Haman on the gallows that he had prepared for Mordecai. Then was the king's wrath pacified. 
+10. So they hanged Haman on the gallows that he had prepared for Mordecai. Then was the king's wrath pacified.
 * 8
 1. On that day did the king Ahasuerus give the house of Haman the Jews' enemy unto Esther the queen. And Mordecai came before the king; for Esther had told what he /was/ unto her.
 2. And the king took off his ring, which he had taken from Haman, and gave it unto Mordecai. And Esther set Mordecai over the house of Haman.
@@ -160,7 +160,7 @@
 
 15. And Mordecai went out from the presence of the king in royal apparel of blue and white, and with a great crown of gold, and with a garment of fine linen and purple: and the city of Shushan rejoiced and was glad.
 16. The Jews had light, and gladness, and joy, and honour.
-17. And in every province, and in every city, whithersoever the king's commandment and his decree came, the Jews had joy and gladness, a feast and a good day. And many of the people of the land became Jews; for the fear of the Jews fell upon them. 
+17. And in every province, and in every city, whithersoever the king's commandment and his decree came, the Jews had joy and gladness, a feast and a good day. And many of the people of the land became Jews; for the fear of the Jews fell upon them.
 * 9
 1. Now in the twelfth month, that /is/, the month Adar, on the thirteenth day of the same, when the king's commandment and his decree drew near to be put in execution, in the day that the enemies of the Jews hoped to have power over them, (though it was turned to the contrary, that the Jews had rule over them that hated them;)
 2. The Jews gathered themselves together in their cities throughout all the provinces of the king Ahasuerus, to lay hand on such as sought their hurt: and no man could withstand them; for the fear of them fell upon all people.
@@ -195,8 +195,8 @@
 29. Then Esther the queen, the daughter of Abihail, and Mordecai the Jew, wrote with all authority, to confirm this second letter of Purim.
 30. And he sent the letters unto all the Jews, to the hundred twenty and seven provinces of the kingdom of Ahasuerus, /with/ words of peace and truth,
 31. To confirm these days of Purim in their times /appointed/, according as Mordecai the Jew and Esther the queen had enjoined them, and as they had decreed for themselves and for their seed, the matters of the fastings and their cry.
-32. And the decree of Esther confirmed these matters of Purim; and it was written in the book. 
+32. And the decree of Esther confirmed these matters of Purim; and it was written in the book.
 * 10
 1. And the king Ahasuerus laid a tribute upon the land, and /upon/ the isles of the sea.
 2. And all the acts of his power and of his might, and the declaration of the greatness of Mordecai, whereunto the king advanced him, /are/ they not written in the book of the chronicles of the kings of Media and Persia?
-3. For Mordecai the Jew /was/ next unto king Ahasuerus, and great among the Jews, and accepted of the multitude of his brethren, seeking the wealth of his people, and speaking peace to all his seed.  
+3. For Mordecai the Jew /was/ next unto king Ahasuerus, and great among the Jews, and accepted of the multitude of his brethren, seeking the wealth of his people, and speaking peace to all his seed.

--- a/18_JOB.org
+++ b/18_JOB.org
@@ -23,7 +23,7 @@
 19. And, behold, there came a great wind from the wilderness, and smote the four corners of the house, and it fell upon the young men, and they are dead; and I only am escaped alone to tell thee.
 20. Then Job arose, and rent his mantle, and shaved his head, and fell down upon the ground, and worshipped,
 21. And said, Naked came I out of my mother's womb, and naked shall I return thither: the LORD gave, and the LORD hath taken away; blessed be the name of the LORD.
-22. In all this Job sinned not, nor charged God foolishly. 
+22. In all this Job sinned not, nor charged God foolishly.
 * 2
 1. Again there was a day when the sons of God came to present themselves before the LORD, and Satan came also among them to present himself before the LORD.
 2. And the LORD said unto Satan, From whence comest thou? And Satan answered the LORD, and said, From going to and fro in the earth, and from walking up and down in it.
@@ -40,7 +40,7 @@
 
 11. Now when Job's three friends heard of all this evil that was come upon him, they came every one from his own place; Eliphaz the Temanite, and Bildad the Shuhite, and Zophar the Naamathite: for they had made an appointment together to come to mourn with him and to comfort him.
 12. And when they lifted up their eyes afar off, and knew him not, they lifted up their voice, and wept; and they rent every one his mantle, and sprinkled dust upon their heads toward heaven.
-13. So they sat down with him upon the ground seven days and seven nights, and none spake a word unto him: for they saw that /his/ grief was very great. 
+13. So they sat down with him upon the ground seven days and seven nights, and none spake a word unto him: for they saw that /his/ grief was very great.
 * 3
 1. After this opened Job his mouth, and cursed his day.
 2. And Job spake, and said,
@@ -67,7 +67,7 @@
 23. /Why is light given/ to a man whose way is hid, and whom God hath hedged in?
 24. For my sighing cometh before I eat, and my roarings are poured out like the waters.
 25. For the thing which I greatly feared is come upon me, and that which I was afraid of is come unto me.
-26. I was not in safety, neither had I rest, neither was I quiet; yet trouble came. 
+26. I was not in safety, neither had I rest, neither was I quiet; yet trouble came.
 * 4
 1. Then Eliphaz the Temanite answered and said,
 2. /If/ we assay to commune with thee, wilt thou be grieved? but who can withhold himself from speaking?
@@ -89,7 +89,7 @@
 18. Behold, he put no trust in his servants; and his angels he charged with folly:
 19. How much less /in/ them that dwell in houses of clay, whose foundation /is/ in the dust, /which/ are crushed before the moth?
 20. They are destroyed from morning to evening: they perish for ever without any regarding /it/.
-21. Doth not their excellency /which is/ in them go away? they die, even without wisdom. 
+21. Doth not their excellency /which is/ in them go away? they die, even without wisdom.
 * 5
 1. Call now, if there be any that will answer thee; and to which of the saints wilt thou turn?
 2. For wrath killeth the foolish man, and envy slayeth the silly one.
@@ -117,7 +117,7 @@
 24. And thou shalt know that thy tabernacle /shall be/ in peace; and thou shalt visit thy habitation, and shalt not sin.
 25. Thou shalt know also that thy seed /shall be/ great, and thine offspring as the grass of the earth.
 26. Thou shalt come to /thy/ grave in a full age, like as a shock of corn cometh in in his season.
-27. Lo this, we have searched it, so it /is/; hear it, and know thou /it/ for thy good. 
+27. Lo this, we have searched it, so it /is/; hear it, and know thou /it/ for thy good.
 * 6
 1. But Job answered and said,
 2. Oh that my grief were throughly weighed, and my calamity laid in the balances together!
@@ -148,7 +148,7 @@
 27. Yea, ye overwhelm the fatherless, and ye dig /a pit/ for your friend.
 28. Now therefore be content, look upon me; for /it is/ evident unto you if I lie.
 29. Return, I pray you, let it not be iniquity; yea, return again, my righteousness /is/ in it.
-30. Is there iniquity in my tongue? cannot my taste discern perverse things? 
+30. Is there iniquity in my tongue? cannot my taste discern perverse things?
 * 7
 1. /Is there/ not an appointed time to man upon earth? /are not/ his days also like the days of an hireling?
 2. As a servant earnestly desireth the shadow, and as an hireling looketh for /the reward of/ his work:
@@ -170,7 +170,7 @@
 18. And /that/ thou shouldest visit him every morning, /and/ try him every moment?
 19. How long wilt thou not depart from me, nor let me alone till I swallow down my spittle?
 20. I have sinned; what shall I do unto thee, O thou preserver of men? why hast thou set me as a mark against thee, so that I am a burden to myself?
-21. And why dost thou not pardon my transgression, and take away mine iniquity? for now shall I sleep in the dust; and thou shalt seek me in the morning, but I /shall/ not /be/. 
+21. And why dost thou not pardon my transgression, and take away mine iniquity? for now shall I sleep in the dust; and thou shalt seek me in the morning, but I /shall/ not /be/.
 * 8
 1. Then answered Bildad the Shuhite, and said,
 2. How long wilt thou speak these /things/? and /how long shall/ the words of thy mouth /be like/ a strong wind?
@@ -193,7 +193,7 @@
 19. Behold, this /is/ the joy of his way, and out of the earth shall others grow.
 20. Behold, God will not cast away a perfect /man/, neither will he help the evil doers:
 21. Till he fill thy mouth with laughing, and thy lips with rejoicing.
-22. They that hate thee shall be clothed with shame; and the dwelling place of the wicked shall come to nought. 
+22. They that hate thee shall be clothed with shame; and the dwelling place of the wicked shall come to nought.
 * 9
 1. Then Job answered and said,
 2. I know /it is/ so of a truth: but how should man be just with God?
@@ -229,7 +229,7 @@
 32. For /he is/ not a man, as I /am, that/ I should answer him, /and/ we should come together in judgment.
 33. Neither is there any daysman betwixt us, /that/ might lay his hand upon us both.
 34. Let him take his rod away from me, and let not his fear terrify me:
-35. /Then/ would I speak, and not fear him; but /it is/ not so with me. 
+35. /Then/ would I speak, and not fear him; but /it is/ not so with me.
 * 10
 1. My soul is weary of my life; I will leave my complaint upon myself; I will speak in the bitterness of my soul.
 2. I will say unto God, Do not condemn me; shew me wherefore thou contendest with me.
@@ -252,7 +252,7 @@
 19. I should have been as though I had not been; I should have been carried from the womb to the grave.
 20. /Are/ not my days few? cease /then, and/ let me alone, that I may take comfort a little,
 21. Before I go /whence/ I shall not return, /even/ to the land of darkness and the shadow of death;
-22. A land of darkness, as darkness /itself; and/ of the shadow of death, without any order, and /where/ the light /is/ as darkness. 
+22. A land of darkness, as darkness /itself; and/ of the shadow of death, without any order, and /where/ the light /is/ as darkness.
 * 11
 1. Then answered Zophar the Naamathite, and said,
 2. Should not the multitude of words be answered? and should a man full of talk be justified?
@@ -273,7 +273,7 @@
 17. And /thine/ age shall be clearer than the noonday; thou shalt shine forth, thou shalt be as the morning.
 18. And thou shalt be secure, because there is hope; yea, thou shalt dig /about thee, and/ thou shalt take thy rest in safety.
 19. Also thou shalt lie down, and none shall make /thee/ afraid; yea, many shall make suit unto thee.
-20. But the eyes of the wicked shall fail, and they shall not escape, and their hope /shall be as/ the giving up of the ghost. 
+20. But the eyes of the wicked shall fail, and they shall not escape, and their hope /shall be as/ the giving up of the ghost.
 * 12
 1. And Job answered and said,
 2. No doubt but ye /are/ the people, and wisdom shall die with you.
@@ -299,7 +299,7 @@
 22. He discovereth deep things out of darkness, and bringeth out to light the shadow of death.
 23. He increaseth the nations, and destroyeth them: he enlargeth the nations, and straiteneth them /again/.
 24. He taketh away the heart of the chief of the people of the earth, and causeth them to wander in a wilderness /where there is/ no way.
-25. They grope in the dark without light, and he maketh them to stagger like /a/ drunken /man/. 
+25. They grope in the dark without light, and he maketh them to stagger like /a/ drunken /man/.
 * 13
 1. Lo, mine eye hath seen all /this/, mine ear hath heard and understood it.
 2. What ye know, /the same/ do I know also: I /am/ not inferior unto you.
@@ -328,7 +328,7 @@
 25. Wilt thou break a leaf driven to and fro? and wilt thou pursue the dry stubble?
 26. For thou writest bitter things against me, and makest me to possess the iniquities of my youth.
 27. Thou puttest my feet also in the stocks, and lookest narrowly unto all my paths; thou settest a print upon the heels of my feet.
-28. And he, as a rotten thing, consumeth, as a garment that is moth eaten. 
+28. And he, as a rotten thing, consumeth, as a garment that is moth eaten.
 * 14
 1. Man /that is/ born of a woman /is/ of few days, and full of trouble.
 2. He cometh forth like a flower, and is cut down: he fleeth also as a shadow, and continueth not.
@@ -351,7 +351,7 @@
 19. The waters wear the stones: thou washest away the things which grow /out/ of the dust of the earth; and thou destroyest the hope of man.
 20. Thou prevailest for ever against him, and he passeth: thou changest his countenance, and sendest him away.
 21. His sons come to honour, and he knoweth /it/ not; and they are brought low, but he perceiveth /it/ not of them.
-22. But his flesh upon him shall have pain, and his soul within him shall mourn. 
+22. But his flesh upon him shall have pain, and his soul within him shall mourn.
 * 15
 1. Then answered Eliphaz the Temanite, and said,
 2. Should a wise man utter vain knowledge, and fill his belly with the east wind?
@@ -387,7 +387,7 @@
 32. It shall be accomplished before his time, and his branch shall not be green.
 33. He shall shake off his unripe grape as the vine, and shall cast off his flower as the olive.
 34. For the congregation of hypocrites /shall be/ desolate, and fire shall consume the tabernacles of bribery.
-35. They conceive mischief, and bring forth vanity, and their belly prepareth deceit. 
+35. They conceive mischief, and bring forth vanity, and their belly prepareth deceit.
 * 16
 1. Then Job answered and said,
 2. I have heard many such things: miserable comforters /are/ ye all.
@@ -410,7 +410,7 @@
 19. Also now, behold, my witness /is/ in heaven, and my record /is/ on high.
 20. My friends scorn me: /but/ mine eye poureth out /tears/ unto God.
 21. O that one might plead for a man with God, as a man /pleadeth/ for his neighbour!
-22. When a few years are come, then I shall go the way /whence/ I shall not return. 
+22. When a few years are come, then I shall go the way /whence/ I shall not return.
 * 17
 1. My breath is corrupt, my days are extinct, the graves /are ready/ for me.
 2. /Are there/ not mockers with me? and doth not mine eye continue in their provocation?
@@ -427,7 +427,7 @@
 13. If I wait, the grave /is/ mine house: I have made my bed in the darkness.
 14. I have said to corruption, Thou /art/ my father: to the worm, /Thou art/ my mother, and my sister.
 15. And where /is/ now my hope? as for my hope, who shall see it?
-16. They shall go down to the bars of the pit, when /our/ rest together /is/ in the dust. 
+16. They shall go down to the bars of the pit, when /our/ rest together /is/ in the dust.
 * 18
 1. Then answered Bildad the Shuhite, and said,
 2. How long /will it be ere/ ye make an end of words? mark, and afterwards we will speak.
@@ -449,7 +449,7 @@
 18. He shall be driven from light into darkness, and chased out of the world.
 19. He shall neither have son nor nephew among his people, nor any remaining in his dwellings.
 20. They that come after /him/ shall be astonied at his day, as they that went before were affrighted.
-21. Surely such /are/ the dwellings of the wicked, and this /is/ the place /of him that/ knoweth not God. 
+21. Surely such /are/ the dwellings of the wicked, and this /is/ the place /of him that/ knoweth not God.
 * 19
 1. Then Job answered and said,
 2. How long will ye vex my soul, and break me in pieces with words?
@@ -479,7 +479,7 @@
 26. And /though/ after my skin /worms/ destroy this /body/, yet in my flesh shall I see God:
 27. Whom I shall see for myself, and mine eyes shall behold, and not another; /though/ my reins be consumed within me.
 28. But ye should say, Why persecute we him, seeing the root of the matter is found in me?
-29. Be ye afraid of the sword: for wrath /bringeth/ the punishments of the sword, that ye may know /there is/ a judgment. 
+29. Be ye afraid of the sword: for wrath /bringeth/ the punishments of the sword, that ye may know /there is/ a judgment.
 * 20
 1. Then answered Zophar the Naamathite, and said,
 2. Therefore do my thoughts cause me to answer, and for /this/ I make haste.
@@ -509,7 +509,7 @@
 26. All darkness /shall be/ hid in his secret places: a fire not blown shall consume him; it shall go ill with him that is left in his tabernacle.
 27. The heaven shall reveal his iniquity; and the earth shall rise up against him.
 28. The increase of his house shall depart, /and his goods/ shall flow away in the day of his wrath.
-29. This /is/ the portion of a wicked man from God, and the heritage appointed unto him by God. 
+29. This /is/ the portion of a wicked man from God, and the heritage appointed unto him by God.
 * 21
 1. But Job answered and said,
 2. Hear diligently my speech, and let this be your consolations.
@@ -544,7 +544,7 @@
 31. Who shall declare his way to his face? and who shall repay him /what/ he hath done?
 32. Yet shall he be brought to the grave, and shall remain in the tomb.
 33. The clods of the valley shall be sweet unto him, and every man shall draw after him, as /there are/ innumerable before him.
-34. How then comfort ye me in vain, seeing in your answers there remaineth falsehood? 
+34. How then comfort ye me in vain, seeing in your answers there remaineth falsehood?
 * 22
 1. Then Eliphaz the Temanite answered and said,
 2. Can a man be profitable unto God, as he that is wise may be profitable unto himself?
@@ -575,7 +575,7 @@
 27. Thou shalt make thy prayer unto him, and he shall hear thee, and thou shalt pay thy vows.
 28. Thou shalt also decree a thing, and it shall be established unto thee: and the light shall shine upon thy ways.
 29. When /men/ are cast down, then thou shalt say, /There is/ lifting up; and he shall save the humble person.
-30. He shall deliver the island of the innocent: and it is delivered by the pureness of thine hands. 
+30. He shall deliver the island of the innocent: and it is delivered by the pureness of thine hands.
 * 23
 1. Then Job answered and said,
 2. Even to day /is/ my complaint bitter: my stroke is heavier than my groaning.
@@ -593,7 +593,7 @@
 14. For he performeth /the thing that is/ appointed for me: and many such /things are/ with him.
 15. Therefore am I troubled at his presence: when I consider, I am afraid of him.
 16. For God maketh my heart soft, and the Almighty troubleth me:
-17. Because I was not cut off before the darkness, /neither/ hath he covered the darkness from my face. 
+17. Because I was not cut off before the darkness, /neither/ hath he covered the darkness from my face.
 * 24
 1. Why, seeing times are not hidden from the Almighty, do they that know him not see his days?
 2. /Some/ remove the landmarks; they violently take away flocks, and feed /thereof/.
@@ -619,14 +619,14 @@
 22. He draweth also the mighty with his power: he riseth up, and no /man/ is sure of life.
 23. /Though/ it be given him /to be/ in safety, whereon he resteth; yet his eyes /are/ upon their ways.
 24. They are exalted for a little while, but are gone and brought low; they are taken out of the way as all /other/, and cut off as the tops of the ears of corn.
-25. And if /it be/ not /so/ now, who will make me a liar, and make my speech nothing worth? 
+25. And if /it be/ not /so/ now, who will make me a liar, and make my speech nothing worth?
 * 25
 1. Then answered Bildad the Shuhite, and said,
 2. Dominion and fear /are/ with him, he maketh peace in his high places.
 3. Is there any number of his armies? and upon whom doth not his light arise?
 4. How then can man be justified with God? or how can he be clean /that is/ born of a woman?
 5. Behold even to the moon, and it shineth not; yea, the stars are not pure in his sight.
-6. How much less man, /that is/ a worm? and the son of man, /which is/ a worm? 
+6. How much less man, /that is/ a worm? and the son of man, /which is/ a worm?
 * 26
 1. But Job answered and said,
 2. How hast thou helped /him that is/ without power? /how/ savest thou the arm /that hath/ no strength?
@@ -641,7 +641,7 @@
 11. The pillars of heaven tremble and are astonished at his reproof.
 12. He divideth the sea with his power, and by his understanding he smiteth through the proud.
 13. By his spirit he hath garnished the heavens; his hand hath formed the crooked serpent.
-14. Lo, these /are/ parts of his ways: but how little a portion is heard of him? but the thunder of his power who can understand? 
+14. Lo, these /are/ parts of his ways: but how little a portion is heard of him? but the thunder of his power who can understand?
 * 27
 1. Moreover Job continued his parable, and said,
 2. /As/ God liveth, /who/ hath taken away my judgment; and the Almighty, /who/ hath vexed my soul;
@@ -665,7 +665,7 @@
 20. Terrors take hold on him as waters, a tempest stealeth him away in the night.
 21. The east wind carrieth him away, and he departeth: and as a storm hurleth him out of his place.
 22. For /God/ shall cast upon him, and not spare: he would fain flee out of his hand.
-23. /Men/ shall clap their hands at him, and shall hiss him out of his place. 
+23. /Men/ shall clap their hands at him, and shall hiss him out of his place.
 * 28
 1. Surely there is a vein for the silver, and a place for gold /where/ they fine /it/.
 2. Iron is taken out of the earth, and brass /is/ molten /out of/ the stone.
@@ -694,7 +694,7 @@
 25. To make the weight for the winds; and he weigheth the waters by measure.
 26. When he made a decree for the rain, and a way for the lightning of the thunder:
 27. Then did he see it, and declare it; he prepared it, yea, and searched it out.
-28. And unto man he said, Behold, the fear of the Lord, that /is/ wisdom; and to depart from evil /is/ understanding. 
+28. And unto man he said, Behold, the fear of the Lord, that /is/ wisdom; and to depart from evil /is/ understanding.
 * 29
 1. Moreover Job continued his parable, and said,
 2. Oh that I were as /in/ months past, as /in/ the days /when/ God preserved me;
@@ -720,7 +720,7 @@
 22. After my words they spake not again; and my speech dropped upon them.
 23. And they waited for me as for the rain; and they opened their mouth wide /as/ for the latter rain.
 24. /If/ I laughed on them, they believed /it/ not; and the light of my countenance they cast not down.
-25. I chose out their way, and sat chief, and dwelt as a king in the army, as one /that/ comforteth the mourners. 
+25. I chose out their way, and sat chief, and dwelt as a king in the army, as one /that/ comforteth the mourners.
 * 30
 1. But now /they that are/ younger than I have me in derision, whose fathers I would have disdained to have set with the dogs of my flock.
 2. Yea, whereto /might/ the strength of their hands /profit/ me, in whom old age was perished?
@@ -752,7 +752,7 @@
 28. I went mourning without the sun: I stood up, /and/ I cried in the congregation.
 29. I am a brother to dragons, and a companion to owls.
 30. My skin is black upon me, and my bones are burned with heat.
-31. My harp also is /turned/ to mourning, and my organ into the voice of them that weep. 
+31. My harp also is /turned/ to mourning, and my organ into the voice of them that weep.
 * 31
 1. I made a covenant with mine eyes; why then should I think upon a maid?
 2. For what portion of God /is there/ from above? and /what/ inheritance of the Almighty from on high?
@@ -793,7 +793,7 @@
 37. I would declare unto him the number of my steps; as a prince would I go near unto him.
 38. If my land cry against me, or that the furrows likewise thereof complain;
 39. If I have eaten the fruits thereof without money, or have caused the owners thereof to lose their life:
-40. Let thistles grow instead of wheat, and cockle instead of barley. The words of Job are ended. 
+40. Let thistles grow instead of wheat, and cockle instead of barley. The words of Job are ended.
 * 32
 1. So these three men ceased to answer Job, because he /was/ righteous in his own eyes.
 2. Then was kindled the wrath of Elihu the son of Barachel the Buzite, of the kindred of Ram: against Job was his wrath kindled, because he justified himself rather than God.
@@ -816,7 +816,7 @@
 19. Behold, my belly /is/ as wine /which/ hath no vent; it is ready to burst like new bottles.
 20. I will speak, that I may be refreshed: I will open my lips and answer.
 21. Let me not, I pray you, accept any man's person, neither let me give flattering titles unto man.
-22. For I know not to give flattering titles; /in so doing/ my maker would soon take me away. 
+22. For I know not to give flattering titles; /in so doing/ my maker would soon take me away.
 * 33
 1. Wherefore, Job, I pray thee, hear my speeches, and hearken to all my words.
 2. Behold, now I have opened my mouth, my tongue hath spoken in my mouth.
@@ -850,7 +850,7 @@
 30. To bring back his soul from the pit, to be enlightened with the light of the living.
 31. Mark well, O Job, hearken unto me: hold thy peace, and I will speak.
 32. If thou hast any thing to say, answer me: speak, for I desire to justify thee.
-33. If not, hearken unto me: hold thy peace, and I shall teach thee wisdom. 
+33. If not, hearken unto me: hold thy peace, and I shall teach thee wisdom.
 * 34
 1. Furthermore Elihu answered and said,
 2. Hear my words, O ye wise /men/; and give ear unto me, ye that have knowledge.
@@ -888,7 +888,7 @@
 34. Let men of understanding tell me, and let a wise man hearken unto me.
 35. Job hath spoken without knowledge, and his words /were/ without wisdom.
 36. My desire /is that/ Job may be tried unto the end because of /his/ answers for wicked men.
-37. For he addeth rebellion unto his sin, he clappeth /his hands/ among us, and multiplieth his words against God. 
+37. For he addeth rebellion unto his sin, he clappeth /his hands/ among us, and multiplieth his words against God.
 * 35
 1. Elihu spake moreover, and said,
 2. Thinkest thou this to be right, /that/ thou saidst, My righteousness /is/ more than God's?
@@ -905,7 +905,7 @@
 13. Surely God will not hear vanity, neither will the Almighty regard it.
 14. Although thou sayest thou shalt not see him, /yet/ judgment /is/ before him; therefore trust thou in him.
 15. But now, because /it is/ not /so/, he hath visited in his anger; yet he knoweth /it/ not in great extremity:
-16. Therefore doth Job open his mouth in vain; he multiplieth words without knowledge. 
+16. Therefore doth Job open his mouth in vain; he multiplieth words without knowledge.
 * 36
 1. Elihu also proceeded, and said,
 2. Suffer me a little, and I will shew thee that /I have/ yet to speak on God's behalf.
@@ -939,7 +939,7 @@
 30. Behold, he spreadeth his light upon it, and covereth the bottom of the sea.
 31. For by them judgeth he the people; he giveth meat in abundance.
 32. With clouds he covereth the light; and commandeth it /not to shine/ by /the cloud/ that cometh betwixt.
-33. The noise thereof sheweth concerning it, the cattle also concerning the vapour. 
+33. The noise thereof sheweth concerning it, the cattle also concerning the vapour.
 * 37
 1. At this also my heart trembleth, and is moved out of his place.
 2. Hear attentively the noise of his voice, and the sound /that/ goeth out of his mouth.
@@ -964,7 +964,7 @@
 21. And now /men/ see not the bright light which /is/ in the clouds: but the wind passeth, and cleanseth them.
 22. Fair weather cometh out of the north: with God /is/ terrible majesty.
 23. /Touching/ the Almighty, we cannot find him out: /he is/ excellent in power, and in judgment, and in plenty of justice: he will not afflict.
-24. Men do therefore fear him: he respecteth not any /that are/ wise of heart. 
+24. Men do therefore fear him: he respecteth not any /that are/ wise of heart.
 * 38
 1. Then the LORD answered Job out of the whirlwind, and said,
 2. Who /is/ this that darkeneth counsel by words without knowledge?
@@ -1006,7 +1006,7 @@
 38. When the dust groweth into hardness, and the clods cleave fast together?
 39. Wilt thou hunt the prey for the lion? or fill the appetite of the young lions,
 40. When they couch in /their/ dens, /and/ abide in the covert to lie in wait?
-41. Who provideth for the raven his food? when his young ones cry unto God, they wander for lack of meat. 
+41. Who provideth for the raven his food? when his young ones cry unto God, they wander for lack of meat.
 * 39
 1. Knowest thou the time when the wild goats of the rock bring forth? /or/ canst thou mark when the hinds do calve?
 2. Canst thou number the months /that/ they fulfil? or knowest thou the time when they bring forth?
@@ -1037,7 +1037,7 @@
 27. Doth the eagle mount up at thy command, and make her nest on high?
 28. She dwelleth and abideth on the rock, upon the crag of the rock, and the strong place.
 29. From thence she seeketh the prey, /and/ her eyes behold afar off.
-30. Her young ones also suck up blood: and where the slain /are/, there /is/ she. 
+30. Her young ones also suck up blood: and where the slain /are/, there /is/ she.
 * 40
 1. Moreover the LORD answered Job, and said,
 2. Shall he that contendeth with the Almighty instruct /him/? he that reproveth God, let him answer it.
@@ -1065,7 +1065,7 @@
 21. He lieth under the shady trees, in the covert of the reed, and fens.
 22. The shady trees cover him /with/ their shadow; the willows of the brook compass him about.
 23. Behold, he drinketh up a river, /and/ hasteth not: he trusteth that he can draw up Jordan into his mouth.
-24. He taketh it with his eyes: /his/ nose pierceth through snares. 
+24. He taketh it with his eyes: /his/ nose pierceth through snares.
 * 41
 1. Canst thou draw out leviathan with an hook? or his tongue with a cord /which/ thou lettest down?
 2. Canst thou put an hook into his nose? or bore his jaw through with a thorn?
@@ -1100,7 +1100,7 @@
 31. He maketh the deep to boil like a pot: he maketh the sea like a pot of ointment.
 32. He maketh a path to shine after him; /one/ would think the deep /to be/ hoary.
 33. Upon earth there is not his like, who is made without fear.
-34. He beholdeth all high /things/: he /is/ a king over all the children of pride. 
+34. He beholdeth all high /things/: he /is/ a king over all the children of pride.
 * 42
 1. Then Job answered the LORD, and said,
 2. I know that thou canst do every /thing/, and /that/ no thought can be withholden from thee.
@@ -1119,4 +1119,4 @@
 14. And he called the name of the first, Jemima; and the name of the second, Kezia; and the name of the third, Keren–happuch.
 15. And in all the land were no women found /so/ fair as the daughters of Job: and their father gave them inheritance among their brethren.
 16. After this lived Job an hundred and forty years, and saw his sons, and his sons' sons, /even/ four generations.
-17. So Job died, /being/ old and full of days.  
+17. So Job died, /being/ old and full of days.

--- a/19_PSA.org
+++ b/19_PSA.org
@@ -5,7 +5,7 @@
 3. And he shall be like a tree planted by the rivers of water, that bringeth forth his fruit in his season; his leaf also shall not wither; and whatsoever he doeth shall prosper.
 4. The ungodly /are/ not so: but /are/ like the chaff which the wind driveth away.
 5. Therefore the ungodly shall not stand in the judgment, nor sinners in the congregation of the righteous.
-6. For the LORD knoweth the way of the righteous: but the way of the ungodly shall perish. 
+6. For the LORD knoweth the way of the righteous: but the way of the ungodly shall perish.
 * 2
 1. Why do the heathen rage, and the people imagine a vain thing?
 2. The kings of the earth set themselves, and the rulers take counsel together, against the LORD, and against his anointed, /saying/,
@@ -18,7 +18,7 @@
 9. Thou shalt break them with a rod of iron; thou shalt dash them in pieces like a potter's vessel.
 10. Be wise now therefore, O ye kings: be instructed, ye judges of the earth.
 11. Serve the LORD with fear, and rejoice with trembling.
-12. Kiss the Son, lest he be angry, and ye perish /from/ the way, when his wrath is kindled but a little. Blessed /are/ all they that put their trust in him. 
+12. Kiss the Son, lest he be angry, and ye perish /from/ the way, when his wrath is kindled but a little. Blessed /are/ all they that put their trust in him.
 * 3
 A Psalm of David, when he fled from Absalom his son.
 1. LORD, how are they increased that trouble me! many /are/ they that rise up against me.
@@ -28,7 +28,7 @@ A Psalm of David, when he fled from Absalom his son.
 5. I laid me down and slept; I awaked; for the LORD sustained me.
 6. I will not be afraid of ten thousands of people, that have set /themselves/ against me round about.
 7. Arise, O LORD; save me, O my God: for thou hast smitten all mine enemies /upon/ the cheek bone; thou hast broken the teeth of the ungodly.
-8. Salvation /belongeth/ unto the LORD: thy blessing /is/ upon thy people. Selah. 
+8. Salvation /belongeth/ unto the LORD: thy blessing /is/ upon thy people. Selah.
 * 4
 To the chief Musician on Neginoth, A Psalm of David.
 1. Hear me when I call, O God of my righteousness: thou hast enlarged me /when I was/ in distress; have mercy upon me, and hear my prayer.
@@ -38,7 +38,7 @@ To the chief Musician on Neginoth, A Psalm of David.
 5. Offer the sacrifices of righteousness, and put your trust in the LORD.
 6. /There be/ many that say, Who will shew us /any/ good? LORD, lift thou up the light of thy countenance upon us.
 7. Thou hast put gladness in my heart, more than in the time /that/ their corn and their wine increased.
-8. I will both lay me down in peace, and sleep: for thou, LORD, only makest me dwell in safety. 
+8. I will both lay me down in peace, and sleep: for thou, LORD, only makest me dwell in safety.
 * 5
 To the chief Musician upon Nehiloth, A Psalm of David.
 1. Give ear to my words, O LORD, consider my meditation.
@@ -52,7 +52,7 @@ To the chief Musician upon Nehiloth, A Psalm of David.
 9. For /there is/ no faithfulness in their mouth; their inward part /is/ very wickedness; their throat /is/ an open sepulchre; they flatter with their tongue.
 10. Destroy thou them, O God; let them fall by their own counsels; cast them out in the multitude of their transgressions; for they have rebelled against thee.
 11. But let all those that put their trust in thee rejoice: let them ever shout for joy, because thou defendest them: let them also that love thy name be joyful in thee.
-12. For thou, LORD, wilt bless the righteous; with favour wilt thou compass him as /with/ a shield. 
+12. For thou, LORD, wilt bless the righteous; with favour wilt thou compass him as /with/ a shield.
 * 6
 To the chief Musician on Neginoth upon Sheminith, A Psalm of David.
 1. O LORD, rebuke me not in thine anger, neither chasten me in thy hot displeasure.
@@ -64,7 +64,7 @@ To the chief Musician on Neginoth upon Sheminith, A Psalm of David.
 7. Mine eye is consumed because of grief; it waxeth old because of all mine enemies.
 8. Depart from me, all ye workers of iniquity; for the LORD hath heard the voice of my weeping.
 9. The LORD hath heard my supplication; the LORD will receive my prayer.
-10. Let all mine enemies be ashamed and sore vexed: let them return /and/ be ashamed suddenly. 
+10. Let all mine enemies be ashamed and sore vexed: let them return /and/ be ashamed suddenly.
 * 7
 Shiggaion of David, which he sang unto the LORD, concerning the words of Cush the Benjamite.
 1. O LORD my God, in thee do I put my trust: save me from all them that persecute me, and deliver me:
@@ -83,7 +83,7 @@ Shiggaion of David, which he sang unto the LORD, concerning the words of Cush th
 14. Behold, he travaileth with iniquity, and hath conceived mischief, and brought forth falsehood.
 15. He made a pit, and digged it, and is fallen into the ditch /which/ he made.
 16. His mischief shall return upon his own head, and his violent dealing shall come down upon his own pate.
-17. I will praise the LORD according to his righteousness: and will sing praise to the name of the LORD most high. 
+17. I will praise the LORD according to his righteousness: and will sing praise to the name of the LORD most high.
 * 8
 To the chief Musician upon Gittith, A Psalm of David.
 1. O LORD our Lord, how excellent /is/ thy name in all the earth! who hast set thy glory above the heavens.
@@ -94,7 +94,7 @@ To the chief Musician upon Gittith, A Psalm of David.
 6. Thou madest him to have dominion over the works of thy hands; thou hast put all /things/ under his feet:
 7. All sheep and oxen, yea, and the beasts of the field;
 8. The fowl of the air, and the fish of the sea, /and whatsoever/ passeth through the paths of the seas.
-9. O LORD our Lord, how excellent /is/ thy name in all the earth! 
+9. O LORD our Lord, how excellent /is/ thy name in all the earth!
 * 9
 To the chief Musician upon Muthlabben, A Psalm of David.
 1. I will praise /thee/, O LORD, with my whole heart; I will shew forth all thy marvellous works.
@@ -116,7 +116,7 @@ To the chief Musician upon Muthlabben, A Psalm of David.
 17. The wicked shall be turned into hell, /and/ all the nations that forget God.
 18. For the needy shall not alway be forgotten: the expectation of the poor shall /not/ perish for ever.
 19. Arise, O LORD; let not man prevail: let the heathen be judged in thy sight.
-20. Put them in fear, O LORD: /that/ the nations may know themselves /to be but/ men. Selah. 
+20. Put them in fear, O LORD: /that/ the nations may know themselves /to be but/ men. Selah.
 * 10
 1. Why standest thou afar off, O LORD? /why/ hidest thou /thyself/ in times of trouble?
 2. The wicked in /his/ pride doth persecute the poor: let them be taken in the devices that they have imagined.
@@ -135,7 +135,7 @@ To the chief Musician upon Muthlabben, A Psalm of David.
 15. Break thou the arm of the wicked and the evil /man/: seek out his wickedness /till/ thou find none.
 16. The LORD /is/ King for ever and ever: the heathen are perished out of his land.
 17. LORD, thou hast heard the desire of the humble: thou wilt prepare their heart, thou wilt cause thine ear to hear:
-18. To judge the fatherless and the oppressed, that the man of the earth may no more oppress. 
+18. To judge the fatherless and the oppressed, that the man of the earth may no more oppress.
 * 11
 To the chief Musician, /A Psalm/ of David.
 1. In the LORD put I my trust: how say ye to my soul, Flee /as/ a bird to your mountain?
@@ -144,7 +144,7 @@ To the chief Musician, /A Psalm/ of David.
 4. The LORD /is/ in his holy temple, the LORD's throne /is/ in heaven: his eyes behold, his eyelids try, the children of men.
 5. The LORD trieth the righteous: but the wicked and him that loveth violence his soul hateth.
 6. Upon the wicked he shall rain snares, fire and brimstone, and an horrible tempest: /this shall be/ the portion of their cup.
-7. For the righteous LORD loveth righteousness; his countenance doth behold the upright. 
+7. For the righteous LORD loveth righteousness; his countenance doth behold the upright.
 * 12
 To the chief Musician upon Sheminith, A Psalm of David.
 1. Help, LORD; for the godly man ceaseth; for the faithful fail from among the children of men.
@@ -154,7 +154,7 @@ To the chief Musician upon Sheminith, A Psalm of David.
 5. For the oppression of the poor, for the sighing of the needy, now will I arise, saith the LORD; I will set /him/ in safety /from him that/ puffeth at him.
 6. The words of the LORD /are/ pure words: /as/ silver tried in a furnace of earth, purified seven times.
 7. Thou shalt keep them, O LORD, thou shalt preserve them from this generation for ever.
-8. The wicked walk on every side, when the vilest men are exalted. 
+8. The wicked walk on every side, when the vilest men are exalted.
 * 13
 To the chief Musician, A Psalm of David.
 1. How long wilt thou forget me, O LORD? for ever? how long wilt thou hide thy face from me?
@@ -162,7 +162,7 @@ To the chief Musician, A Psalm of David.
 3. Consider /and/ hear me, O LORD my God: lighten mine eyes, lest I sleep the /sleep of/ death;
 4. Lest mine enemy say, I have prevailed against him; /and/ those that trouble me rejoice when I am moved.
 5. But I have trusted in thy mercy; my heart shall rejoice in thy salvation.
-6. I will sing unto the LORD, because he hath dealt bountifully with me. 
+6. I will sing unto the LORD, because he hath dealt bountifully with me.
 * 14
 To the chief Musician, /A Psalm/ of David.
 1. The fool hath said in his heart, /There is/ no God. They are corrupt, they have done abominable works, /there is/ none that doeth good.
@@ -171,14 +171,14 @@ To the chief Musician, /A Psalm/ of David.
 4. Have all the workers of iniquity no knowledge? who eat up my people /as/ they eat bread, and call not upon the LORD.
 5. There were they in great fear: for God /is/ in the generation of the righteous.
 6. Ye have shamed the counsel of the poor, because the LORD /is/ his refuge.
-7. Oh that the salvation of Israel /were come/ out of Zion! when the LORD bringeth back the captivity of his people, Jacob shall rejoice, /and/ Israel shall be glad. 
+7. Oh that the salvation of Israel /were come/ out of Zion! when the LORD bringeth back the captivity of his people, Jacob shall rejoice, /and/ Israel shall be glad.
 * 15
 A Psalm of David.
 1. LORD, who shall abide in thy tabernacle? who shall dwell in thy holy hill?
 2. He that walketh uprightly, and worketh righteousness, and speaketh the truth in his heart.
 3. /He that/ backbiteth not with his tongue, nor doeth evil to his neighbour, nor taketh up a reproach against his neighbour.
 4. In whose eyes a vile person is contemned; but he honoureth them that fear the LORD. /He that/ sweareth to /his own/ hurt, and changeth not.
-5. /He that/ putteth not out his money to usury, nor taketh reward against the innocent. He that doeth these /things/ shall never be moved. 
+5. /He that/ putteth not out his money to usury, nor taketh reward against the innocent. He that doeth these /things/ shall never be moved.
 * 16
 Michtam of David.
 1. Preserve me, O God: for in thee do I put my trust.
@@ -191,7 +191,7 @@ Michtam of David.
 8. I have set the LORD always before me: because /he is/ at my right hand, I shall not be moved.
 9. Therefore my heart is glad, and my glory rejoiceth: my flesh also shall rest in hope.
 10. For thou wilt not leave my soul in hell; neither wilt thou suffer thine Holy One to see corruption.
-11. Thou wilt shew me the path of life: in thy presence /is/ fulness of joy; at thy right hand /there are/ pleasures for evermore. 
+11. Thou wilt shew me the path of life: in thy presence /is/ fulness of joy; at thy right hand /there are/ pleasures for evermore.
 * 17
 A Prayer of David.
 1. Hear the right, O LORD, attend unto my cry, give ear unto my prayer, /that goeth/ not out of feigned lips.
@@ -208,7 +208,7 @@ A Prayer of David.
 12. Like as a lion /that/ is greedy of his prey, and as it were a young lion lurking in secret places.
 13. Arise, O LORD, disappoint him, cast him down: deliver my soul from the wicked, /which is/ thy sword:
 14. From men /which are/ thy hand, O LORD, from men of the world, /which have/ their portion in /this/ life, and whose belly thou fillest with thy hid /treasure/: they are full of children, and leave the rest of their /substance/ to their babes.
-15. As for me, I will behold thy face in righteousness: I shall be satisfied, when I awake, with thy likeness. 
+15. As for me, I will behold thy face in righteousness: I shall be satisfied, when I awake, with thy likeness.
 * 18
 To the chief Musician, /A Psalm/ of David, the servant of the LORD, who spake unto the LORD the words of this song in the day /that/ the LORD delivered him from the hand of all his enemies, and from the hand of Saul: And he said,
 1. I will love thee, O LORD, my strength.
@@ -260,7 +260,7 @@ To the chief Musician, /A Psalm/ of David, the servant of the LORD, who spake un
 47. /It is/ God that avengeth me, and subdueth the people under me.
 48. He delivereth me from mine enemies: yea, thou liftest me up above those that rise up against me: thou hast delivered me from the violent man.
 49. Therefore will I give thanks unto thee, O LORD, among the heathen, and sing praises unto thy name.
-50. Great deliverance giveth he to his king; and sheweth mercy to his anointed, to David, and to his seed for evermore. 
+50. Great deliverance giveth he to his king; and sheweth mercy to his anointed, to David, and to his seed for evermore.
 * 19
 To the chief Musician, A Psalm of David.
 1. The heavens declare the glory of God; and the firmament sheweth his handywork.
@@ -276,7 +276,7 @@ To the chief Musician, A Psalm of David.
 11. Moreover by them is thy servant warned: /and/ in keeping of them /there is/ great reward.
 12. Who can understand /his/ errors? cleanse thou me from secret /faults/.
 13. Keep back thy servant also from presumptuous /sins/; let them not have dominion over me: then shall I be upright, and I shall be innocent from the great transgression.
-14. Let the words of my mouth, and the meditation of my heart, be acceptable in thy sight, O LORD, my strength, and my redeemer. 
+14. Let the words of my mouth, and the meditation of my heart, be acceptable in thy sight, O LORD, my strength, and my redeemer.
 * 20
 To the chief Musician, A Psalm of David.
 1. The LORD hear thee in the day of trouble; the name of the God of Jacob defend thee;
@@ -287,7 +287,7 @@ To the chief Musician, A Psalm of David.
 6. Now know I that the LORD saveth his anointed; he will hear him from his holy heaven with the saving strength of his right hand.
 7. Some /trust/ in chariots, and some in horses: but we will remember the name of the LORD our God.
 8. They are brought down and fallen: but we are risen, and stand upright.
-9. Save, LORD: let the king hear us when we call. 
+9. Save, LORD: let the king hear us when we call.
 * 21
 To the chief Musician, A Psalm of David.
 1. The king shall joy in thy strength, O LORD; and in thy salvation how greatly shall he rejoice!
@@ -302,7 +302,7 @@ To the chief Musician, A Psalm of David.
 10. Their fruit shalt thou destroy from the earth, and their seed from among the children of men.
 11. For they intended evil against thee: they imagined a mischievous device, /which/ they are not able /to perform/.
 12. Therefore shalt thou make them turn their back, /when/ thou shalt make ready /thine arrows/ upon thy strings against the face of them.
-13. Be thou exalted, LORD, in thine own strength: /so/ will we sing and praise thy power. 
+13. Be thou exalted, LORD, in thine own strength: /so/ will we sing and praise thy power.
 * 22
 To the chief Musician upon Aijeleth Shahar, A Psalm of David.
 1. My God, my God, why hast thou forsaken me? /why art thou so/ far from helping me, /and from/ the words of my roaring?
@@ -335,7 +335,7 @@ To the chief Musician upon Aijeleth Shahar, A Psalm of David.
 28. For the kingdom /is/ the LORD's: and he /is/ the governor among the nations.
 29. All /they that be/ fat upon earth shall eat and worship: all they that go down to the dust shall bow before him: and none can keep alive his own soul.
 30. A seed shall serve him; it shall be accounted to the Lord for a generation.
-31. They shall come, and shall declare his righteousness unto a people that shall be born, that he hath done /this/. 
+31. They shall come, and shall declare his righteousness unto a people that shall be born, that he hath done /this/.
 * 23
 A Psalm of David.
 1. The LORD /is/ my shepherd; I shall not want.
@@ -343,7 +343,7 @@ A Psalm of David.
 3. He restoreth my soul: he leadeth me in the paths of righteousness for his name's sake.
 4. Yea, though I walk through the valley of the shadow of death, I will fear no evil: for thou /art/ with me; thy rod and thy staff they comfort me.
 5. Thou preparest a table before me in the presence of mine enemies: thou anointest my head with oil; my cup runneth over.
-6. Surely goodness and mercy shall follow me all the days of my life: and I will dwell in the house of the LORD for ever. 
+6. Surely goodness and mercy shall follow me all the days of my life: and I will dwell in the house of the LORD for ever.
 * 24
 A Psalm of David.
 1. The earth /is/ the LORD's, and the fulness thereof; the world, and they that dwell therein.
@@ -355,7 +355,7 @@ A Psalm of David.
 7. Lift up your heads, O ye gates; and be ye lift up, ye everlasting doors; and the King of glory shall come in.
 8. Who /is/ this King of glory? The LORD strong and mighty, the LORD mighty in battle.
 9. Lift up your heads, O ye gates; even lift /them/ up, ye everlasting doors; and the King of glory shall come in.
-10. Who is this King of glory? The LORD of hosts, he /is/ the King of glory. Selah. 
+10. Who is this King of glory? The LORD of hosts, he /is/ the King of glory. Selah.
 * 25
 /A Psalm/ of David.
 1. Unto thee, O LORD, do I lift up my soul.
@@ -379,7 +379,7 @@ A Psalm of David.
 19. Consider mine enemies; for they are many; and they hate me with cruel hatred.
 20. O keep my soul, and deliver me: let me not be ashamed; for I put my trust in thee.
 21. Let integrity and uprightness preserve me; for I wait on thee.
-22. Redeem Israel, O God, out of all his troubles. 
+22. Redeem Israel, O God, out of all his troubles.
 * 26
 /A Psalm/ of David.
 1. Judge me, O LORD; for I have walked in mine integrity: I have trusted also in the LORD; /therefore/ I shall not slide.
@@ -393,7 +393,7 @@ A Psalm of David.
 9. Gather not my soul with sinners, nor my life with bloody men:
 10. In whose hands /is/ mischief, and their right hand is full of bribes.
 11. But as for me, I will walk in mine integrity: redeem me, and be merciful unto me.
-12. My foot standeth in an even place: in the congregations will I bless the LORD. 
+12. My foot standeth in an even place: in the congregations will I bless the LORD.
 * 27
 /A Psalm/ of David.
 1. The LORD /is/ my light and my salvation; whom shall I fear? the LORD /is/ the strength of my life; of whom shall I be afraid?
@@ -409,7 +409,7 @@ A Psalm of David.
 11. Teach me thy way, O LORD, and lead me in a plain path, because of mine enemies.
 12. Deliver me not over unto the will of mine enemies: for false witnesses are risen up against me, and such as breathe out cruelty.
 13. /I had fainted/, unless I had believed to see the goodness of the LORD in the land of the living.
-14. Wait on the LORD: be of good courage, and he shall strengthen thine heart: wait, I say, on the LORD. 
+14. Wait on the LORD: be of good courage, and he shall strengthen thine heart: wait, I say, on the LORD.
 * 28
 /A Psalm/ of David.
 1. Unto thee will I cry, O LORD my rock; be not silent to me: lest, /if/ thou be silent to me, I become like them that go down into the pit.
@@ -420,7 +420,7 @@ A Psalm of David.
 6. Blessed /be/ the LORD, because he hath heard the voice of my supplications.
 7. The LORD /is/ my strength and my shield; my heart trusted in him, and I am helped: therefore my heart greatly rejoiceth; and with my song will I praise him.
 8. The LORD /is/ their strength, and he /is/ the saving strength of his anointed.
-9. Save thy people, and bless thine inheritance: feed them also, and lift them up for ever. 
+9. Save thy people, and bless thine inheritance: feed them also, and lift them up for ever.
 * 29
 A Psalm of David.
 1. Give unto the LORD, O ye mighty, give unto the LORD glory and strength.
@@ -433,7 +433,7 @@ A Psalm of David.
 8. The voice of the LORD shaketh the wilderness; the LORD shaketh the wilderness of Kadesh.
 9. The voice of the LORD maketh the hinds to calve, and discovereth the forests: and in his temple doth every one speak of /his/ glory.
 10. The LORD sitteth upon the flood; yea, the LORD sitteth King for ever.
-11. The LORD will give strength unto his people; the LORD will bless his people with peace. 
+11. The LORD will give strength unto his people; the LORD will bless his people with peace.
 * 30
 A Psalm /and/ Song /at/ the dedication of the house of David.
 1. I will extol thee, O LORD; for thou hast lifted me up, and hast not made my foes to rejoice over me.
@@ -447,7 +447,7 @@ A Psalm /and/ Song /at/ the dedication of the house of David.
 9. What profit /is there/ in my blood, when I go down to the pit? Shall the dust praise thee? shall it declare thy truth?
 10. Hear, O LORD, and have mercy upon me: LORD, be thou my helper.
 11. Thou hast turned for me my mourning into dancing: thou hast put off my sackcloth, and girded me with gladness;
-12. To the end that /my/ glory may sing praise to thee, and not be silent. O LORD my God, I will give thanks unto thee for ever. 
+12. To the end that /my/ glory may sing praise to thee, and not be silent. O LORD my God, I will give thanks unto thee for ever.
 * 31
 To the chief Musician, A Psalm of David.
 1. In thee, O LORD, do I put my trust; let me never be ashamed: deliver me in thy righteousness.
@@ -473,7 +473,7 @@ To the chief Musician, A Psalm of David.
 21. Blessed /be/ the LORD: for he hath shewed me his marvellous kindness in a strong city.
 22. For I said in my haste, I am cut off from before thine eyes: nevertheless thou heardest the voice of my supplications when I cried unto thee.
 23. O love the LORD, all ye his saints: /for/ the LORD preserveth the faithful, and plentifully rewardeth the proud doer.
-24. Be of good courage, and he shall strengthen your heart, all ye that hope in the LORD. 
+24. Be of good courage, and he shall strengthen your heart, all ye that hope in the LORD.
 * 32
 /A Psalm/ of David, Maschil.
 1. Blessed /is he whose/ transgression /is/ forgiven, /whose/ sin /is/ covered.
@@ -486,7 +486,7 @@ To the chief Musician, A Psalm of David.
 8. I will instruct thee and teach thee in the way which thou shalt go: I will guide thee with mine eye.
 9. Be ye not as the horse, /or/ as the mule, /which/ have no understanding: whose mouth must be held in with bit and bridle, lest they come near unto thee.
 10. Many sorrows /shall be/ to the wicked: but he that trusteth in the LORD, mercy shall compass him about.
-11. Be glad in the LORD, and rejoice, ye righteous: and shout for joy, all /ye that are/ upright in heart. 
+11. Be glad in the LORD, and rejoice, ye righteous: and shout for joy, all /ye that are/ upright in heart.
 * 33
 1. Rejoice in the LORD, O ye righteous: /for/ praise is comely for the upright.
 2. Praise the LORD with harp: sing unto him with the psaltery /and/ an instrument of ten strings.
@@ -509,7 +509,7 @@ To the chief Musician, A Psalm of David.
 19. To deliver their soul from death, and to keep them alive in famine.
 20. Our soul waiteth for the LORD: he /is/ our help and our shield.
 21. For our heart shall rejoice in him, because we have trusted in his holy name.
-22. Let thy mercy, O LORD, be upon us, according as we hope in thee. 
+22. Let thy mercy, O LORD, be upon us, according as we hope in thee.
 * 34
 /A Psalm/ of David, when he changed his behaviour before Abimelech; who drove him away, and he departed.
 1. I will bless the LORD at all times: his praise /shall/ continually /be/ in my mouth.
@@ -533,7 +533,7 @@ To the chief Musician, A Psalm of David.
 19. Many /are/ the afflictions of the righteous: but the LORD delivereth him out of them all.
 20. He keepeth all his bones: not one of them is broken.
 21. Evil shall slay the wicked: and they that hate the righteous shall be desolate.
-22. The LORD redeemeth the soul of his servants: and none of them that trust in him shall be desolate. 
+22. The LORD redeemeth the soul of his servants: and none of them that trust in him shall be desolate.
 * 35
 /A Psalm/ of David.
 1. Plead /my cause/, O LORD, with them that strive with me: fight against them that fight against me.
@@ -563,7 +563,7 @@ To the chief Musician, A Psalm of David.
 25. Let them not say in their hearts, Ah, so would we have it: let them not say, We have swallowed him up.
 26. Let them be ashamed and brought to confusion together that rejoice at mine hurt: let them be clothed with shame and dishonour that magnify /themselves/ against me.
 27. Let them shout for joy, and be glad, that favour my righteous cause: yea, let them say continually, Let the LORD be magnified, which hath pleasure in the prosperity of his servant.
-28. And my tongue shall speak of thy righteousness /and/ of thy praise all the day long. 
+28. And my tongue shall speak of thy righteousness /and/ of thy praise all the day long.
 * 36
 To the chief Musician, /A Psalm/ of David the servant of the LORD.
 1. The transgression of the wicked saith within my heart, /that there is/ no fear of God before his eyes.
@@ -577,7 +577,7 @@ To the chief Musician, /A Psalm/ of David the servant of the LORD.
 9. For with thee /is/ the fountain of life: in thy light shall we see light.
 10. O continue thy lovingkindness unto them that know thee; and thy righteousness to the upright in heart.
 11. Let not the foot of pride come against me, and let not the hand of the wicked remove me.
-12. There are the workers of iniquity fallen: they are cast down, and shall not be able to rise. 
+12. There are the workers of iniquity fallen: they are cast down, and shall not be able to rise.
 * 37
 /A Psalm/ of David.
 1. Fret not thyself because of evildoers, neither be thou envious against the workers of iniquity.
@@ -619,7 +619,7 @@ To the chief Musician, /A Psalm/ of David the servant of the LORD.
 37. Mark the perfect /man/, and behold the upright: for the end of /that/ man /is/ peace.
 38. But the transgressors shall be destroyed together: the end of the wicked shall be cut off.
 39. But the salvation of the righteous /is/ of the LORD: /he is/ their strength in the time of trouble.
-40. And the LORD shall help them, and deliver them: he shall deliver them from the wicked, and save them, because they trust in him. 
+40. And the LORD shall help them, and deliver them: he shall deliver them from the wicked, and save them, because they trust in him.
 * 38
 A Psalm of David, to bring to remembrance.
 1. O LORD, rebuke me not in thy wrath: neither chasten me in thy hot displeasure.
@@ -643,7 +643,7 @@ A Psalm of David, to bring to remembrance.
 19. But mine enemies /are/ lively, /and/ they are strong: and they that hate me wrongfully are multiplied.
 20. They also that render evil for good are mine adversaries; because I follow /the thing that/ good /is/.
 21. Forsake me not, O LORD: O my God, be not far from me.
-22. Make haste to help me, O Lord my salvation. 
+22. Make haste to help me, O Lord my salvation.
 * 39
 To the chief Musician, /even/ to Jeduthun, A Psalm of David.
 1. I said, I will take heed to my ways, that I sin not with my tongue: I will keep my mouth with a bridle, while the wicked is before me.
@@ -658,7 +658,7 @@ To the chief Musician, /even/ to Jeduthun, A Psalm of David.
 10. Remove thy stroke away from me: I am consumed by the blow of thine hand.
 11. When thou with rebukes dost correct man for iniquity, thou makest his beauty to consume away like a moth: surely every man /is/ vanity. Selah.
 12. Hear my prayer, O LORD, and give ear unto my cry; hold not thy peace at my tears: for I /am/ a stranger with thee, /and/ a sojourner, as all my fathers /were/.
-13. O spare me, that I may recover strength, before I go hence, and be no more. 
+13. O spare me, that I may recover strength, before I go hence, and be no more.
 * 40
 To the chief Musician, A Psalm of David.
 1. I waited patiently for the LORD; and he inclined unto me, and heard my cry.
@@ -677,7 +677,7 @@ To the chief Musician, A Psalm of David.
 14. Let them be ashamed and confounded together that seek after my soul to destroy it; let them be driven backward and put to shame that wish me evil.
 15. Let them be desolate for a reward of their shame that say unto me, Aha, aha.
 16. Let all those that seek thee rejoice and be glad in thee: let such as love thy salvation say continually, The LORD be magnified.
-17. But I /am/ poor and needy; /yet/ the Lord thinketh upon me: thou /art/ my help and my deliverer; make no tarrying, O my God. 
+17. But I /am/ poor and needy; /yet/ the Lord thinketh upon me: thou /art/ my help and my deliverer; make no tarrying, O my God.
 * 41
 To the chief Musician, A Psalm of David.
 1. Blessed /is/ he that considereth the poor: the LORD will deliver him in time of trouble.
@@ -692,7 +692,7 @@ To the chief Musician, A Psalm of David.
 10. But thou, O LORD, be merciful unto me, and raise me up, that I may requite them.
 11. By this I know that thou favourest me, because mine enemy doth not triumph over me.
 12. And as for me, thou upholdest me in mine integrity, and settest me before thy face for ever.
-13. Blessed /be/ the LORD God of Israel from everlasting, and to everlasting. Amen, and Amen. 
+13. Blessed /be/ the LORD God of Israel from everlasting, and to everlasting. Amen, and Amen.
 * 42
 To the chief Musician, Maschil, for the sons of Korah.
 1. As the hart panteth after the water brooks, so panteth my soul after thee, O God.
@@ -705,13 +705,13 @@ To the chief Musician, Maschil, for the sons of Korah.
 8. /Yet/ the LORD will command his lovingkindness in the daytime, and in the night his song /shall be/ with me, /and/ my prayer unto the God of my life.
 9. I will say unto God my rock, Why hast thou forgotten me? why go I mourning because of the oppression of the enemy?
 10. /As/ with a sword in my bones, mine enemies reproach me; while they say daily unto me, Where /is/ thy God?
-11. Why art thou cast down, O my soul? and why art thou disquieted within me? hope thou in God: for I shall yet praise him, /who is/ the health of my countenance, and my God. 
+11. Why art thou cast down, O my soul? and why art thou disquieted within me? hope thou in God: for I shall yet praise him, /who is/ the health of my countenance, and my God.
 * 43
 1. Judge me, O God, and plead my cause against an ungodly nation: O deliver me from the deceitful and unjust man.
 2. For thou /art/ the God of my strength: why dost thou cast me off? why go I mourning because of the oppression of the enemy?
 3. O send out thy light and thy truth: let them lead me; let them bring me unto thy holy hill, and to thy tabernacles.
 4. Then will I go unto the altar of God, unto God my exceeding joy: yea, upon the harp will I praise thee, O God my God.
-5. Why art thou cast down, O my soul? and why art thou disquieted within me? hope in God: for I shall yet praise him, /who is/ the health of my countenance, and my God. 
+5. Why art thou cast down, O my soul? and why art thou disquieted within me? hope in God: for I shall yet praise him, /who is/ the health of my countenance, and my God.
 * 44
 To the chief Musician for the sons of Korah, Maschil.
 1. We have heard with our ears, O God, our fathers have told us, /what/ work thou didst in their days, in the times of old.
@@ -739,7 +739,7 @@ To the chief Musician for the sons of Korah, Maschil.
 23. Awake, why sleepest thou, O Lord? arise, cast /us/ not off for ever.
 24. Wherefore hidest thou thy face, /and/ forgettest our affliction and our oppression?
 25. For our soul is bowed down to the dust: our belly cleaveth unto the earth.
-26. Arise for our help, and redeem us for thy mercies' sake. 
+26. Arise for our help, and redeem us for thy mercies' sake.
 * 45
 To the chief Musician upon Shoshannim, for the sons of Korah, Maschil, A Song of loves.
 1. My heart is inditing a good matter: I speak of the things which I have made touching the king: my tongue /is/ the pen of a ready writer.
@@ -758,7 +758,7 @@ To the chief Musician upon Shoshannim, for the sons of Korah, Maschil, A Song of
 14. She shall be brought unto the king in raiment of needlework: the virgins her companions that follow her shall be brought unto thee.
 15. With gladness and rejoicing shall they be brought: they shall enter into the king's palace.
 16. Instead of thy fathers shall be thy children, whom thou mayest make princes in all the earth.
-17. I will make thy name to be remembered in all generations: therefore shall the people praise thee for ever and ever. 
+17. I will make thy name to be remembered in all generations: therefore shall the people praise thee for ever and ever.
 * 46
 To the chief Musician for the sons of Korah, A Song upon Alamoth.
 1. God /is/ our refuge and strength, a very present help in trouble.
@@ -771,7 +771,7 @@ To the chief Musician for the sons of Korah, A Song upon Alamoth.
 8. Come, behold the works of the LORD, what desolations he hath made in the earth.
 9. He maketh wars to cease unto the end of the earth; he breaketh the bow, and cutteth the spear in sunder; he burneth the chariot in the fire.
 10. Be still, and know that I /am/ God: I will be exalted among the heathen, I will be exalted in the earth.
-11. The LORD of hosts /is/ with us; the God of Jacob /is/ our refuge. Selah. 
+11. The LORD of hosts /is/ with us; the God of Jacob /is/ our refuge. Selah.
 * 47
 To the chief Musician, A Psalm for the sons of Korah.
 1. O clap your hands, all ye people; shout unto God with the voice of triumph.
@@ -782,7 +782,7 @@ To the chief Musician, A Psalm for the sons of Korah.
 6. Sing praises to God, sing praises: sing praises unto our King, sing praises.
 7. For God /is/ the King of all the earth: sing ye praises with understanding.
 8. God reigneth over the heathen: God sitteth upon the throne of his holiness.
-9. The princes of the people are gathered together, /even/ the people of the God of Abraham: for the shields of the earth /belong/ unto God: he is greatly exalted. 
+9. The princes of the people are gathered together, /even/ the people of the God of Abraham: for the shields of the earth /belong/ unto God: he is greatly exalted.
 * 48
 A Song /and/ Psalm for the sons of Korah.
 1. Great /is/ the LORD, and greatly to be praised in the city of our God, /in/ the mountain of his holiness.
@@ -798,7 +798,7 @@ A Song /and/ Psalm for the sons of Korah.
 11. Let mount Zion rejoice, let the daughters of Judah be glad, because of thy judgments.
 12. Walk about Zion, and go round about her: tell the towers thereof.
 13. Mark ye well her bulwarks, consider her palaces; that ye may tell /it/ to the generation following.
-14. For this God /is/ our God for ever and ever: he will be our guide /even/ unto death. 
+14. For this God /is/ our God for ever and ever: he will be our guide /even/ unto death.
 * 49
 To the chief Musician, A Psalm for the sons of Korah.
 1. Hear this, all /ye/ people; give ear, all /ye/ inhabitants of the world:
@@ -820,7 +820,7 @@ To the chief Musician, A Psalm for the sons of Korah.
 17. For when he dieth he shall carry nothing away: his glory shall not descend after him.
 18. Though while he lived he blessed his soul: and /men/ will praise thee, when thou doest well to thyself.
 19. He shall go to the generation of his fathers; they shall never see light.
-20. Man /that is/ in honour, and understandeth not, is like the beasts /that/ perish. 
+20. Man /that is/ in honour, and understandeth not, is like the beasts /that/ perish.
 * 50
 A Psalm of Asaph.
 1. The mighty God, /even/ the LORD, hath spoken, and called the earth from the rising of the sun unto the going down thereof.
@@ -845,7 +845,7 @@ A Psalm of Asaph.
 20. Thou sittest /and/ speakest against thy brother; thou slanderest thine own mother's son.
 21. These /things/ hast thou done, and I kept silence; thou thoughtest that I was altogether /such an one/ as thyself: /but/ I will reprove thee, and set /them/ in order before thine eyes.
 22. Now consider this, ye that forget God, lest I tear /you/ in pieces, and /there be/ none to deliver.
-23. Whoso offereth praise glorifieth me: and to him that ordereth /his/ conversation /aright/ will I shew the salvation of God. 
+23. Whoso offereth praise glorifieth me: and to him that ordereth /his/ conversation /aright/ will I shew the salvation of God.
 * 51
 To the chief Musician, A Psalm of David, when Nathan the prophet came unto him, after he had gone in to Bath–sheba.
 1. Have mercy upon me, O God, according to thy lovingkindness: according unto the multitude of thy tender mercies blot out my transgressions.
@@ -866,7 +866,7 @@ To the chief Musician, A Psalm of David, when Nathan the prophet came unto him, 
 16. For thou desirest not sacrifice; else would I give /it/: thou delightest not in burnt offering.
 17. The sacrifices of God /are/ a broken spirit: a broken and a contrite heart, O God, thou wilt not despise.
 18. Do good in thy good pleasure unto Zion: build thou the walls of Jerusalem.
-19. Then shalt thou be pleased with the sacrifices of righteousness, with burnt offering and whole burnt offering: then shall they offer bullocks upon thine altar. 
+19. Then shalt thou be pleased with the sacrifices of righteousness, with burnt offering and whole burnt offering: then shall they offer bullocks upon thine altar.
 * 52
 To the chief Musician, Maschil, /A Psalm/ of David, when Doeg the Edomite came and told Saul, and said unto him, David is come to the house of Ahimelech.
 1. Why boastest thou thyself in mischief, O mighty man? the goodness of God /endureth/ continually.
@@ -877,7 +877,7 @@ To the chief Musician, Maschil, /A Psalm/ of David, when Doeg the Edomite came a
 6. The righteous also shall see, and fear, and shall laugh at him:
 7. Lo, /this is/ the man /that/ made not God his strength; but trusted in the abundance of his riches, /and/ strengthened himself in his wickedness.
 8. But I /am/ like a green olive tree in the house of God: I trust in the mercy of God for ever and ever.
-9. I will praise thee for ever, because thou hast done /it/: and I will wait on thy name; for /it is/ good before thy saints. 
+9. I will praise thee for ever, because thou hast done /it/: and I will wait on thy name; for /it is/ good before thy saints.
 * 53
 To the chief Musician upon Mahalath, Maschil, /A Psalm/ of David.
 1. The fool hath said in his heart, /There is/ no God. Corrupt are they, and have done abominable iniquity: /there is/ none that doeth good.
@@ -885,7 +885,7 @@ To the chief Musician upon Mahalath, Maschil, /A Psalm/ of David.
 3. Every one of them is gone back: they are altogether become filthy; /there is/ none that doeth good, no, not one.
 4. Have the workers of iniquity no knowledge? who eat up my people /as/ they eat bread: they have not called upon God.
 5. There were they in great fear, /where/ no fear was: for God hath scattered the bones of him that encampeth /against/ thee: thou hast put /them/ to shame, because God hath despised them.
-6. Oh that the salvation of Israel /were come/ out of Zion! When God bringeth back the captivity of his people, Jacob shall rejoice, /and/ Israel shall be glad. 
+6. Oh that the salvation of Israel /were come/ out of Zion! When God bringeth back the captivity of his people, Jacob shall rejoice, /and/ Israel shall be glad.
 * 54
 To the chief Musician on Neginoth, Maschil, /A Psalm/ of David, when the Ziphims came and said to Saul, Doth not David hide himself with us?
 1. Save me, O God, by thy name, and judge me by thy strength.
@@ -894,7 +894,7 @@ To the chief Musician on Neginoth, Maschil, /A Psalm/ of David, when the Ziphims
 4. Behold, God /is/ mine helper: the Lord /is/ with them that uphold my soul.
 5. He shall reward evil unto mine enemies: cut them off in thy truth.
 6. I will freely sacrifice unto thee: I will praise thy name, O LORD; for /it is/ good.
-7. For he hath delivered me out of all trouble: and mine eye hath seen /his desire/ upon mine enemies. 
+7. For he hath delivered me out of all trouble: and mine eye hath seen /his desire/ upon mine enemies.
 * 55
 To the chief Musician on Neginoth, Maschil, /A Psalm/ of David.
 1. Give ear to my prayer, O God; and hide not thyself from my supplication.
@@ -919,7 +919,7 @@ To the chief Musician on Neginoth, Maschil, /A Psalm/ of David.
 20. He hath put forth his hands against such as be at peace with him: he hath broken his covenant.
 21. /The words/ of his mouth were smoother than butter, but war /was/ in his heart: his words were softer than oil, yet /were/ they drawn swords.
 22. Cast thy burden upon the LORD, and he shall sustain thee: he shall never suffer the righteous to be moved.
-23. But thou, O God, shalt bring them down into the pit of destruction: bloody and deceitful men shall not live out half their days; but I will trust in thee. 
+23. But thou, O God, shalt bring them down into the pit of destruction: bloody and deceitful men shall not live out half their days; but I will trust in thee.
 * 56
 To the chief Musician upon Jonath–elem–rechokim, Michtam of David, when the Philistines took him in Gath.
 1. Be merciful unto me, O God: for man would swallow me up; he fighting daily oppresseth me.
@@ -934,7 +934,7 @@ To the chief Musician upon Jonath–elem–rechokim, Michtam of David, when the 
 10. In God will I praise /his/ word: in the LORD will I praise /his/ word.
 11. In God have I put my trust: I will not be afraid what man can do unto me.
 12. Thy vows /are/ upon me, O God: I will render praises unto thee.
-13. For thou hast delivered my soul from death: /wilt/ not /thou deliver/ my feet from falling, that I may walk before God in the light of the living? 
+13. For thou hast delivered my soul from death: /wilt/ not /thou deliver/ my feet from falling, that I may walk before God in the light of the living?
 * 57
 To the chief Musician, Al–taschith, Michtam of David, when he fled from Saul in the cave.
 1. Be merciful unto me, O God, be merciful unto me: for my soul trusteth in thee: yea, in the shadow of thy wings will I make my refuge, until /these/ calamities be overpast.
@@ -947,7 +947,7 @@ To the chief Musician, Al–taschith, Michtam of David, when he fled from Saul i
 8. Awake up, my glory; awake, psaltery and harp: I /myself/ will awake early.
 9. I will praise thee, O Lord, among the people: I will sing unto thee among the nations.
 10. For thy mercy /is/ great unto the heavens, and thy truth unto the clouds.
-11. Be thou exalted, O God, above the heavens: /let/ thy glory /be/ above all the earth. 
+11. Be thou exalted, O God, above the heavens: /let/ thy glory /be/ above all the earth.
 * 58
 To the chief Musician, Al–taschith, Michtam of David.
 1. Do ye indeed speak righteousness, O congregation? do ye judge uprightly, O ye sons of men?
@@ -960,7 +960,7 @@ To the chief Musician, Al–taschith, Michtam of David.
 8. As a snail /which/ melteth, let /every one of them/ pass away: /like/ the untimely birth of a woman, /that/ they may not see the sun.
 9. Before your pots can feel the thorns, he shall take them away as with a whirlwind, both living, and in /his/ wrath.
 10. The righteous shall rejoice when he seeth the vengeance: he shall wash his feet in the blood of the wicked.
-11. So that a man shall say, Verily /there is/ a reward for the righteous: verily he is a God that judgeth in the earth. 
+11. So that a man shall say, Verily /there is/ a reward for the righteous: verily he is a God that judgeth in the earth.
 * 59
 To the chief Musician, Al–taschith, Michtam of David; when Saul sent, and they watched the house to kill him.
 1. Deliver me from mine enemies, O my God: defend me from them that rise up against me.
@@ -979,7 +979,7 @@ To the chief Musician, Al–taschith, Michtam of David; when Saul sent, and they
 14. And at evening let them return; /and/ let them make a noise like a dog, and go round about the city.
 15. Let them wander up and down for meat, and grudge if they be not satisfied.
 16. But I will sing of thy power; yea, I will sing aloud of thy mercy in the morning: for thou hast been my defence and refuge in the day of my trouble.
-17. Unto thee, O my strength, will I sing: for God /is/ my defence, /and/ the God of my mercy. 
+17. Unto thee, O my strength, will I sing: for God /is/ my defence, /and/ the God of my mercy.
 * 60
 To the chief Musician upon Shushan–eduth, Michtam of David, to teach; when he strove with Aram–naharaim and with Aram–zobah, when Joab returned, and smote of Edom in the valley of salt twelve thousand.
 1. O God, thou hast cast us off, thou hast scattered us, thou hast been displeased; O turn thyself to us again.
@@ -993,7 +993,7 @@ To the chief Musician upon Shushan–eduth, Michtam of David, to teach; when he 
 9. Who will bring me /into/ the strong city? who will lead me into Edom?
 10. /Wilt/ not thou, O God, /which/ hadst cast us off? and /thou/, O God, /which/ didst not go out with our armies?
 11. Give us help from trouble: for vain /is/ the help of man.
-12. Through God we shall do valiantly: for he /it is that/ shall tread down our enemies. 
+12. Through God we shall do valiantly: for he /it is that/ shall tread down our enemies.
 * 61
 To the chief Musician upon Neginah, /A Psalm/ of David.
 1. Hear my cry, O God; attend unto my prayer.
@@ -1003,7 +1003,7 @@ To the chief Musician upon Neginah, /A Psalm/ of David.
 5. For thou, O God, hast heard my vows: thou hast given /me/ the heritage of those that fear thy name.
 6. Thou wilt prolong the king's life: /and/ his years as many generations.
 7. He shall abide before God for ever: O prepare mercy and truth, /which/ may preserve him.
-8. So will I sing praise unto thy name for ever, that I may daily perform my vows. 
+8. So will I sing praise unto thy name for ever, that I may daily perform my vows.
 * 62
 To the chief Musician, to Jeduthun, A Psalm of David.
 1. Truly my soul waiteth upon God: from him /cometh/ my salvation.
@@ -1017,7 +1017,7 @@ To the chief Musician, to Jeduthun, A Psalm of David.
 9. Surely men of low degree /are/ vanity, /and/ men of high degree /are/ a lie: to be laid in the balance, they /are/ altogether /lighter/ than vanity.
 10. Trust not in oppression, and become not vain in robbery: if riches increase, set not your heart /upon them/.
 11. God hath spoken once; twice have I heard this; that power /belongeth/ unto God.
-12. Also unto thee, O Lord, /belongeth/ mercy: for thou renderest to every man according to his work. 
+12. Also unto thee, O Lord, /belongeth/ mercy: for thou renderest to every man according to his work.
 * 63
 A Psalm of David, when he was in the wilderness of Judah.
 1. O God, thou /art/ my God; early will I seek thee: my soul thirsteth for thee, my flesh longeth for thee in a dry and thirsty land, where no water is;
@@ -1030,7 +1030,7 @@ A Psalm of David, when he was in the wilderness of Judah.
 8. My soul followeth hard after thee: thy right hand upholdeth me.
 9. But those /that/ seek my soul, to destroy /it/, shall go into the lower parts of the earth.
 10. They shall fall by the sword: they shall be a portion for foxes.
-11. But the king shall rejoice in God; every one that sweareth by him shall glory: but the mouth of them that speak lies shall be stopped. 
+11. But the king shall rejoice in God; every one that sweareth by him shall glory: but the mouth of them that speak lies shall be stopped.
 * 64
 To the chief Musician, A Psalm of David.
 1. Hear my voice, O God, in my prayer: preserve my life from fear of the enemy.
@@ -1042,7 +1042,7 @@ To the chief Musician, A Psalm of David.
 7. But God shall shoot at them /with/ an arrow; suddenly shall they be wounded.
 8. So they shall make their own tongue to fall upon themselves: all that see them shall flee away.
 9. And all men shall fear, and shall declare the work of God; for they shall wisely consider of his doing.
-10. The righteous shall be glad in the LORD, and shall trust in him; and all the upright in heart shall glory. 
+10. The righteous shall be glad in the LORD, and shall trust in him; and all the upright in heart shall glory.
 * 65
 To the chief Musician, A Psalm /and/ Song of David.
 1. Praise waiteth for thee, O God, in Sion: and unto thee shall the vow be performed.
@@ -1057,7 +1057,7 @@ To the chief Musician, A Psalm /and/ Song of David.
 10. Thou waterest the ridges thereof abundantly: thou settlest the furrows thereof: thou makest it soft with showers: thou blessest the springing thereof.
 11. Thou crownest the year with thy goodness; and thy paths drop fatness.
 12. They drop /upon/ the pastures of the wilderness: and the little hills rejoice on every side.
-13. The pastures are clothed with flocks; the valleys also are covered over with corn; they shout for joy, they also sing. 
+13. The pastures are clothed with flocks; the valleys also are covered over with corn; they shout for joy, they also sing.
 * 66
 To the chief Musician, A Song /or/ Psalm.
 1. Make a joyful noise unto God, all ye lands:
@@ -1079,7 +1079,7 @@ To the chief Musician, A Song /or/ Psalm.
 17. I cried unto him with my mouth, and he was extolled with my tongue.
 18. If I regard iniquity in my heart, the Lord will not hear /me/:
 19. /But/ verily God hath heard /me/; he hath attended to the voice of my prayer.
-20. Blessed /be/ God, which hath not turned away my prayer, nor his mercy from me. 
+20. Blessed /be/ God, which hath not turned away my prayer, nor his mercy from me.
 * 67
 To the chief Musician on Neginoth, A Psalm /or/ Song.
 1. God be merciful unto us, and bless us; /and/ cause his face to shine upon us; Selah.
@@ -1088,7 +1088,7 @@ To the chief Musician on Neginoth, A Psalm /or/ Song.
 4. O let the nations be glad and sing for joy: for thou shalt judge the people righteously, and govern the nations upon earth. Selah.
 5. Let the people praise thee, O God; let all the people praise thee.
 6. /Then/ shall the earth yield her increase; /and/ God, /even/ our own God, shall bless us.
-7. God shall bless us; and all the ends of the earth shall fear him. 
+7. God shall bless us; and all the ends of the earth shall fear him.
 * 68
 To the chief Musician, A Psalm /or/ Song of David.
 1. Let God arise, let his enemies be scattered: let them also that hate him flee before him.
@@ -1125,7 +1125,7 @@ To the chief Musician, A Psalm /or/ Song of David.
 32. Sing unto God, ye kingdoms of the earth; O sing praises unto the Lord; Selah:
 33. To him that rideth upon the heavens of heavens, /which were/ of old; lo, he doth send out his voice, /and that/ a mighty voice.
 34. Ascribe ye strength unto God: his excellency /is/ over Israel, and his strength /is/ in the clouds.
-35. O God, /thou art/ terrible out of thy holy places: the God of Israel /is/ he that giveth strength and power unto /his/ people. Blessed /be/ God. 
+35. O God, /thou art/ terrible out of thy holy places: the God of Israel /is/ he that giveth strength and power unto /his/ people. Blessed /be/ God.
 * 69
 To the chief Musician upon Shoshannim, /A Psalm/ of David.
 1. Save me, O God; for the waters are come in unto /my/ soul.
@@ -1163,14 +1163,14 @@ To the chief Musician upon Shoshannim, /A Psalm/ of David.
 33. For the LORD heareth the poor, and despiseth not his prisoners.
 34. Let the heaven and earth praise him, the seas, and every thing that moveth therein.
 35. For God will save Zion, and will build the cities of Judah: that they may dwell there, and have it in possession.
-36. The seed also of his servants shall inherit it: and they that love his name shall dwell therein. 
+36. The seed also of his servants shall inherit it: and they that love his name shall dwell therein.
 * 70
 To the chief Musician, /A Psalm/ of David, to bring to remembrance.
 1. /Make haste/, O God, to deliver me; make haste to help me, O LORD.
 2. Let them be ashamed and confounded that seek after my soul: let them be turned backward, and put to confusion, that desire my hurt.
 3. Let them be turned back for a reward of their shame that say, Aha, aha.
 4. Let all those that seek thee rejoice and be glad in thee: and let such as love thy salvation say continually, Let God be magnified.
-5. But I /am/ poor and needy: make haste unto me, O God: thou /art/ my help and my deliverer; O LORD, make no tarrying. 
+5. But I /am/ poor and needy: make haste unto me, O God: thou /art/ my help and my deliverer; O LORD, make no tarrying.
 * 71
 1. In thee, O LORD, do I put my trust: let me never be put to confusion.
 2. Deliver me in thy righteousness, and cause me to escape: incline thine ear unto me, and save me.
@@ -1195,7 +1195,7 @@ To the chief Musician, /A Psalm/ of David, to bring to remembrance.
 21. Thou shalt increase my greatness, and comfort me on every side.
 22. I will also praise thee with the psaltery, /even/ thy truth, O my God: unto thee will I sing with the harp, O thou Holy One of Israel.
 23. My lips shall greatly rejoice when I sing unto thee; and my soul, which thou hast redeemed.
-24. My tongue also shall talk of thy righteousness all the day long: for they are confounded, for they are brought unto shame, that seek my hurt. 
+24. My tongue also shall talk of thy righteousness all the day long: for they are confounded, for they are brought unto shame, that seek my hurt.
 * 72
 /A Psalm/ for Solomon.
 1. Give the king thy judgments, O God, and thy righteousness unto the king's son.
@@ -1217,7 +1217,7 @@ To the chief Musician, /A Psalm/ of David, to bring to remembrance.
 17. His name shall endure for ever: his name shall be continued as long as the sun: and /men/ shall be blessed in him: all nations shall call him blessed.
 18. Blessed /be/ the LORD God, the God of Israel, who only doeth wondrous things.
 19. And blessed /be/ his glorious name for ever: and let the whole earth be filled /with/ his glory; Amen, and Amen.
-20. The prayers of David the son of Jesse are ended. 
+20. The prayers of David the son of Jesse are ended.
 * 73
 A Psalm of Asaph.
 1. Truly God /is/ good to Israel, /even/ to such as are of a clean heart.
@@ -1247,7 +1247,7 @@ A Psalm of Asaph.
 25. Whom have I in heaven /but thee/? and /there is/ none upon earth /that/ I desire beside thee.
 26. My flesh and my heart faileth: /but/ God /is/ the strength of my heart, and my portion for ever.
 27. For, lo, they that are far from thee shall perish: thou hast destroyed all them that go a whoring from thee.
-28. But /it is/ good for me to draw near to God: I have put my trust in the Lord GOD, that I may declare all thy works. 
+28. But /it is/ good for me to draw near to God: I have put my trust in the Lord GOD, that I may declare all thy works.
 * 74
 Maschil of Asaph.
 1. O God, why hast thou cast /us/ off for ever? /why/ doth thine anger smoke against the sheep of thy pasture?
@@ -1272,7 +1272,7 @@ Maschil of Asaph.
 20. Have respect unto the covenant: for the dark places of the earth are full of the habitations of cruelty.
 21. O let not the oppressed return ashamed: let the poor and needy praise thy name.
 22. Arise, O God, plead thine own cause: remember how the foolish man reproacheth thee daily.
-23. Forget not the voice of thine enemies: the tumult of those that rise up against thee increaseth continually. 
+23. Forget not the voice of thine enemies: the tumult of those that rise up against thee increaseth continually.
 * 75
 To the chief Musician, Al–taschith, A Psalm /or/ Song of Asaph.
 1. Unto thee, O God, do we give thanks, /unto thee/ do we give thanks: for /that/ thy name is near thy wondrous works declare.
@@ -1284,7 +1284,7 @@ To the chief Musician, Al–taschith, A Psalm /or/ Song of Asaph.
 7. But God /is/ the judge: he putteth down one, and setteth up another.
 8. For in the hand of the LORD /there is/ a cup, and the wine is red; it is full of mixture; and he poureth out of the same: but the dregs thereof, all the wicked of the earth shall wring /them/ out, /and/ drink /them/.
 9. But I will declare for ever; I will sing praises to the God of Jacob.
-10. All the horns of the wicked also will I cut off; /but/ the horns of the righteous shall be exalted. 
+10. All the horns of the wicked also will I cut off; /but/ the horns of the righteous shall be exalted.
 * 76
 To the chief Musician on Neginoth, A Psalm /or/ Song of Asaph.
 1. In Judah /is/ God known: his name /is/ great in Israel.
@@ -1298,7 +1298,7 @@ To the chief Musician on Neginoth, A Psalm /or/ Song of Asaph.
 9. When God arose to judgment, to save all the meek of the earth. Selah.
 10. Surely the wrath of man shall praise thee: the remainder of wrath shalt thou restrain.
 11. Vow, and pay unto the LORD your God: let all that be round about him bring presents unto him that ought to be feared.
-12. He shall cut off the spirit of princes: /he is/ terrible to the kings of the earth. 
+12. He shall cut off the spirit of princes: /he is/ terrible to the kings of the earth.
 * 77
 To the chief Musician, to Jeduthun, A Psalm of Asaph.
 1. I cried unto God with my voice, /even/ unto God with my voice; and he gave ear unto me.
@@ -1320,7 +1320,7 @@ To the chief Musician, to Jeduthun, A Psalm of Asaph.
 17. The clouds poured out water: the skies sent out a sound: thine arrows also went abroad.
 18. The voice of thy thunder /was/ in the heaven: the lightnings lightened the world: the earth trembled and shook.
 19. Thy way /is/ in the sea, and thy path in the great waters, and thy footsteps are not known.
-20. Thou leddest thy people like a flock by the hand of Moses and Aaron. 
+20. Thou leddest thy people like a flock by the hand of Moses and Aaron.
 * 78
 Maschil of Asaph.
 1. Give ear, O my people, /to/ my law: incline your ears to the words of my mouth.
@@ -1394,7 +1394,7 @@ Maschil of Asaph.
 69. And he built his sanctuary like high /palaces/, like the earth which he hath established for ever.
 70. He chose David also his servant, and took him from the sheepfolds:
 71. From following the ewes great with young he brought him to feed Jacob his people, and Israel his inheritance.
-72. So he fed them according to the integrity of his heart; and guided them by the skilfulness of his hands. 
+72. So he fed them according to the integrity of his heart; and guided them by the skilfulness of his hands.
 * 79
 A Psalm of Asaph.
 1. O God, the heathen are come into thine inheritance; thy holy temple have they defiled; they have laid Jerusalem on heaps.
@@ -1409,7 +1409,7 @@ A Psalm of Asaph.
 10. Wherefore should the heathen say, Where /is/ their God? let him be known among the heathen in our sight /by/ the revenging of the blood of thy servants /which is/ shed.
 11. Let the sighing of the prisoner come before thee; according to the greatness of thy power preserve thou those that are appointed to die;
 12. And render unto our neighbours sevenfold into their bosom their reproach, wherewith they have reproached thee, O Lord.
-13. So we thy people and sheep of thy pasture will give thee thanks for ever: we will shew forth thy praise to all generations. 
+13. So we thy people and sheep of thy pasture will give thee thanks for ever: we will shew forth thy praise to all generations.
 * 80
 To the chief Musician upon Shoshannim–eduth, A Psalm of Asaph.
 1. Give ear, O Shepherd of Israel, thou that leadest Joseph like a flock; thou that dwellest /between/ the cherubims, shine forth.
@@ -1430,7 +1430,7 @@ To the chief Musician upon Shoshannim–eduth, A Psalm of Asaph.
 16. /It is/ burned with fire, /it is/ cut down: they perish at the rebuke of thy countenance.
 17. Let thy hand be upon the man of thy right hand, upon the son of man /whom/ thou madest strong for thyself.
 18. So will not we go back from thee: quicken us, and we will call upon thy name.
-19. Turn us again, O LORD God of hosts, cause thy face to shine; and we shall be saved. 
+19. Turn us again, O LORD God of hosts, cause thy face to shine; and we shall be saved.
 * 81
 To the chief Musician upon Gittith, /A Psalm/ of Asaph.
 1. Sing aloud unto God our strength: make a joyful noise unto the God of Jacob.
@@ -1448,7 +1448,7 @@ To the chief Musician upon Gittith, /A Psalm/ of Asaph.
 13. Oh that my people had hearkened unto me, /and/ Israel had walked in my ways!
 14. I should soon have subdued their enemies, and turned my hand against their adversaries.
 15. The haters of the LORD should have submitted themselves unto him: but their time should have endured for ever.
-16. He should have fed them also with the finest of the wheat: and with honey out of the rock should I have satisfied thee. 
+16. He should have fed them also with the finest of the wheat: and with honey out of the rock should I have satisfied thee.
 * 82
 A Psalm of Asaph.
 1. God standeth in the congregation of the mighty; he judgeth among the gods.
@@ -1458,7 +1458,7 @@ A Psalm of Asaph.
 5. They know not, neither will they understand; they walk on in darkness: all the foundations of the earth are out of course.
 6. I have said, Ye /are/ gods; and all of you /are/ children of the most High.
 7. But ye shall die like men, and fall like one of the princes.
-8. Arise, O God, judge the earth: for thou shalt inherit all nations. 
+8. Arise, O God, judge the earth: for thou shalt inherit all nations.
 * 83
 A Song /or/ Psalm of Asaph.
 1. Keep not thou silence, O God: hold not thy peace, and be not still, O God.
@@ -1492,7 +1492,7 @@ To the chief Musician upon Gittith, A Psalm for the sons of Korah.
 9. Behold, O God our shield, and look upon the face of thine anointed.
 10. For a day in thy courts /is/ better than a thousand. I had rather be a doorkeeper in the house of my God, than to dwell in the tents of wickedness.
 11. For the LORD God /is/ a sun and shield: the LORD will give grace and glory: no good /thing/ will he withhold from them that walk uprightly.
-12. O LORD of hosts, blessed /is/ the man that trusteth in thee. 
+12. O LORD of hosts, blessed /is/ the man that trusteth in thee.
 * 85
 To the chief Musician, A Psalm for the sons of Korah.
 1. LORD, thou hast been favourable unto thy land: thou hast brought back the captivity of Jacob.
@@ -1507,7 +1507,7 @@ To the chief Musician, A Psalm for the sons of Korah.
 10. Mercy and truth are met together; righteousness and peace have kissed /each other/.
 11. Truth shall spring out of the earth; and righteousness shall look down from heaven.
 12. Yea, the LORD shall give /that which is/ good; and our land shall yield her increase.
-13. Righteousness shall go before him; and shall set /us/ in the way of his steps. 
+13. Righteousness shall go before him; and shall set /us/ in the way of his steps.
 * 86
 A Prayer of David.
 1. Bow down thine ear, O LORD, hear me: for I /am/ poor and needy.
@@ -1526,7 +1526,7 @@ A Prayer of David.
 14. O God, the proud are risen against me, and the assemblies of violent /men/ have sought after my soul; and have not set thee before them.
 15. But thou, O Lord, /art/ a God full of compassion, and gracious, longsuffering, and plenteous in mercy and truth.
 16. O turn unto me, and have mercy upon me; give thy strength unto thy servant, and save the son of thine handmaid.
-17. Shew me a token for good; that they which hate me may see /it/, and be ashamed: because thou, LORD, hast holpen me, and comforted me. 
+17. Shew me a token for good; that they which hate me may see /it/, and be ashamed: because thou, LORD, hast holpen me, and comforted me.
 * 87
 A Psalm /or/ Song for the sons of Korah.
 1. His foundation /is/ in the holy mountains.
@@ -1535,7 +1535,7 @@ A Psalm /or/ Song for the sons of Korah.
 4. I will make mention of Rahab and Babylon to them that know me: behold Philistia, and Tyre, with Ethiopia; this /man/ was born there.
 5. And of Zion it shall be said, This and that man was born in her: and the highest himself shall establish her.
 6. The LORD shall count, when he writeth up the people, /that/ this /man/ was born there. Selah.
-7. As well the singers as the players on instruments /shall be there/: all my springs /are/ in thee. 
+7. As well the singers as the players on instruments /shall be there/: all my springs /are/ in thee.
 * 88
 A Song /or/ Psalm for the sons of Korah, to the chief Musician upon Mahalath Leannoth, Maschil of Heman the Ezrahite.
 1. O LORD God of my salvation, I have cried day /and/ night before thee:
@@ -1555,7 +1555,7 @@ A Song /or/ Psalm for the sons of Korah, to the chief Musician upon Mahalath Lea
 15. I /am/ afflicted and ready to die from /my/ youth up: /while/ I suffer thy terrors I am distracted.
 16. Thy fierce wrath goeth over me; thy terrors have cut me off.
 17. They came round about me daily like water; they compassed me about together.
-18. Lover and friend hast thou put far from me, /and/ mine acquaintance into darkness. 
+18. Lover and friend hast thou put far from me, /and/ mine acquaintance into darkness.
 * 89
 Maschil of Ethan the Ezrahite.
 1. I will sing of the mercies of the LORD for ever: with my mouth will I make known thy faithfulness to all generations.
@@ -1609,7 +1609,7 @@ Maschil of Ethan the Ezrahite.
 49. Lord, where /are/ thy former lovingkindnesses, /which/ thou swarest unto David in thy truth?
 50. Remember, Lord, the reproach of thy servants; /how/ I do bear in my bosom /the reproach of/ all the mighty people;
 51. Wherewith thine enemies have reproached, O LORD; wherewith they have reproached the footsteps of thine anointed.
-52. Blessed /be/ the LORD for evermore. Amen, and Amen. 
+52. Blessed /be/ the LORD for evermore. Amen, and Amen.
 * 90
 A Prayer of Moses the man of God.
 1. Lord, thou hast been our dwelling place in all generations.
@@ -1628,7 +1628,7 @@ A Prayer of Moses the man of God.
 14. O satisfy us early with thy mercy; that we may rejoice and be glad all our days.
 15. Make us glad according to the days /wherein/ thou hast afflicted us, /and/ the years /wherein/ we have seen evil.
 16. Let thy work appear unto thy servants, and thy glory unto their children.
-17. And let the beauty of the LORD our God be upon us: and establish thou the work of our hands upon us; yea, the work of our hands establish thou it. 
+17. And let the beauty of the LORD our God be upon us: and establish thou the work of our hands upon us; yea, the work of our hands establish thou it.
 * 91
 1. He that dwelleth in the secret place of the most High shall abide under the shadow of the Almighty.
 2. I will say of the LORD, /He is/ my refuge and my fortress: my God; in him will I trust.
@@ -1645,7 +1645,7 @@ A Prayer of Moses the man of God.
 13. Thou shalt tread upon the lion and adder: the young lion and the dragon shalt thou trample under feet.
 14. Because he hath set his love upon me, therefore will I deliver him: I will set him on high, because he hath known my name.
 15. He shall call upon me, and I will answer him: I /will be/ with him in trouble; I will deliver him, and honour him.
-16. With long life will I satisfy him, and shew him my salvation. 
+16. With long life will I satisfy him, and shew him my salvation.
 * 92
 A Psalm /or/ Song for the sabbath day.
 1. /It is a/ good /thing/ to give thanks unto the LORD, and to sing praises unto thy name, O most High:
@@ -1662,13 +1662,13 @@ A Psalm /or/ Song for the sabbath day.
 12. The righteous shall flourish like the palm tree: he shall grow like a cedar in Lebanon.
 13. Those that be planted in the house of the LORD shall flourish in the courts of our God.
 14. They shall still bring forth fruit in old age; they shall be fat and flourishing;
-15. To shew that the LORD /is/ upright: /he is/ my rock, and /there is/ no unrighteousness in him. 
+15. To shew that the LORD /is/ upright: /he is/ my rock, and /there is/ no unrighteousness in him.
 * 93
 1. The LORD reigneth, he is clothed with majesty; the LORD is clothed with strength, /wherewith/ he hath girded himself: the world also is stablished, that it cannot be moved.
 2. Thy throne /is/ established of old: thou /art/ from everlasting.
 3. The floods have lifted up, O LORD, the floods have lifted up their voice; the floods lift up their waves.
 4. The LORD on high /is/ mightier than the noise of many waters, /yea, than/ the mighty waves of the sea.
-5. Thy testimonies are very sure: holiness becometh thine house, O LORD, for ever. 
+5. Thy testimonies are very sure: holiness becometh thine house, O LORD, for ever.
 * 94
 1. O LORD God, to whom vengeance belongeth; O God, to whom vengeance belongeth, shew thyself.
 2. Lift up thyself, thou judge of the earth: render a reward to the proud.
@@ -1692,7 +1692,7 @@ A Psalm /or/ Song for the sabbath day.
 20. Shall the throne of iniquity have fellowship with thee, which frameth mischief by a law?
 21. They gather themselves together against the soul of the righteous, and condemn the innocent blood.
 22. But the LORD is my defence; and my God /is/ the rock of my refuge.
-23. And he shall bring upon them their own iniquity, and shall cut them off in their own wickedness; /yea/, the LORD our God shall cut them off. 
+23. And he shall bring upon them their own iniquity, and shall cut them off in their own wickedness; /yea/, the LORD our God shall cut them off.
 * 95
 1. O come, let us sing unto the LORD: let us make a joyful noise to the rock of our salvation.
 2. Let us come before his presence with thanksgiving, and make a joyful noise unto him with psalms.
@@ -1704,7 +1704,7 @@ A Psalm /or/ Song for the sabbath day.
 8. Harden not your heart, as in the provocation, /and/ as /in/ the day of temptation in the wilderness:
 9. When your fathers tempted me, proved me, and saw my work.
 10. Forty years long was I grieved with /this/ generation, and said, It /is/ a people that do err in their heart, and they have not known my ways:
-11. Unto whom I sware in my wrath that they should not enter into my rest. 
+11. Unto whom I sware in my wrath that they should not enter into my rest.
 * 96
 1. O sing unto the LORD a new song: sing unto the LORD, all the earth.
 2. Sing unto the LORD, bless his name; shew forth his salvation from day to day.
@@ -1718,7 +1718,7 @@ A Psalm /or/ Song for the sabbath day.
 10. Say among the heathen /that/ the LORD reigneth: the world also shall be established that it shall not be moved: he shall judge the people righteously.
 11. Let the heavens rejoice, and let the earth be glad; let the sea roar, and the fulness thereof.
 12. Let the field be joyful, and all that /is/ therein: then shall all the trees of the wood rejoice
-13. Before the LORD: for he cometh, for he cometh to judge the earth: he shall judge the world with righteousness, and the people with his truth. 
+13. Before the LORD: for he cometh, for he cometh to judge the earth: he shall judge the world with righteousness, and the people with his truth.
 * 97
 1. The LORD reigneth; let the earth rejoice; let the multitude of isles be glad /thereof/.
 2. Clouds and darkness /are/ round about him: righteousness and judgment /are/ the habitation of his throne.
@@ -1731,7 +1731,7 @@ A Psalm /or/ Song for the sabbath day.
 9. For thou, LORD, /art/ high above all the earth: thou art exalted far above all gods.
 10. Ye that love the LORD, hate evil: he preserveth the souls of his saints; he delivereth them out of the hand of the wicked.
 11. Light is sown for the righteous, and gladness for the upright in heart.
-12. Rejoice in the LORD, ye righteous; and give thanks at the remembrance of his holiness. 
+12. Rejoice in the LORD, ye righteous; and give thanks at the remembrance of his holiness.
 * 98
 A Psalm.
 1. O sing unto the LORD a new song; for he hath done marvellous things: his right hand, and his holy arm, hath gotten him the victory.
@@ -1742,7 +1742,7 @@ A Psalm.
 6. With trumpets and sound of cornet make a joyful noise before the LORD, the King.
 7. Let the sea roar, and the fulness thereof; the world, and they that dwell therein.
 8. Let the floods clap /their/ hands: let the hills be joyful together
-9. Before the LORD; for he cometh to judge the earth: with righteousness shall he judge the world, and the people with equity. 
+9. Before the LORD; for he cometh to judge the earth: with righteousness shall he judge the world, and the people with equity.
 * 99
 1. The LORD reigneth; let the people tremble: he sitteth /between/ the cherubims; let the earth be moved.
 2. The LORD /is/ great in Zion; and he /is/ high above all the people.
@@ -1752,14 +1752,14 @@ A Psalm.
 6. Moses and Aaron among his priests, and Samuel among them that call upon his name; they called upon the LORD, and he answered them.
 7. He spake unto them in the cloudy pillar: they kept his testimonies, and the ordinance /that/ he gave them.
 8. Thou answeredst them, O LORD our God: thou wast a God that forgavest them, though thou tookest vengeance of their inventions.
-9. Exalt the LORD our God, and worship at his holy hill; for the LORD our God /is/ holy. 
+9. Exalt the LORD our God, and worship at his holy hill; for the LORD our God /is/ holy.
 * 100
 A Psalm of praise.
 1. Make a joyful noise unto the LORD, all ye lands.
 2. Serve the LORD with gladness: come before his presence with singing.
 3. Know ye that the LORD he /is/ God: /it is/ he /that/ hath made us, and not we ourselves; /we are/ his people, and the sheep of his pasture.
 4. Enter into his gates with thanksgiving, /and/ into his courts with praise: be thankful unto him, /and/ bless his name.
-5. For the LORD /is/ good; his mercy /is/ everlasting; and his truth /endureth/ to all generations. 
+5. For the LORD /is/ good; his mercy /is/ everlasting; and his truth /endureth/ to all generations.
 * 101
 A Psalm of David.
 1. I will sing of mercy and judgment: unto thee, O LORD, will I sing.
@@ -1769,7 +1769,7 @@ A Psalm of David.
 5. Whoso privily slandereth his neighbour, him will I cut off: him that hath an high look and a proud heart will not I suffer.
 6. Mine eyes /shall be/ upon the faithful of the land, that they may dwell with me: he that walketh in a perfect way, he shall serve me.
 7. He that worketh deceit shall not dwell within my house: he that telleth lies shall not tarry in my sight.
-8. I will early destroy all the wicked of the land; that I may cut off all wicked doers from the city of the LORD. 
+8. I will early destroy all the wicked of the land; that I may cut off all wicked doers from the city of the LORD.
 * 102
 A Prayer of the afflicted, when he is overwhelmed, and poureth out his complaint before the LORD.
 1. Hear my prayer, O LORD, and let my cry come unto thee.
@@ -1799,7 +1799,7 @@ A Prayer of the afflicted, when he is overwhelmed, and poureth out his complaint
 25. Of old hast thou laid the foundation of the earth: and the heavens /are/ the work of thy hands.
 26. They shall perish, but thou shalt endure: yea, all of them shall wax old like a garment; as a vesture shalt thou change them, and they shall be changed:
 27. But thou /art/ the same, and thy years shall have no end.
-28. The children of thy servants shall continue, and their seed shall be established before thee. 
+28. The children of thy servants shall continue, and their seed shall be established before thee.
 * 103
 /A Psalm/ of David.
 1. Bless the LORD, O my soul: and all that is within me, /bless/ his holy name.
@@ -1823,7 +1823,7 @@ A Prayer of the afflicted, when he is overwhelmed, and poureth out his complaint
 19. The LORD hath prepared his throne in the heavens; and his kingdom ruleth over all.
 20. Bless the LORD, ye his angels, that excel in strength, that do his commandments, hearkening unto the voice of his word.
 21. Bless ye the LORD, all /ye/ his hosts; /ye/ ministers of his, that do his pleasure.
-22. Bless the LORD, all his works in all places of his dominion: bless the LORD, O my soul. 
+22. Bless the LORD, all his works in all places of his dominion: bless the LORD, O my soul.
 * 104
 1. Bless the LORD, O my soul. O LORD my God, thou art very great; thou art clothed with honour and majesty.
 2. Who coverest /thyself/ with light as /with/ a garment: who stretchest out the heavens like a curtain:
@@ -1859,7 +1859,7 @@ A Prayer of the afflicted, when he is overwhelmed, and poureth out his complaint
 32. He looketh on the earth, and it trembleth: he toucheth the hills, and they smoke.
 33. I will sing unto the LORD as long as I live: I will sing praise to my God while I have my being.
 34. My meditation of him shall be sweet: I will be glad in the LORD.
-35. Let the sinners be consumed out of the earth, and let the wicked be no more. Bless thou the LORD, O my soul. Praise ye the LORD. 
+35. Let the sinners be consumed out of the earth, and let the wicked be no more. Bless thou the LORD, O my soul. Praise ye the LORD.
 * 105
 1. O give thanks unto the LORD; call upon his name: make known his deeds among the people.
 2. Sing unto him, sing psalms unto him: talk ye of all his wondrous works.
@@ -1905,7 +1905,7 @@ A Prayer of the afflicted, when he is overwhelmed, and poureth out his complaint
 42. For he remembered his holy promise, /and/ Abraham his servant.
 43. And he brought forth his people with joy, /and/ his chosen with gladness:
 44. And gave them the lands of the heathen: and they inherited the labour of the people;
-45. That they might observe his statutes, and keep his laws. Praise ye the LORD. 
+45. That they might observe his statutes, and keep his laws. Praise ye the LORD.
 * 106
 1. Praise ye the LORD. O give thanks unto the LORD; for /he is/ good: for his mercy /endureth/ for ever.
 2. Who can utter the mighty acts of the LORD? /who/ can shew forth all his praise?
@@ -1954,7 +1954,7 @@ A Prayer of the afflicted, when he is overwhelmed, and poureth out his complaint
 45. And he remembered for them his covenant, and repented according to the multitude of his mercies.
 46. He made them also to be pitied of all those that carried them captives.
 47. Save us, O LORD our God, and gather us from among the heathen, to give thanks unto thy holy name, /and/ to triumph in thy praise.
-48. Blessed /be/ the LORD God of Israel from everlasting to everlasting: and let all the people say, Amen. Praise ye the LORD. 
+48. Blessed /be/ the LORD God of Israel from everlasting to everlasting: and let all the people say, Amen. Praise ye the LORD.
 * 107
 1. O give thanks unto the LORD, for /he is/ good: for his mercy /endureth/ for ever.
 2. Let the redeemed of the LORD say /so/, whom he hath redeemed from the hand of the enemy;
@@ -1998,7 +1998,7 @@ A Prayer of the afflicted, when he is overwhelmed, and poureth out his complaint
 40. He poureth contempt upon princes, and causeth them to wander in the wilderness, /where there is/ no way.
 41. Yet setteth he the poor on high from affliction, and maketh /him/ families like a flock.
 42. The righteous shall see /it/, and rejoice: and all iniquity shall stop her mouth.
-43. Whoso /is/ wise, and will observe these /things/, even they shall understand the lovingkindness of the LORD. 
+43. Whoso /is/ wise, and will observe these /things/, even they shall understand the lovingkindness of the LORD.
 * 108
 A Song /or/ Psalm of David.
 1. O God, my heart is fixed; I will sing and give praise, even with my glory.
@@ -2013,7 +2013,7 @@ A Song /or/ Psalm of David.
 10. Who will bring me into the strong city? who will lead me into Edom?
 11. /Wilt/ not /thou/, O God, /who/ hast cast us off? and wilt not thou, O God, go forth with our hosts?
 12. Give us help from trouble: for vain /is/ the help of man.
-13. Through God we shall do valiantly: for he /it is that/ shall tread down our enemies. 
+13. Through God we shall do valiantly: for he /it is that/ shall tread down our enemies.
 * 109
 To the chief Musician, A Psalm of David.
 1. Hold not thy peace, O God of my praise;
@@ -2046,7 +2046,7 @@ To the chief Musician, A Psalm of David.
 28. Let them curse, but bless thou: when they arise, let them be ashamed; but let thy servant rejoice.
 29. Let mine adversaries be clothed with shame, and let them cover themselves with their own confusion, as with a mantle.
 30. I will greatly praise the LORD with my mouth; yea, I will praise him among the multitude.
-31. For he shall stand at the right hand of the poor, to save /him/ from those that condemn his soul. 
+31. For he shall stand at the right hand of the poor, to save /him/ from those that condemn his soul.
 * 110
 A Psalm of David.
 1. The LORD said unto my Lord, Sit thou at my right hand, until I make thine enemies thy footstool.
@@ -2055,7 +2055,7 @@ A Psalm of David.
 4. The LORD hath sworn, and will not repent, Thou /art/ a priest for ever after the order of Melchizedek.
 5. The Lord at thy right hand shall strike through kings in the day of his wrath.
 6. He shall judge among the heathen, he shall fill /the places/ with the dead bodies; he shall wound the heads over many countries.
-7. He shall drink of the brook in the way: therefore shall he lift up the head. 
+7. He shall drink of the brook in the way: therefore shall he lift up the head.
 * 111
 1. Praise ye the LORD. I will praise the LORD with /my/ whole heart, in the assembly of the upright, and /in/ the congregation.
 2. The works of the LORD /are/ great, sought out of all them that have pleasure therein.
@@ -2066,7 +2066,7 @@ A Psalm of David.
 7. The works of his hands /are/ verity and judgment; all his commandments /are/ sure.
 8. They stand fast for ever and ever, /and are/ done in truth and uprightness.
 9. He sent redemption unto his people: he hath commanded his covenant for ever: holy and reverend /is/ his name.
-10. The fear of the LORD /is/ the beginning of wisdom: a good understanding have all they that do /his commandments/: his praise endureth for ever. 
+10. The fear of the LORD /is/ the beginning of wisdom: a good understanding have all they that do /his commandments/: his praise endureth for ever.
 * 112
 1. Praise ye the LORD. Blessed /is/ the man /that/ feareth the LORD, /that/ delighteth greatly in his commandments.
 2. His seed shall be mighty upon earth: the generation of the upright shall be blessed.
@@ -2077,7 +2077,7 @@ A Psalm of David.
 7. He shall not be afraid of evil tidings: his heart is fixed, trusting in the LORD.
 8. His heart /is/ established, he shall not be afraid, until he see /his desire/ upon his enemies.
 9. He hath dispersed, he hath given to the poor; his righteousness endureth for ever; his horn shall be exalted with honour.
-10. The wicked shall see /it/, and be grieved; he shall gnash with his teeth, and melt away: the desire of the wicked shall perish. 
+10. The wicked shall see /it/, and be grieved; he shall gnash with his teeth, and melt away: the desire of the wicked shall perish.
 * 113
 1. Praise ye the LORD. Praise, O ye servants of the LORD, praise the name of the LORD.
 2. Blessed be the name of the LORD from this time forth and for evermore.
@@ -2087,7 +2087,7 @@ A Psalm of David.
 6. Who humbleth /himself/ to behold /the things that are/ in heaven, and in the earth!
 7. He raiseth up the poor out of the dust, /and/ lifteth the needy out of the dunghill;
 8. That he may set /him/ with princes, /even/ with the princes of his people.
-9. He maketh the barren woman to keep house, /and to be/ a joyful mother of children. Praise ye the LORD. 
+9. He maketh the barren woman to keep house, /and to be/ a joyful mother of children. Praise ye the LORD.
 * 114
 1. When Israel went out of Egypt, the house of Jacob from a people of strange language;
 2. Judah was his sanctuary, /and/ Israel his dominion.
@@ -2096,7 +2096,7 @@ A Psalm of David.
 5. What /ailed/ thee, O thou sea, that thou fleddest? thou Jordan, /that/ thou wast driven back?
 6. Ye mountains, /that/ ye skipped like rams; /and/ ye little hills, like lambs?
 7. Tremble, thou earth, at the presence of the Lord, at the presence of the God of Jacob;
-8. Which turned the rock /into/ a standing water, the flint into a fountain of waters. 
+8. Which turned the rock /into/ a standing water, the flint into a fountain of waters.
 * 115
 1. Not unto us, O LORD, not unto us, but unto thy name give glory, for thy mercy, /and/ for thy truth's sake.
 2. Wherefore should the heathen say, Where /is/ now their God?
@@ -2115,7 +2115,7 @@ A Psalm of David.
 15. Ye /are/ blessed of the LORD which made heaven and earth.
 16. The heaven, /even/ the heavens, /are/ the LORD's: but the earth hath he given to the children of men.
 17. The dead praise not the LORD, neither any that go down into silence.
-18. But we will bless the LORD from this time forth and for evermore. Praise the LORD. 
+18. But we will bless the LORD from this time forth and for evermore. Praise the LORD.
 * 116
 1. I love the LORD, because he hath heard my voice /and/ my supplications.
 2. Because he hath inclined his ear unto me, therefore will I call upon /him/ as long as I live.
@@ -2135,10 +2135,10 @@ A Psalm of David.
 16. O LORD, truly I /am/ thy servant; I /am/ thy servant, /and/ the son of thine handmaid: thou hast loosed my bonds.
 17. I will offer to thee the sacrifice of thanksgiving, and will call upon the name of the LORD.
 18. I will pay my vows unto the LORD now in the presence of all his people,
-19. In the courts of the LORD's house, in the midst of thee, O Jerusalem. Praise ye the LORD. 
+19. In the courts of the LORD's house, in the midst of thee, O Jerusalem. Praise ye the LORD.
 * 117
 1. O praise the LORD, all ye nations: praise him, all ye people.
-2. For his merciful kindness is great toward us: and the truth of the LORD /endureth/ for ever. Praise ye the LORD. 
+2. For his merciful kindness is great toward us: and the truth of the LORD /endureth/ for ever. Praise ye the LORD.
 * 118
 1. O give thanks unto the LORD; for /he is/ good: because his mercy /endureth/ for ever.
 2. Let Israel now say, that his mercy /endureth/ for ever.
@@ -2168,7 +2168,7 @@ A Psalm of David.
 26. Blessed /be/ he that cometh in the name of the LORD: we have blessed you out of the house of the LORD.
 27. God /is/ the LORD, which hath shewed us light: bind the sacrifice with cords, /even/ unto the horns of the altar.
 28. Thou /art/ my God, and I will praise thee: /thou art/ my God, I will exalt thee.
-29. O give thanks unto the LORD; for /he is/ good: for his mercy /endureth/ for ever. 
+29. O give thanks unto the LORD; for /he is/ good: for his mercy /endureth/ for ever.
 * 119
 א ALEPH
 1. Blessed /are/ the undefiled in the way, who walk in the law of the LORD.
@@ -2388,7 +2388,7 @@ A Psalm of David.
 173. Let thine hand help me; for I have chosen thy precepts.
 174. I have longed for thy salvation, O LORD; and thy law /is/ my delight.
 175. Let my soul live, and it shall praise thee; and let thy judgments help me.
-176. I have gone astray like a lost sheep; seek thy servant; for I do not forget thy commandments. 
+176. I have gone astray like a lost sheep; seek thy servant; for I do not forget thy commandments.
 * 120
 A Song of degrees.
 1. In my distress I cried unto the LORD, and he heard me.
@@ -2397,7 +2397,7 @@ A Song of degrees.
 4. Sharp arrows of the mighty, with coals of juniper.
 5. Woe is me, that I sojourn in Mesech, /that/ I dwell in the tents of Kedar!
 6. My soul hath long dwelt with him that hateth peace.
-7. I /am for/ peace: but when I speak, they /are/ for war. 
+7. I /am for/ peace: but when I speak, they /are/ for war.
 * 121
 A Song of degrees.
 1. I will lift up mine eyes unto the hills, from whence cometh my help.
@@ -2407,7 +2407,7 @@ A Song of degrees.
 5. The LORD /is/ thy keeper: the LORD /is/ thy shade upon thy right hand.
 6. The sun shall not smite thee by day, nor the moon by night.
 7. The LORD shall preserve thee from all evil: he shall preserve thy soul.
-8. The LORD shall preserve thy going out and thy coming in from this time forth, and even for evermore. 
+8. The LORD shall preserve thy going out and thy coming in from this time forth, and even for evermore.
 * 122
 A Song of degrees of David.
 1. I was glad when they said unto me, Let us go into the house of the LORD.
@@ -2418,13 +2418,13 @@ A Song of degrees of David.
 6. Pray for the peace of Jerusalem: they shall prosper that love thee.
 7. Peace be within thy walls, /and/ prosperity within thy palaces.
 8. For my brethren and companions' sakes, I will now say, Peace /be/ within thee.
-9. Because of the house of the LORD our God I will seek thy good. 
+9. Because of the house of the LORD our God I will seek thy good.
 * 123
 A Song of degrees.
 1. Unto thee lift I up mine eyes, O thou that dwellest in the heavens.
 2. Behold, as the eyes of servants /look/ unto the hand of their masters, /and/ as the eyes of a maiden unto the hand of her mistress; so our eyes /wait/ upon the LORD our God, until that he have mercy upon us.
 3. Have mercy upon us, O LORD, have mercy upon us: for we are exceedingly filled with contempt.
-4. Our soul is exceedingly filled with the scorning of those that are at ease, /and/ with the contempt of the proud. 
+4. Our soul is exceedingly filled with the scorning of those that are at ease, /and/ with the contempt of the proud.
 * 124
 A Song of degrees of David.
 1. If /it had not been/ the LORD who was on our side, now may Israel say;
@@ -2434,14 +2434,14 @@ A Song of degrees of David.
 5. Then the proud waters had gone over our soul.
 6. Blessed /be/ the LORD, who hath not given us /as/ a prey to their teeth.
 7. Our soul is escaped as a bird out of the snare of the fowlers: the snare is broken, and we are escaped.
-8. Our help /is/ in the name of the LORD, who made heaven and earth. 
+8. Our help /is/ in the name of the LORD, who made heaven and earth.
 * 125
 A Song of degrees.
 1. They that trust in the LORD /shall be/ as mount Zion, /which/ cannot be removed, /but/ abideth for ever.
 2. As the mountains /are/ round about Jerusalem, so the LORD /is/ round about his people from henceforth even for ever.
 3. For the rod of the wicked shall not rest upon the lot of the righteous; lest the righteous put forth their hands unto iniquity.
 4. Do good, O LORD, unto /those that be/ good, and /to them that are/ upright in their hearts.
-5. As for such as turn aside unto their crooked ways, the LORD shall lead them forth with the workers of iniquity: /but/ peace /shall be/ upon Israel. 
+5. As for such as turn aside unto their crooked ways, the LORD shall lead them forth with the workers of iniquity: /but/ peace /shall be/ upon Israel.
 * 126
 A Song of degrees.
 1. When the LORD turned again the captivity of Zion, we were like them that dream.
@@ -2449,14 +2449,14 @@ A Song of degrees.
 3. The LORD hath done great things for us; /whereof/ we are glad.
 4. Turn again our captivity, O LORD, as the streams in the south.
 5. They that sow in tears shall reap in joy.
-6. He that goeth forth and weepeth, bearing precious seed, shall doubtless come again with rejoicing, bringing his sheaves /with him/. 
+6. He that goeth forth and weepeth, bearing precious seed, shall doubtless come again with rejoicing, bringing his sheaves /with him/.
 * 127
 A Song of degrees for Solomon.
 1. Except the LORD build the house, they labour in vain that build it: except the LORD keep the city, the watchman waketh /but/ in vain.
 2. /It is/ vain for you to rise up early, to sit up late, to eat the bread of sorrows: /for/ so he giveth his beloved sleep.
 3. Lo, children /are/ an heritage of the LORD: /and/ the fruit of the womb /is his/ reward.
 4. As arrows /are/ in the hand of a mighty man; so /are/ children of the youth.
-5. Happy /is/ the man that hath his quiver full of them: they shall not be ashamed, but they shall speak with the enemies in the gate. 
+5. Happy /is/ the man that hath his quiver full of them: they shall not be ashamed, but they shall speak with the enemies in the gate.
 * 128
 A Song of degrees.
 1. Blessed /is/ every one that feareth the LORD; that walketh in his ways.
@@ -2464,7 +2464,7 @@ A Song of degrees.
 3. Thy wife /shall be/ as a fruitful vine by the sides of thine house: thy children like olive plants round about thy table.
 4. Behold, that thus shall the man be blessed that feareth the LORD.
 5. The LORD shall bless thee out of Zion: and thou shalt see the good of Jerusalem all the days of thy life.
-6. Yea, thou shalt see thy children's children, /and/ peace upon Israel. 
+6. Yea, thou shalt see thy children's children, /and/ peace upon Israel.
 * 129
 A Song of degrees.
 1. Many a time have they afflicted me from my youth, may Israel now say:
@@ -2474,7 +2474,7 @@ A Song of degrees.
 5. Let them all be confounded and turned back that hate Zion.
 6. Let them be as the grass /upon/ the housetops, which withereth afore it groweth up:
 7. Wherewith the mower filleth not his hand; nor he that bindeth sheaves his bosom.
-8. Neither do they which go by say, The blessing of the LORD /be/ upon you: we bless you in the name of the LORD. 
+8. Neither do they which go by say, The blessing of the LORD /be/ upon you: we bless you in the name of the LORD.
 * 130
 A Song of degrees.
 1. Out of the depths have I cried unto thee, O LORD.
@@ -2484,7 +2484,7 @@ A Song of degrees.
 5. I wait for the LORD, my soul doth wait, and in his word do I hope.
 6. My soul /waiteth/ for the Lord more than they that watch for the morning: /I say, more than/ they that watch for the morning.
 7. Let Israel hope in the LORD: for with the LORD /there is/ mercy, and with him /is/ plenteous redemption.
-8. And he shall redeem Israel from all his iniquities. 
+8. And he shall redeem Israel from all his iniquities.
 * 131
 A Song of degrees of David.
 1. LORD, my heart is not haughty, nor mine eyes lofty: neither do I exercise myself in great matters, or in things too high for me.
@@ -2509,7 +2509,7 @@ A Song of degrees.
 15. I will abundantly bless her provision: I will satisfy her poor with bread.
 16. I will also clothe her priests with salvation: and her saints shall shout aloud for joy.
 17. There will I make the horn of David to bud: I have ordained a lamp for mine anointed.
-18. His enemies will I clothe with shame: but upon himself shall his crown flourish. 
+18. His enemies will I clothe with shame: but upon himself shall his crown flourish.
 * 133
 A Song of degrees of David.
 1. Behold, how good and how pleasant /it is/ for brethren to dwell together in unity!
@@ -2541,7 +2541,7 @@ A Song of degrees.
 18. They that make them are like unto them: /so is/ every one that trusteth in them.
 19. Bless the LORD, O house of Israel: bless the LORD, O house of Aaron:
 20. Bless the LORD, O house of Levi: ye that fear the LORD, bless the LORD.
-21. Blessed be the LORD out of Zion, which dwelleth at Jerusalem. Praise ye the LORD. 
+21. Blessed be the LORD out of Zion, which dwelleth at Jerusalem. Praise ye the LORD.
 * 136
 1. O give thanks unto the LORD; for /he is/ good: for his mercy /endureth/ for ever.
 2. O give thanks unto the God of gods: for his mercy /endureth/ for ever.
@@ -2568,7 +2568,7 @@ A Song of degrees.
 23. Who remembered us in our low estate: for his mercy /endureth/ for ever:
 24. And hath redeemed us from our enemies: for his mercy /endureth/ for ever.
 25. Who giveth food to all flesh: for his mercy /endureth/ for ever.
-26. O give thanks unto the God of heaven: for his mercy /endureth/ for ever. 
+26. O give thanks unto the God of heaven: for his mercy /endureth/ for ever.
 * 137
 1. By the rivers of Babylon, there we sat down, yea, we wept, when we remembered Zion.
 2. We hanged our harps upon the willows in the midst thereof.
@@ -2578,7 +2578,7 @@ A Song of degrees.
 6. If I do not remember thee, let my tongue cleave to the roof of my mouth; if I prefer not Jerusalem above my chief joy.
 7. Remember, O LORD, the children of Edom in the day of Jerusalem; who said, Rase /it/, rase /it, even/ to the foundation thereof.
 8. O daughter of Babylon, who art to be destroyed; happy /shall he be/, that rewardeth thee as thou hast served us.
-9. Happy /shall he be/, that taketh and dasheth thy little ones against the stones. 
+9. Happy /shall he be/, that taketh and dasheth thy little ones against the stones.
 * 138
 /A Psalm/ of David.
 1. I will praise thee with my whole heart: before the gods will I sing praise unto thee.
@@ -2588,7 +2588,7 @@ A Song of degrees.
 5. Yea, they shall sing in the ways of the LORD: for great /is/ the glory of the LORD.
 6. Though the LORD /be/ high, yet hath he respect unto the lowly: but the proud he knoweth afar off.
 7. Though I walk in the midst of trouble, thou wilt revive me: thou shalt stretch forth thine hand against the wrath of mine enemies, and thy right hand shall save me.
-8. The LORD will perfect /that which/ concerneth me: thy mercy, O LORD, /endureth/ for ever: forsake not the works of thine own hands. 
+8. The LORD will perfect /that which/ concerneth me: thy mercy, O LORD, /endureth/ for ever: forsake not the works of thine own hands.
 * 139
 To the chief Musician, A Psalm of David.
 1. O LORD, thou hast searched me, and known /me/.
@@ -2614,7 +2614,7 @@ To the chief Musician, A Psalm of David.
 21. Do not I hate them, O LORD, that hate thee? and am not I grieved with those that rise up against thee?
 22. I hate them with perfect hatred: I count them mine enemies.
 23. Search me, O God, and know my heart: try me, and know my thoughts:
-24. And see if /there be any/ wicked way in me, and lead me in the way everlasting. 
+24. And see if /there be any/ wicked way in me, and lead me in the way everlasting.
 * 140
 To the chief Musician, A Psalm of David.
 1. Deliver me, O LORD, from the evil man: preserve me from the violent man;
@@ -2629,7 +2629,7 @@ To the chief Musician, A Psalm of David.
 10. Let burning coals fall upon them: let them be cast into the fire; into deep pits, that they rise not up again.
 11. Let not an evil speaker be established in the earth: evil shall hunt the violent man to overthrow /him/.
 12. I know that the LORD will maintain the cause of the afflicted, /and/ the right of the poor.
-13. Surely the righteous shall give thanks unto thy name: the upright shall dwell in thy presence. 
+13. Surely the righteous shall give thanks unto thy name: the upright shall dwell in thy presence.
 * 141
 A Psalm of David.
 1. LORD, I cry unto thee: make haste unto me; give ear unto my voice, when I cry unto thee.
@@ -2641,7 +2641,7 @@ A Psalm of David.
 7. Our bones are scattered at the grave's mouth, as when one cutteth and cleaveth /wood/ upon the earth.
 8. But mine eyes /are/ unto thee, O GOD the Lord: in thee is my trust; leave not my soul destitute.
 9. Keep me from the snares /which/ they have laid for me, and the gins of the workers of iniquity.
-10. Let the wicked fall into their own nets, whilst that I withal escape. 
+10. Let the wicked fall into their own nets, whilst that I withal escape.
 * 142
 Maschil of David; A Prayer when he was in the cave.
 1. I cried unto the LORD with my voice; with my voice unto the LORD did I make my supplication.
@@ -2650,7 +2650,7 @@ Maschil of David; A Prayer when he was in the cave.
 4. I looked on /my/ right hand, and beheld, but /there was/ no man that would know me: refuge failed me; no man cared for my soul.
 5. I cried unto thee, O LORD: I said, Thou /art/ my refuge /and/ my portion in the land of the living.
 6. Attend unto my cry; for I am brought very low: deliver me from my persecutors; for they are stronger than I.
-7. Bring my soul out of prison, that I may praise thy name: the righteous shall compass me about; for thou shalt deal bountifully with me. 
+7. Bring my soul out of prison, that I may praise thy name: the righteous shall compass me about; for thou shalt deal bountifully with me.
 * 143
 A Psalm of David.
 1. Hear my prayer, O LORD, give ear to my supplications: in thy faithfulness answer me, /and/ in thy righteousness.
@@ -2664,7 +2664,7 @@ A Psalm of David.
 9. Deliver me, O LORD, from mine enemies: I flee unto thee to hide me.
 10. Teach me to do thy will; for thou /art/ my God: thy spirit /is/ good; lead me into the land of uprightness.
 11. Quicken me, O LORD, for thy name's sake: for thy righteousness' sake bring my soul out of trouble.
-12. And of thy mercy cut off mine enemies, and destroy all them that afflict my soul: for I /am/ thy servant. 
+12. And of thy mercy cut off mine enemies, and destroy all them that afflict my soul: for I /am/ thy servant.
 * 144
 /A Psalm/ of David.
 1. Blessed /be/ the LORD my strength, which teacheth my hands to war, /and/ my fingers to fight:
@@ -2681,7 +2681,7 @@ A Psalm of David.
 12. That our sons /may be/ as plants grown up in their youth; /that/ our daughters /may be/ as corner stones, polished /after/ the similitude of a palace:
 13. /That/ our garners /may be/ full, affording all manner of store: /that/ our sheep may bring forth thousands and ten thousands in our streets:
 14. /That/ our oxen /may be/ strong to labour; /that there be/ no breaking in, nor going out; that /there be/ no complaining in our streets.
-15. Happy /is that/ people, that is in such a case: /yea/, happy /is that/ people, whose God /is/ the LORD. 
+15. Happy /is that/ people, that is in such a case: /yea/, happy /is that/ people, whose God /is/ the LORD.
 * 145
 David's /Psalm/ of praise.
 1. I will extol thee, my God, O king; and I will bless thy name for ever and ever.
@@ -2704,7 +2704,7 @@ David's /Psalm/ of praise.
 18. The LORD /is/ nigh unto all them that call upon him, to all that call upon him in truth.
 19. He will fulfil the desire of them that fear him: he also will hear their cry, and will save them.
 20. The LORD preserveth all them that love him: but all the wicked will he destroy.
-21. My mouth shall speak the praise of the LORD: and let all flesh bless his holy name for ever and ever. 
+21. My mouth shall speak the praise of the LORD: and let all flesh bless his holy name for ever and ever.
 * 146
 1. Praise ye the LORD. Praise the LORD, O my soul.
 2. While I live will I praise the LORD: I will sing praises unto my God while I have any being.
@@ -2715,7 +2715,7 @@ David's /Psalm/ of praise.
 7. Which executeth judgment for the oppressed: which giveth food to the hungry. The LORD looseth the prisoners:
 8. The LORD openeth /the eyes of/ the blind: the LORD raiseth them that are bowed down: the LORD loveth the righteous:
 9. The LORD preserveth the strangers; he relieveth the fatherless and widow: but the way of the wicked he turneth upside down.
-10. The LORD shall reign for ever, /even/ thy God, O Zion, unto all generations. Praise ye the LORD. 
+10. The LORD shall reign for ever, /even/ thy God, O Zion, unto all generations. Praise ye the LORD.
 * 147
 1. Praise ye the LORD: for /it is/ good to sing praises unto our God; for /it is/ pleasant; /and/ praise is comely.
 2. The LORD doth build up Jerusalem: he gathereth together the outcasts of Israel.
@@ -2736,7 +2736,7 @@ David's /Psalm/ of praise.
 17. He casteth forth his ice like morsels: who can stand before his cold?
 18. He sendeth out his word, and melteth them: he causeth his wind to blow, /and/ the waters flow.
 19. He sheweth his word unto Jacob, his statutes and his judgments unto Israel.
-20. He hath not dealt so with any nation: and /as for his/ judgments, they have not known them. Praise ye the LORD. 
+20. He hath not dealt so with any nation: and /as for his/ judgments, they have not known them. Praise ye the LORD.
 * 148
 1. Praise ye the LORD. Praise ye the LORD from the heavens: praise him in the heights.
 2. Praise ye him, all his angels: praise ye him, all his hosts.
@@ -2751,7 +2751,7 @@ David's /Psalm/ of praise.
 11. Kings of the earth, and all people; princes, and all judges of the earth:
 12. Both young men, and maidens; old men, and children:
 13. Let them praise the name of the LORD: for his name alone is excellent; his glory /is/ above the earth and heaven.
-14. He also exalteth the horn of his people, the praise of all his saints; /even/ of the children of Israel, a people near unto him. Praise ye the LORD. 
+14. He also exalteth the horn of his people, the praise of all his saints; /even/ of the children of Israel, a people near unto him. Praise ye the LORD.
 * 149
 1. Praise ye the LORD. Sing unto the LORD a new song, /and/ his praise in the congregation of saints.
 2. Let Israel rejoice in him that made him: let the children of Zion be joyful in their King.
@@ -2761,11 +2761,11 @@ David's /Psalm/ of praise.
 6. /Let/ the high /praises/ of God /be/ in their mouth, and a twoedged sword in their hand;
 7. To execute vengeance upon the heathen, /and/ punishments upon the people;
 8. To bind their kings with chains, and their nobles with fetters of iron;
-9. To execute upon them the judgment written: this honour have all his saints. Praise ye the LORD. 
+9. To execute upon them the judgment written: this honour have all his saints. Praise ye the LORD.
 * 150
 1. Praise ye the LORD. Praise God in his sanctuary: praise him in the firmament of his power.
 2. Praise him for his mighty acts: praise him according to his excellent greatness.
 3. Praise him with the sound of the trumpet: praise him with the psaltery and harp.
 4. Praise him with the timbrel and dance: praise him with stringed instruments and organs.
 5. Praise him upon the loud cymbals: praise him upon the high sounding cymbals.
-6. Let every thing that hath breath praise the LORD. Praise ye the LORD.  
+6. Let every thing that hath breath praise the LORD. Praise ye the LORD.

--- a/20_PRO.org
+++ b/20_PRO.org
@@ -36,7 +36,7 @@
 30. They would none of my counsel: they despised all my reproof.
 31. Therefore shall they eat of the fruit of their own way, and be filled with their own devices.
 32. For the turning away of the simple shall slay them, and the prosperity of fools shall destroy them.
-33. But whoso hearkeneth unto me shall dwell safely, and shall be quiet from fear of evil. 
+33. But whoso hearkeneth unto me shall dwell safely, and shall be quiet from fear of evil.
 * 2
 1. My son, if thou wilt receive my words, and hide my commandments with thee;
 2. So that thou incline thine ear unto wisdom, /and/ apply thine heart to understanding;
@@ -60,7 +60,7 @@
 19. None that go unto her return again, neither take they hold of the paths of life.
 20. That thou mayest walk in the way of good /men/, and keep the paths of the righteous.
 21. For the upright shall dwell in the land, and the perfect shall remain in it.
-22. But the wicked shall be cut off from the earth, and the transgressors shall be rooted out of it. 
+22. But the wicked shall be cut off from the earth, and the transgressors shall be rooted out of it.
 * 3
 1. My son, forget not my law; but let thine heart keep my commandments:
 2. For length of days, and long life, and peace, shall they add to thee.
@@ -105,7 +105,7 @@
 
 33. The curse of the LORD /is/ in the house of the wicked: but he blesseth the habitation of the just.
 34. Surely he scorneth the scorners: but he giveth grace unto the lowly.
-35. The wise shall inherit glory: but shame shall be the promotion of fools. 
+35. The wise shall inherit glory: but shame shall be the promotion of fools.
 * 4
 1. Hear, ye children, the instruction of a father, and attend to know understanding.
 2. For I give you good doctrine, forsake ye not my law.
@@ -136,7 +136,7 @@
 24. Put away from thee a froward mouth, and perverse lips put far from thee.
 25. Let thine eyes look right on, and let thine eyelids look straight before thee.
 26. Ponder the path of thy feet, and let all thy ways be established.
-27. Turn not to the right hand nor to the left: remove thy foot from evil. 
+27. Turn not to the right hand nor to the left: remove thy foot from evil.
 * 5
 1. My son, attend unto my wisdom, /and/ bow thine ear to my understanding:
 2. That thou mayest regard discretion, and /that/ thy lips may keep knowledge.
@@ -163,7 +163,7 @@
 21. For the ways of man /are/ before the eyes of the LORD, and he pondereth all his goings.
 
 22. His own iniquities shall take the wicked himself, and he shall be holden with the cords of his sins.
-23. He shall die without instruction; and in the greatness of his folly he shall go astray. 
+23. He shall die without instruction; and in the greatness of his folly he shall go astray.
 * 6
 1. My son, if thou be surety for thy friend, /if/ thou hast stricken thy hand with a stranger,
 2. Thou art snared with the words of thy mouth, thou art taken with the words of thy mouth.
@@ -203,7 +203,7 @@
 32. /But/ whoso committeth adultery with a woman lacketh understanding: he /that/ doeth it destroyeth his own soul.
 33. A wound and dishonour shall he get; and his reproach shall not be wiped away.
 34. For jealousy /is/ the rage of a man: therefore he will not spare in the day of vengeance.
-35. He will not regard any ransom; neither will he rest content, though thou givest many gifts. 
+35. He will not regard any ransom; neither will he rest content, though thou givest many gifts.
 * 7
 1. My son, keep my words, and lay up my commandments with thee.
 2. Keep my commandments, and live; and my law as the apple of thine eye.
@@ -233,7 +233,7 @@
 24. Hearken unto me now therefore, O ye children, and attend to the words of my mouth.
 25. Let not thine heart decline to her ways, go not astray in her paths.
 26. For she hath cast down many wounded: yea, many strong /men/ have been slain by her.
-27. Her house /is/ the way to hell, going down to the chambers of death. 
+27. Her house /is/ the way to hell, going down to the chambers of death.
 * 8
 1. Doth not wisdom cry? and understanding put forth her voice?
 2. She standeth in the top of high places, by the way in the places of the paths.
@@ -270,7 +270,7 @@
 33. Hear instruction, and be wise, and refuse it not.
 34. Blessed /is/ the man that heareth me, watching daily at my gates, waiting at the posts of my doors.
 35. For whoso findeth me findeth life, and shall obtain favour of the LORD.
-36. But he that sinneth against me wrongeth his own soul: all they that hate me love death. 
+36. But he that sinneth against me wrongeth his own soul: all they that hate me love death.
 * 9
 1. Wisdom hath builded her house, she hath hewn out her seven pillars:
 2. She hath killed her beasts; she hath mingled her wine; she hath also furnished her table.
@@ -290,7 +290,7 @@
 15. To call passengers who go right on their ways:
 16. Whoso /is/ simple, let him turn in hither: and /as for/ him that wanteth understanding, she saith to him,
 17. Stolen waters are sweet, and bread /eaten/ in secret is pleasant.
-18. But he knoweth not that the dead /are/ there; /and that/ her guests /are/ in the depths of hell. 
+18. But he knoweth not that the dead /are/ there; /and that/ her guests /are/ in the depths of hell.
 * 10
 1. The proverbs of Solomon. A wise son maketh a glad father: but a foolish son /is/ the heaviness of his mother.
 2. Treasures of wickedness profit nothing: but righteousness delivereth from death.
@@ -323,7 +323,7 @@
 29. The way of the LORD /is/ strength to the upright: but destruction /shall be/ to the workers of iniquity.
 30. The righteous shall never be removed: but the wicked shall not inhabit the earth.
 31. The mouth of the just bringeth forth wisdom: but the froward tongue shall be cut out.
-32. The lips of the righteous know what is acceptable: but the mouth of the wicked /speaketh/ frowardness. 
+32. The lips of the righteous know what is acceptable: but the mouth of the wicked /speaketh/ frowardness.
 * 11
 1. A false balance /is/ abomination to the LORD: but a just weight /is/ his delight.
 2. /When/ pride cometh, then cometh shame: but with the lowly /is/ wisdom.
@@ -355,7 +355,7 @@
 28. He that trusteth in his riches shall fall: but the righteous shall flourish as a branch.
 29. He that troubleth his own house shall inherit the wind: and the fool /shall be/ servant to the wise of heart.
 30. The fruit of the righteous /is/ a tree of life; and he that winneth souls /is/ wise.
-31. Behold, the righteous shall be recompensed in the earth: much more the wicked and the sinner. 
+31. Behold, the righteous shall be recompensed in the earth: much more the wicked and the sinner.
 * 12
 1. Whoso loveth instruction loveth knowledge: but he that hateth reproof /is/ brutish.
 2. A good /man/ obtaineth favour of the LORD: but a man of wicked devices will he condemn.
@@ -384,7 +384,7 @@
 25. Heaviness in the heart of man maketh it stoop: but a good word maketh it glad.
 26. The righteous /is/ more excellent than his neighbour: but the way of the wicked seduceth them.
 27. The slothful /man/ roasteth not that which he took in hunting: but the substance of a diligent man /is/ precious.
-28. In the way of righteousness /is/ life; and /in/ the pathway /thereof there is/ no death. 
+28. In the way of righteousness /is/ life; and /in/ the pathway /thereof there is/ no death.
 * 13
 1. A wise son /heareth/ his father's instruction: but a scorner heareth not rebuke.
 2. A man shall eat good by the fruit of /his/ mouth: but the soul of the transgressors /shall eat/ violence.
@@ -410,7 +410,7 @@
 22. A good /man/ leaveth an inheritance to his children's children: and the wealth of the sinner /is/ laid up for the just.
 23. Much food /is in/ the tillage of the poor: but there is /that is/ destroyed for want of judgment.
 24. He that spareth his rod hateth his son: but he that loveth him chasteneth him betimes.
-25. The righteous eateth to the satisfying of his soul: but the belly of the wicked shall want. 
+25. The righteous eateth to the satisfying of his soul: but the belly of the wicked shall want.
 * 14
 1. Every wise woman buildeth her house: but the foolish plucketh it down with her hands.
 2. He that walketh in his uprightness feareth the LORD: but /he that is/ perverse in his ways despiseth him.
@@ -446,7 +446,7 @@
 32. The wicked is driven away in his wickedness: but the righteous hath hope in his death.
 33. Wisdom resteth in the heart of him that hath understanding: but /that which is/ in the midst of fools is made known.
 34. Righteousness exalteth a nation: but sin /is/ a reproach to any people.
-35. The king's favour /is/ toward a wise servant: but his wrath is /against/ him that causeth shame. 
+35. The king's favour /is/ toward a wise servant: but his wrath is /against/ him that causeth shame.
 * 15
 1. A soft answer turneth away wrath: but grievous words stir up anger.
 2. The tongue of the wise useth knowledge aright: but the mouth of fools poureth out foolishness.
@@ -480,7 +480,7 @@
 30. The light of the eyes rejoiceth the heart: /and/ a good report maketh the bones fat.
 31. The ear that heareth the reproof of life abideth among the wise.
 32. He that refuseth instruction despiseth his own soul: but he that heareth reproof getteth understanding.
-33. The fear of the LORD /is/ the instruction of wisdom; and before honour /is/ humility. 
+33. The fear of the LORD /is/ the instruction of wisdom; and before honour /is/ humility.
 * 16
 1. The preparations of the heart in man, and the answer of the tongue, /is/ from the LORD.
 2. All the ways of a man /are/ clean in his own eyes; but the LORD weigheth the spirits.
@@ -514,7 +514,7 @@
 30. He shutteth his eyes to devise froward things: moving his lips he bringeth evil to pass.
 31. The hoary head /is/ a crown of glory, /if/ it be found in the way of righteousness.
 32. /He that is/ slow to anger /is/ better than the mighty; and he that ruleth his spirit than he that taketh a city.
-33. The lot is cast into the lap; but the whole disposing thereof /is/ of the LORD. 
+33. The lot is cast into the lap; but the whole disposing thereof /is/ of the LORD.
 * 17
 1. Better /is/ a dry morsel, and quietness therewith, than an house full of sacrifices /with/ strife.
 2. A wise servant shall have rule over a son that causeth shame, and shall have part of the inheritance among the brethren.
@@ -543,7 +543,7 @@
 25. A foolish son /is/ a grief to his father, and bitterness to her that bare him.
 26. Also to punish the just /is/ not good, /nor/ to strike princes for equity.
 27. He that hath knowledge spareth his words: /and/ a man of understanding is of an excellent spirit.
-28. Even a fool, when he holdeth his peace, is counted wise: /and/ he that shutteth his lips /is esteemed/ a man of understanding. 
+28. Even a fool, when he holdeth his peace, is counted wise: /and/ he that shutteth his lips /is esteemed/ a man of understanding.
 * 18
 1. Through desire a man, having separated himself, seeketh /and/ intermeddleth with all wisdom.
 2. A fool hath no delight in understanding, but that his heart may discover itself.
@@ -568,7 +568,7 @@
 21. Death and life /are/ in the power of the tongue: and they that love it shall eat the fruit thereof.
 22. /Whoso/ findeth a wife findeth a good /thing/, and obtaineth favour of the LORD.
 23. The poor useth intreaties; but the rich answereth roughly.
-24. A man /that hath/ friends must shew himself friendly: and there is a friend /that/ sticketh closer than a brother. 
+24. A man /that hath/ friends must shew himself friendly: and there is a friend /that/ sticketh closer than a brother.
 * 19
 1. Better /is/ the poor that walketh in his integrity, than /he that is/ perverse in his lips, and is a fool.
 2. Also, /that/ the soul /be/ without knowledge, /it is/ not good; and he that hasteth with /his/ feet sinneth.
@@ -598,7 +598,7 @@
 26. He that wasteth /his/ father, /and/ chaseth away /his/ mother, /is/ a son that causeth shame, and bringeth reproach.
 27. Cease, my son, to hear the instruction /that causeth/ to err from the words of knowledge.
 28. An ungodly witness scorneth judgment: and the mouth of the wicked devoureth iniquity.
-29. Judgments are prepared for scorners, and stripes for the back of fools. 
+29. Judgments are prepared for scorners, and stripes for the back of fools.
 * 20
 1. Wine /is/ a mocker, strong drink /is/ raging: and whosoever is deceived thereby is not wise.
 2. The fear of a king /is/ as the roaring of a lion: /whoso/ provoketh him to anger sinneth /against/ his own soul.
@@ -629,7 +629,7 @@
 27. The spirit of man /is/ the candle of the LORD, searching all the inward parts of the belly.
 28. Mercy and truth preserve the king: and his throne is upholden by mercy.
 29. The glory of young men /is/ their strength: and the beauty of old men /is/ the gray head.
-30. The blueness of a wound cleanseth away evil: so /do/ stripes the inward parts of the belly. 
+30. The blueness of a wound cleanseth away evil: so /do/ stripes the inward parts of the belly.
 * 21
 1. The king's heart /is/ in the hand of the LORD, /as/ the rivers of water: he turneth it whithersoever he will.
 2. Every way of a man /is/ right in his own eyes: but the LORD pondereth the hearts.
@@ -661,7 +661,7 @@
 28. A false witness shall perish: but the man that heareth speaketh constantly.
 29. A wicked man hardeneth his face: but /as for/ the upright, he directeth his way.
 30. /There is/ no wisdom nor understanding nor counsel against the LORD.
-31. The horse /is/ prepared against the day of battle: but safety /is/ of the LORD. 
+31. The horse /is/ prepared against the day of battle: but safety /is/ of the LORD.
 * 22
 1. A /good/ name /is/ rather to be chosen than great riches, /and/ loving favour rather than silver and gold.
 2. The rich and poor meet together: the LORD /is/ the maker of them all.
@@ -691,7 +691,7 @@
 26. Be not thou /one/ of them that strike hands, /or/ of them that are sureties for debts.
 27. If thou hast nothing to pay, why should he take away thy bed from under thee?
 28. Remove not the ancient landmark, which thy fathers have set.
-29. Seest thou a man diligent in his business? he shall stand before kings; he shall not stand before mean /men/. 
+29. Seest thou a man diligent in his business? he shall stand before kings; he shall not stand before mean /men/.
 * 23
 1. When thou sittest to eat with a ruler, consider diligently what /is/ before thee:
 2. And put a knife to thy throat, if thou /be/ a man given to appetite.
@@ -727,7 +727,7 @@
 32. At the last it biteth like a serpent, and stingeth like an adder.
 33. Thine eyes shall behold strange women, and thine heart shall utter perverse things.
 34. Yea, thou shalt be as he that lieth down in the midst of the sea, or as he that lieth upon the top of a mast.
-35. They have stricken me, /shalt thou say, and/ I was not sick; they have beaten me, /and/ I felt /it/ not: when shall I awake? I will seek it yet again. 
+35. They have stricken me, /shalt thou say, and/ I was not sick; they have beaten me, /and/ I felt /it/ not: when shall I awake? I will seek it yet again.
 * 24
 1. Be not thou envious against evil men, neither desire to be with them.
 2. For their heart studieth destruction, and their lips talk of mischief.
@@ -762,7 +762,7 @@
 31. And, lo, it was all grown over with thorns, /and/ nettles had covered the face thereof, and the stone wall thereof was broken down.
 32. Then I saw, /and/ considered /it/ well: I looked upon /it, and/ received instruction.
 33. /Yet/ a little sleep, a little slumber, a little folding of the hands to sleep:
-34. So shall thy poverty come /as/ one that travelleth; and thy want as an armed man. 
+34. So shall thy poverty come /as/ one that travelleth; and thy want as an armed man.
 * 25
 1. These /are/ also proverbs of Solomon, which the men of Hezekiah king of Judah copied out.
 2. /It is/ the glory of God to conceal a thing: but the honour of kings /is/ to search out a matter.
@@ -791,7 +791,7 @@
 25. /As/ cold waters to a thirsty soul, so /is/ good news from a far country.
 26. A righteous man falling down before the wicked /is as/ a troubled fountain, and a corrupt spring.
 27. /It is/ not good to eat much honey: so /for men/ to search their own glory /is not/ glory.
-28. He that /hath/ no rule over his own spirit /is like/ a city /that is/ broken down, /and/ without walls. 
+28. He that /hath/ no rule over his own spirit /is like/ a city /that is/ broken down, /and/ without walls.
 * 26
 1. As snow in summer, and as rain in harvest, so honour is not seemly for a fool.
 2. As the bird by wandering, as the swallow by flying, so the curse causeless shall not come.
@@ -820,7 +820,7 @@
 25. When he speaketh fair, believe him not: for /there are/ seven abominations in his heart.
 26. /Whose/ hatred is covered by deceit, his wickedness shall be shewed before the /whole/ congregation.
 27. Whoso diggeth a pit shall fall therein: and he that rolleth a stone, it will return upon him.
-28. A lying tongue hateth /those that are/ afflicted by it; and a flattering mouth worketh ruin. 
+28. A lying tongue hateth /those that are/ afflicted by it; and a flattering mouth worketh ruin.
 * 27
 1. Boast not thyself of to morrow; for thou knowest not what a day may bring forth.
 2. Let another man praise thee, and not thine own mouth; a stranger, and not thine own lips.
@@ -848,7 +848,7 @@
 24. For riches /are/ not for ever: and doth the crown /endure/ to every generation?
 25. The hay appeareth, and the tender grass sheweth itself, and herbs of the mountains are gathered.
 26. The lambs /are/ for thy clothing, and the goats /are/ the price of the field.
-27. And /thou shalt have/ goats' milk enough for thy food, for the food of thy household, and /for/ the maintenance for thy maidens. 
+27. And /thou shalt have/ goats' milk enough for thy food, for the food of thy household, and /for/ the maintenance for thy maidens.
 * 28
 1. The wicked flee when no man pursueth: but the righteous are bold as a lion.
 2. For the transgression of a land many /are/ the princes thereof: but by a man of understanding /and/ knowledge the state /thereof/ shall be prolonged.
@@ -877,7 +877,7 @@
 25. He that is of a proud heart stirreth up strife: but he that putteth his trust in the LORD shall be made fat.
 26. He that trusteth in his own heart is a fool: but whoso walketh wisely, he shall be delivered.
 27. He that giveth unto the poor shall not lack: but he that hideth his eyes shall have many a curse.
-28. When the wicked rise, men hide themselves: but when they perish, the righteous increase. 
+28. When the wicked rise, men hide themselves: but when they perish, the righteous increase.
 * 29
 1. He, that being often reproved hardeneth /his/ neck, shall suddenly be destroyed, and that without remedy.
 2. When the righteous are in authority, the people rejoice: but when the wicked beareth rule, the people mourn.
@@ -905,7 +905,7 @@
 24. Whoso is partner with a thief hateth his own soul: he heareth cursing, and bewrayeth /it/ not.
 25. The fear of man bringeth a snare: but whoso putteth his trust in the LORD shall be safe.
 26. Many seek the ruler's favour; but /every/ man's judgment /cometh/ from the LORD.
-27. An unjust man /is/ an abomination to the just: and /he that is/ upright in the way /is/ abomination to the wicked. 
+27. An unjust man /is/ an abomination to the just: and /he that is/ upright in the way /is/ abomination to the wicked.
 * 30
 1. The words of Agur the son of Jakeh, /even/ the prophecy: the man spake unto Ithiel, even unto Ithiel and Ucal,
 2. Surely I /am/ more brutish than /any/ man, and have not the understanding of a man.
@@ -939,7 +939,7 @@
 30. A lion /which is/ strongest among beasts, and turneth not away for any;
 31. A greyhound; an he goat also; and a king, against whom /there is/ no rising up.
 32. If thou hast done foolishly in lifting up thyself, or if thou hast thought evil, /lay/ thine hand upon thy mouth.
-33. Surely the churning of milk bringeth forth butter, and the wringing of the nose bringeth forth blood: so the forcing of wrath bringeth forth strife. 
+33. Surely the churning of milk bringeth forth butter, and the wringing of the nose bringeth forth blood: so the forcing of wrath bringeth forth strife.
 * 31
 1. The words of king Lemuel, the prophecy that his mother taught him.
 2. What, my son? and what, the son of my womb? and what, the son of my vows?
@@ -972,4 +972,4 @@
 28. Her children arise up, and call her blessed; her husband /also/, and he praiseth her.
 29. Many daughters have done virtuously, but thou excellest them all.
 30. Favour /is/ deceitful, and beauty /is/ vain: /but/ a woman /that/ feareth the LORD, she shall be praised.
-31. Give her of the fruit of her hands; and let her own works praise her in the gates.  
+31. Give her of the fruit of her hands; and let her own works praise her in the gates.

--- a/21_ECC.org
+++ b/21_ECC.org
@@ -18,7 +18,7 @@
 15. /That which is/ crooked cannot be made straight: and that which is wanting cannot be numbered.
 16. I communed with mine own heart, saying, Lo, I am come to great estate, and have gotten more wisdom than all /they/ that have been before me in Jerusalem: yea, my heart had great experience of wisdom and knowledge.
 17. And I gave my heart to know wisdom, and to know madness and folly: I perceived that this also is vexation of spirit.
-18. For in much wisdom /is/ much grief: and he that increaseth knowledge increaseth sorrow. 
+18. For in much wisdom /is/ much grief: and he that increaseth knowledge increaseth sorrow.
 * 2
 1. I said in mine heart, Go to now, I will prove thee with mirth, therefore enjoy pleasure: and, behold, this also /is/ vanity.
 2. I said of laughter, /It is/ mad: and of mirth, What doeth it?
@@ -48,7 +48,7 @@
 
 24. /There is/ nothing better for a man, /than/ that he should eat and drink, and /that/ he should make his soul enjoy good in his labour. This also I saw, that it /was/ from the hand of God.
 25. For who can eat, or who else can hasten /hereunto/, more than I?
-26. For /God/ giveth to a man that /is/ good in his sight wisdom, and knowledge, and joy: but to the sinner he giveth travail, to gather and to heap up, that he may give to /him that is/ good before God. This also /is/ vanity and vexation of spirit. 
+26. For /God/ giveth to a man that /is/ good in his sight wisdom, and knowledge, and joy: but to the sinner he giveth travail, to gather and to heap up, that he may give to /him that is/ good before God. This also /is/ vanity and vexation of spirit.
 * 3
 1. To every /thing there is/ a season, and a time to every purpose under the heaven:
 2. A time to be born, and a time to die; a time to plant, and a time to pluck up /that which is/ planted;
@@ -72,7 +72,7 @@
 19. For that which befalleth the sons of men befalleth beasts; even one thing befalleth them: as the one dieth, so dieth the other; yea, they have all one breath; so that a man hath no preeminence above a beast: for all /is/ vanity.
 20. All go unto one place; all are of the dust, and all turn to dust again.
 21. Who knoweth the spirit of man that goeth upward, and the spirit of the beast that goeth downward to the earth?
-22. Wherefore I perceive that /there is/ nothing better, than that a man should rejoice in his own works; for that /is/ his portion: for who shall bring him to see what shall be after him? 
+22. Wherefore I perceive that /there is/ nothing better, than that a man should rejoice in his own works; for that /is/ his portion: for who shall bring him to see what shall be after him?
 * 4
 1. So I returned, and considered all the oppressions that are done under the sun: and behold the tears of /such as were/ oppressed, and they had no comforter; and on the side of their oppressors /there was/ power; but they had no comforter.
 2. Wherefore I praised the dead which are already dead more than the living which are yet alive.
@@ -93,7 +93,7 @@
 13. Better /is/ a poor and a wise child than an old and foolish king, who will no more be admonished.
 14. For out of prison he cometh to reign; whereas also /he that is/ born in his kingdom becometh poor.
 15. I considered all the living which walk under the sun, with the second child that shall stand up in his stead.
-16. /There is/ no end of all the people, /even/ of all that have been before them: they also that come after shall not rejoice in him. Surely this also /is/ vanity and vexation of spirit. 
+16. /There is/ no end of all the people, /even/ of all that have been before them: they also that come after shall not rejoice in him. Surely this also /is/ vanity and vexation of spirit.
 * 5
 1. Keep thy foot when thou goest to the house of God, and be more ready to hear, than to give the sacrifice of fools: for they consider not that they do evil.
 2. Be not rash with thy mouth, and let not thine heart be hasty to utter /any/ thing before God: for God /is/ in heaven, and thou upon earth: therefore let thy words be few.
@@ -117,7 +117,7 @@
 
 18. Behold /that/ which I have seen: /it is/ good and comely /for one/ to eat and to drink, and to enjoy the good of all his labour that he taketh under the sun all the days of his life, which God giveth him: for it /is/ his portion.
 19. Every man also to whom God hath given riches and wealth, and hath given him power to eat thereof, and to take his portion, and to rejoice in his labour; this /is/ the gift of God.
-20. For he shall not much remember the days of his life; because God answereth /him/ in the joy of his heart. 
+20. For he shall not much remember the days of his life; because God answereth /him/ in the joy of his heart.
 * 6
 1. There is an evil which I have seen under the sun, and it /is/ common among men:
 2. A man to whom God hath given riches, wealth, and honour, so that he wanteth nothing for his soul of all that he desireth, yet God giveth him not power to eat thereof, but a stranger eateth it: this /is/ vanity, and it /is/ an evil disease.
@@ -134,7 +134,7 @@
 10. That which hath been is named already, and it is known that it /is/ man: neither may he contend with him that is mightier than he.
 
 11. Seeing there be many things that increase vanity, what /is/ man the better?
-12. For who knoweth what /is/ good for man in /this/ life, all the days of his vain life which he spendeth as a shadow? for who can tell a man what shall be after him under the sun? 
+12. For who knoweth what /is/ good for man in /this/ life, all the days of his vain life which he spendeth as a shadow? for who can tell a man what shall be after him under the sun?
 * 7
 1. A good name /is/ better than precious ointment; and the day of death than the day of one's birth.
 
@@ -168,7 +168,7 @@
 26. And I find more bitter than death the woman, whose heart /is/ snares and nets, /and/ her hands /as/ bands: whoso pleaseth God shall escape from her; but the sinner shall be taken by her.
 27. Behold, this have I found, saith the preacher, /counting/ one by one, to find out the account:
 28. Which yet my soul seeketh, but I find not: one man among a thousand have I found; but a woman among all those have I not found.
-29. Lo, this only have I found, that God hath made man upright; but they have sought out many inventions. 
+29. Lo, this only have I found, that God hath made man upright; but they have sought out many inventions.
 * 8
 1. Who /is/ as the wise /man/? and who knoweth the interpretation of a thing? a man's wisdom maketh his face to shine, and the boldness of his face shall be changed.
 2. I /counsel thee/ to keep the king's commandment, and /that/ in regard of the oath of God.
@@ -189,7 +189,7 @@
 15. Then I commended mirth, because a man hath no better thing under the sun, than to eat, and to drink, and to be merry: for that shall abide with him of his labour the days of his life, which God giveth him under the sun.
 
 16. When I applied mine heart to know wisdom, and to see the business that is done upon the earth: (for also /there is that/ neither day nor night seeth sleep with his eyes:)
-17. Then I beheld all the work of God, that a man cannot find out the work that is done under the sun: because though a man labour to seek /it/ out, yet he shall not find /it/; yea further; though a wise /man/ think to know /it/, yet shall he not be able to find /it/. 
+17. Then I beheld all the work of God, that a man cannot find out the work that is done under the sun: because though a man labour to seek /it/ out, yet he shall not find /it/; yea further; though a wise /man/ think to know /it/, yet shall he not be able to find /it/.
 * 9
 1. For all this I considered in my heart even to declare all this, that the righteous, and the wise, and their works, /are/ in the hand of God: no man knoweth either love or hatred /by/ all /that is/ before them.
 2. All /things come/ alike to all: /there is/ one event to the righteous, and to the wicked; to the good and to the clean, and to the unclean; to him that sacrificeth, and to him that sacrificeth not: as /is/ the good, so /is/ the sinner; /and/ he that sweareth, as /he/ that feareth an oath.
@@ -212,7 +212,7 @@
 15. Now there was found in it a poor wise man, and he by his wisdom delivered the city; yet no man remembered that same poor man.
 16. Then said I, Wisdom /is/ better than strength: nevertheless the poor man's wisdom /is/ despised, and his words are not heard.
 17. The words of wise /men are/ heard in quiet more than the cry of him that ruleth among fools.
-18. Wisdom /is/ better than weapons of war: but one sinner destroyeth much good. 
+18. Wisdom /is/ better than weapons of war: but one sinner destroyeth much good.
 * 10
 1. Dead flies cause the ointment of the apothecary to send forth a stinking savour: /so doth/ a little folly him that is in reputation for wisdom /and/ honour.
 2. A wise man's heart /is/ at his right hand; but a fool's heart at his left.
@@ -237,7 +237,7 @@
 
 19. A feast is made for laughter, and wine maketh merry: but money answereth all /things/.
 
-20. Curse not the king, no not in thy thought; and curse not the rich in thy bedchamber: for a bird of the air shall carry the voice, and that which hath wings shall tell the matter. 
+20. Curse not the king, no not in thy thought; and curse not the rich in thy bedchamber: for a bird of the air shall carry the voice, and that which hath wings shall tell the matter.
 * 11
 1. Cast thy bread upon the waters: for thou shalt find it after many days.
 2. Give a portion to seven, and also to eight; for thou knowest not what evil shall be upon the earth.
@@ -250,7 +250,7 @@
 8. But if a man live many years, /and/ rejoice in them all; yet let him remember the days of darkness; for they shall be many. All that cometh /is/ vanity.
 
 9. Rejoice, O young man, in thy youth; and let thy heart cheer thee in the days of thy youth, and walk in the ways of thine heart, and in the sight of thine eyes: but know thou, that for all these /things/ God will bring thee into judgment.
-10. Therefore remove sorrow from thy heart, and put away evil from thy flesh: for childhood and youth /are/ vanity. 
+10. Therefore remove sorrow from thy heart, and put away evil from thy flesh: for childhood and youth /are/ vanity.
 * 12
 1. Remember now thy Creator in the days of thy youth, while the evil days come not, nor the years draw nigh, when thou shalt say, I have no pleasure in them;
 2. While the sun, or the light, or the moon, or the stars, be not darkened, nor the clouds return after the rain:
@@ -267,4 +267,4 @@
 12. And further, by these, my son, be admonished: of making many books /there is/ no end; and much study /is/ a weariness of the flesh.
 
 13. Let us hear the conclusion of the whole matter: Fear God, and keep his commandments: for this /is/ the whole /duty/ of man.
-14. For God shall bring every work into judgment, with every secret thing, whether /it be/ good, or whether /it be/ evil.  
+14. For God shall bring every work into judgment, with every secret thing, whether /it be/ good, or whether /it be/ evil.

--- a/22_SNG.org
+++ b/22_SNG.org
@@ -18,7 +18,7 @@
 14. My beloved /is/ unto me /as/ a cluster of camphire in the vineyards of En–gedi.
 15. Behold, thou /art/ fair, my love; behold, thou /art/ fair; thou /hast/ doves' eyes.
 16. Behold, thou /art/ fair, my beloved, yea, pleasant: also our bed /is/ green.
-17. The beams of our house /are/ cedar, /and/ our rafters of fir. 
+17. The beams of our house /are/ cedar, /and/ our rafters of fir.
 * 2
 1. I /am/ the rose of Sharon, /and/ the lily of the valleys.
 2. As the lily among thorns, so /is/ my love among the daughters.
@@ -39,7 +39,7 @@
 15. Take us the foxes, the little foxes, that spoil the vines: for our vines /have/ tender grapes.
 
 16. My beloved /is/ mine, and I /am/ his: he feedeth among the lilies.
-17. Until the day break, and the shadows flee away, turn, my beloved, and be thou like a roe or a young hart upon the mountains of Bether. 
+17. Until the day break, and the shadows flee away, turn, my beloved, and be thou like a roe or a young hart upon the mountains of Bether.
 * 3
 1. By night on my bed I sought him whom my soul loveth: I sought him, but I found him not.
 2. I will rise now, and go about the city in the streets, and in the broad ways I will seek him whom my soul loveth: I sought him, but I found him not.
@@ -52,7 +52,7 @@
 8. They all hold swords, /being/ expert in war: every man /hath/ his sword upon his thigh because of fear in the night.
 9. King Solomon made himself a chariot of the wood of Lebanon.
 10. He made the pillars thereof /of/ silver, the bottom thereof /of/ gold, the covering of it /of/ purple, the midst thereof being paved /with/ love, for the daughters of Jerusalem.
-11. Go forth, O ye daughters of Zion, and behold king Solomon with the crown wherewith his mother crowned him in the day of his espousals, and in the day of the gladness of his heart. 
+11. Go forth, O ye daughters of Zion, and behold king Solomon with the crown wherewith his mother crowned him in the day of his espousals, and in the day of the gladness of his heart.
 * 4
 1. Behold, thou /art/ fair, my love; behold, thou /art/ fair; thou /hast/ doves' eyes within thy locks: thy hair /is/ as a flock of goats, that appear from mount Gilead.
 2. Thy teeth /are/ like a flock /of sheep that are even/ shorn, which came up from the washing; whereof every one bear twins, and none /is/ barren among them.
@@ -71,7 +71,7 @@
 14. Spikenard and saffron; calamus and cinnamon, with all trees of frankincense; myrrh and aloes, with all the chief spices:
 15. A fountain of gardens, a well of living waters, and streams from Lebanon.
 
-16. Awake, O north wind; and come, thou south; blow upon my garden, /that/ the spices thereof may flow out. Let my beloved come into his garden, and eat his pleasant fruits. 
+16. Awake, O north wind; and come, thou south; blow upon my garden, /that/ the spices thereof may flow out. Let my beloved come into his garden, and eat his pleasant fruits.
 * 5
 1. I am come into my garden, my sister, /my/ spouse: I have gathered my myrrh with my spice; I have eaten my honeycomb with my honey; I have drunk my wine with my milk: eat, O friends; drink, yea, drink abundantly, O beloved.
 
@@ -90,7 +90,7 @@
 13. His cheeks /are/ as a bed of spices, /as/ sweet flowers: his lips /like/ lilies, dropping sweet smelling myrrh.
 14. His hands /are as/ gold rings set with the beryl: his belly /is as/ bright ivory overlaid /with/ sapphires.
 15. His legs /are as/ pillars of marble, set upon sockets of fine gold: his countenance /is/ as Lebanon, excellent as the cedars.
-16. His mouth /is/ most sweet: yea, he /is/ altogether lovely. This /is/ my beloved, and this /is/ my friend, O daughters of Jerusalem. 
+16. His mouth /is/ most sweet: yea, he /is/ altogether lovely. This /is/ my beloved, and this /is/ my friend, O daughters of Jerusalem.
 * 6
 1. Whither is thy beloved gone, O thou fairest among women? whither is thy beloved turned aside? that we may seek him with thee.
 2. My beloved is gone down into his garden, to the beds of spices, to feed in the gardens, and to gather lilies.
@@ -106,7 +106,7 @@
 10. Who /is/ she /that/ looketh forth as the morning, fair as the moon, clear as the sun, /and/ terrible as /an army/ with banners?
 11. I went down into the garden of nuts to see the fruits of the valley, /and/ to see whether the vine flourished, /and/ the pomegranates budded.
 12. Or ever I was aware, my soul made me /like/ the chariots of Amminadib.
-13. Return, return, O Shulamite; return, return, that we may look upon thee. What will ye see in the Shulamite? As it were the company of two armies. 
+13. Return, return, O Shulamite; return, return, that we may look upon thee. What will ye see in the Shulamite? As it were the company of two armies.
 * 7
 1. How beautiful are thy feet with shoes, O prince's daughter! the joints of thy thighs /are/ like jewels, the work of the hands of a cunning workman.
 2. Thy navel /is like/ a round goblet, /which/ wanteth not liquor: thy belly /is like/ an heap of wheat set about with lilies.
@@ -121,7 +121,7 @@
 10. I /am/ my beloved's, and his desire /is/ toward me.
 11. Come, my beloved, let us go forth into the field; let us lodge in the villages.
 12. Let us get up early to the vineyards; let us see if the vine flourish, /whether/ the tender grape appear, /and/ the pomegranates bud forth: there will I give thee my loves.
-13. The mandrakes give a smell, and at our gates /are/ all manner of pleasant /fruits/, new and old, /which/ I have laid up for thee, O my beloved. 
+13. The mandrakes give a smell, and at our gates /are/ all manner of pleasant /fruits/, new and old, /which/ I have laid up for thee, O my beloved.
 * 8
 1. O that thou /wert/ as my brother, that sucked the breasts of my mother! /when/ I should find thee without, I would kiss thee; yea, I should not be despised.
 2. I would lead thee, /and/ bring thee into my mother's house, /who/ would instruct me: I would cause thee to drink of spiced wine of the juice of my pomegranate.
@@ -139,4 +139,4 @@
 12. My vineyard, which /is/ mine, /is/ before me: thou, O Solomon, /must have/ a thousand, and those that keep the fruit thereof two hundred.
 13. Thou that dwellest in the gardens, the companions hearken to thy voice: cause me to hear /it/.
 
-14. Make haste, my beloved, and be thou like to a roe or to a young hart upon the mountains of spices.  
+14. Make haste, my beloved, and be thou like to a roe or to a young hart upon the mountains of spices.

--- a/23_ISA.org
+++ b/23_ISA.org
@@ -36,7 +36,7 @@
 28. And the destruction of the transgressors and of the sinners /shall be/ together, and they that forsake the LORD shall be consumed.
 29. For they shall be ashamed of the oaks which ye have desired, and ye shall be confounded for the gardens that ye have chosen.
 30. For ye shall be as an oak whose leaf fadeth, and as a garden that hath no water.
-31. And the strong shall be as tow, and the maker of it as a spark, and they shall both burn together, and none shall quench /them/. 
+31. And the strong shall be as tow, and the maker of it as a spark, and they shall both burn together, and none shall quench /them/.
 * 2
 1. The word that Isaiah the son of Amoz saw concerning Judah and Jerusalem.
 2. And it shall come to pass in the last days, /that/ the mountain of the LORD's house shall be established in the top of the mountains, and shall be exalted above the hills; and all nations shall flow unto it.
@@ -61,7 +61,7 @@
 19. And they shall go into the holes of the rocks, and into the caves of the earth, for fear of the LORD, and for the glory of his majesty, when he ariseth to shake terribly the earth.
 20. In that day a man shall cast his idols of silver, and his idols of gold, which they made /each one/ for himself to worship, to the moles and to the bats;
 21. To go into the clefts of the rocks, and into the tops of the ragged rocks, for fear of the LORD, and for the glory of his majesty, when he ariseth to shake terribly the earth.
-22. Cease ye from man, whose breath /is/ in his nostrils: for wherein is he to be accounted of? 
+22. Cease ye from man, whose breath /is/ in his nostrils: for wherein is he to be accounted of?
 * 3
 1. For, behold, the Lord, the LORD of hosts, doth take away from Jerusalem and from Judah the stay and the staff, the whole stay of bread, and the whole stay of water,
 2. The mighty man, and the man of war, the judge, and the prophet, and the prudent, and the ancient,
@@ -91,14 +91,14 @@
 23. The glasses, and the fine linen, and the hoods, and the vails.
 24. And it shall come to pass, /that/ instead of sweet smell there shall be stink; and instead of a girdle a rent; and instead of well set hair baldness; and instead of a stomacher a girding of sackcloth; /and/ burning instead of beauty.
 25. Thy men shall fall by the sword, and thy mighty in the war.
-26. And her gates shall lament and mourn; and she /being/ desolate shall sit upon the ground. 
+26. And her gates shall lament and mourn; and she /being/ desolate shall sit upon the ground.
 * 4
 1. And in that day seven women shall take hold of one man, saying, We will eat our own bread, and wear our own apparel: only let us be called by thy name, to take away our reproach.
 2. In that day shall the branch of the LORD be beautiful and glorious, and the fruit of the earth /shall be/ excellent and comely for them that are escaped of Israel.
 3. And it shall come to pass, /that he that is/ left in Zion, and /he that/ remaineth in Jerusalem, shall be called holy, /even/ every one that is written among the living in Jerusalem:
 4. When the Lord shall have washed away the filth of the daughters of Zion, and shall have purged the blood of Jerusalem from the midst thereof by the spirit of judgment, and by the spirit of burning.
 5. And the LORD will create upon every dwelling place of mount Zion, and upon her assemblies, a cloud and smoke by day, and the shining of a flaming fire by night: for upon all the glory /shall be/ a defence.
-6. And there shall be a tabernacle for a shadow in the daytime from the heat, and for a place of refuge, and for a covert from storm and from rain. 
+6. And there shall be a tabernacle for a shadow in the daytime from the heat, and for a place of refuge, and for a covert from storm and from rain.
 * 5
 1. Now will I sing to my wellbeloved a song of my beloved touching his vineyard. My wellbeloved hath a vineyard in a very fruitful hill:
 2. And he fenced it, and gathered out the stones thereof, and planted it with the choicest vine, and built a tower in the midst of it, and also made a winepress therein: and he looked that it should bring forth grapes, and it brought forth wild grapes.
@@ -134,7 +134,7 @@
 27. None shall be weary nor stumble among them; none shall slumber nor sleep; neither shall the girdle of their loins be loosed, nor the latchet of their shoes be broken:
 28. Whose arrows /are/ sharp, and all their bows bent, their horses' hoofs shall be counted like flint, and their wheels like a whirlwind:
 29. Their roaring /shall be/ like a lion, they shall roar like young lions: yea, they shall roar, and lay hold of the prey, and shall carry /it/ away safe, and none shall deliver /it/.
-30. And in that day they shall roar against them like the roaring of the sea: and if /one/ look unto the land, behold darkness /and/ sorrow, and the light is darkened in the heavens thereof. 
+30. And in that day they shall roar against them like the roaring of the sea: and if /one/ look unto the land, behold darkness /and/ sorrow, and the light is darkened in the heavens thereof.
 * 6
 1. In the year that king Uzziah died I saw also the Lord sitting upon a throne, high and lifted up, and his train filled the temple.
 2. Above it stood the seraphims: each one had six wings; with twain he covered his face, and with twain he covered his feet, and with twain he did fly.
@@ -151,7 +151,7 @@
 11. Then said I, Lord, how long? And he answered, Until the cities be wasted without inhabitant, and the houses without man, and the land be utterly desolate,
 12. And the LORD have removed men far away, and /there be/ a great forsaking in the midst of the land.
 
-13. But yet in it /shall be/ a tenth, and /it/ shall return, and shall be eaten: as a teil tree, and as an oak, whose substance /is/ in them, when they cast /their leaves: so/ the holy seed /shall be/ the substance thereof. 
+13. But yet in it /shall be/ a tenth, and /it/ shall return, and shall be eaten: as a teil tree, and as an oak, whose substance /is/ in them, when they cast /their leaves: so/ the holy seed /shall be/ the substance thereof.
 * 7
 1. And it came to pass in the days of Ahaz the son of Jotham, the son of Uzziah, king of Judah, /that/ Rezin the king of Syria, and Pekah the son of Remaliah, king of Israel, went up toward Jerusalem to war against it, but could not prevail against it.
 2. And it was told the house of David, saying, Syria is confederate with Ephraim. And his heart was moved, and the heart of his people, as the trees of the wood are moved with the wind.
@@ -179,7 +179,7 @@
 22. And it shall come to pass, for the abundance of milk /that/ they shall give he shall eat butter: for butter and honey shall every one eat that is left in the land.
 23. And it shall come to pass in that day, /that/ every place shall be, where there were a thousand vines at a thousand silverlings, it shall /even/ be for briers and thorns.
 24. With arrows and with bows shall /men/ come thither; because all the land shall become briers and thorns.
-25. And /on/ all hills that shall be digged with the mattock, there shall not come thither the fear of briers and thorns: but it shall be for the sending forth of oxen, and for the treading of lesser cattle. 
+25. And /on/ all hills that shall be digged with the mattock, there shall not come thither the fear of briers and thorns: but it shall be for the sending forth of oxen, and for the treading of lesser cattle.
 * 8
 1. Moreover the LORD said unto me, Take thee a great roll, and write in it with a man's pen concerning Maher–shalal–hash–baz.
 2. And I took unto me faithful witnesses to record, Uriah the priest, and Zechariah the son of Jeberechiah.
@@ -206,7 +206,7 @@
 19. And when they shall say unto you, Seek unto them that have familiar spirits, and unto wizards that peep, and that mutter: should not a people seek unto their God? for the living to the dead?
 20. To the law and to the testimony: if they speak not according to this word, /it is/ because /there is/ no light in them.
 21. And they shall pass through it, hardly bestead and hungry: and it shall come to pass, that when they shall be hungry, they shall fret themselves, and curse their king and their God, and look upward.
-22. And they shall look unto the earth; and behold trouble and darkness, dimness of anguish; and /they shall be/ driven to darkness. 
+22. And they shall look unto the earth; and behold trouble and darkness, dimness of anguish; and /they shall be/ driven to darkness.
 * 9
 1. Nevertheless the dimness /shall/ not /be/ such as /was/ in her vexation, when at the first he lightly afflicted the land of Zebulun and the land of Naphtali, and afterward did more grievously afflict /her by/ the way of the sea, beyond Jordan, in Galilee of the nations.
 2. The people that walked in darkness have seen a great light: they that dwell in the land of the shadow of death, upon them hath the light shined.
@@ -231,7 +231,7 @@
 18. For wickedness burneth as the fire: it shall devour the briers and thorns, and shall kindle in the thickets of the forest, and they shall mount up /like/ the lifting up of smoke.
 19. Through the wrath of the LORD of hosts is the land darkened, and the people shall be as the fuel of the fire: no man shall spare his brother.
 20. And he shall snatch on the right hand, and be hungry; and he shall eat on the left hand, and they shall not be satisfied: they shall eat every man the flesh of his own arm:
-21. Manasseh, Ephraim; and Ephraim, Manasseh: /and/ they together /shall be/ against Judah. For all this his anger is not turned away, but his hand /is/ stretched out still. 
+21. Manasseh, Ephraim; and Ephraim, Manasseh: /and/ they together /shall be/ against Judah. For all this his anger is not turned away, but his hand /is/ stretched out still.
 * 10
 1. Woe unto them that decree unrighteous decrees, and that write grievousness /which/ they have prescribed;
 2. To turn aside the needy from judgment, and to take away the right from the poor of my people, that widows may be their prey, and /that/ they may rob the fatherless!
@@ -269,7 +269,7 @@
 31. Madmenah is removed; the inhabitants of Gebim gather themselves to flee.
 32. As yet shall he remain at Nob that day: he shall shake his hand /against/ the mount of the daughter of Zion, the hill of Jerusalem.
 33. Behold, the Lord, the LORD of hosts, shall lop the bough with terror: and the high ones of stature /shall be/ hewn down, and the haughty shall be humbled.
-34. And he shall cut down the thickets of the forest with iron, and Lebanon shall fall by a mighty one. 
+34. And he shall cut down the thickets of the forest with iron, and Lebanon shall fall by a mighty one.
 * 11
 1. And there shall come forth a rod out of the stem of Jesse, and a Branch shall grow out of his roots:
 2. And the spirit of the LORD shall rest upon him, the spirit of wisdom and understanding, the spirit of counsel and might, the spirit of knowledge and of the fear of the LORD;
@@ -287,14 +287,14 @@
 13. The envy also of Ephraim shall depart, and the adversaries of Judah shall be cut off: Ephraim shall not envy Judah, and Judah shall not vex Ephraim.
 14. But they shall fly upon the shoulders of the Philistines toward the west; they shall spoil them of the east together: they shall lay their hand upon Edom and Moab; and the children of Ammon shall obey them.
 15. And the LORD shall utterly destroy the tongue of the Egyptian sea; and with his mighty wind shall he shake his hand over the river, and shall smite it in the seven streams, and make /men/ go over dryshod.
-16. And there shall be an highway for the remnant of his people, which shall be left, from Assyria; like as it was to Israel in the day that he came up out of the land of Egypt. 
+16. And there shall be an highway for the remnant of his people, which shall be left, from Assyria; like as it was to Israel in the day that he came up out of the land of Egypt.
 * 12
 1. And in that day thou shalt say, O LORD, I will praise thee: though thou wast angry with me, thine anger is turned away, and thou comfortedst me.
 2. Behold, God /is/ my salvation; I will trust, and not be afraid: for the LORD JEHOVAH /is/ my strength and /my/ song; he also is become my salvation.
 3. Therefore with joy shall ye draw water out of the wells of salvation.
 4. And in that day shall ye say, Praise the LORD, call upon his name, declare his doings among the people, make mention that his name is exalted.
 5. Sing unto the LORD; for he hath done excellent things: this /is/ known in all the earth.
-6. Cry out and shout, thou inhabitant of Zion: for great /is/ the Holy One of Israel in the midst of thee. 
+6. Cry out and shout, thou inhabitant of Zion: for great /is/ the Holy One of Israel in the midst of thee.
 * 13
 1. The burden of Babylon, which Isaiah the son of Amoz did see.
 2. Lift ye up a banner upon the high mountain, exalt the voice unto them, shake the hand, that they may go into the gates of the nobles.
@@ -319,7 +319,7 @@
 19. And Babylon, the glory of kingdoms, the beauty of the Chaldees' excellency, shall be as when God overthrew Sodom and Gomorrah.
 20. It shall never be inhabited, neither shall it be dwelt in from generation to generation: neither shall the Arabian pitch tent there; neither shall the shepherds make their fold there.
 21. But wild beasts of the desert shall lie there; and their houses shall be full of doleful creatures; and owls shall dwell there, and satyrs shall dance there.
-22. And the wild beasts of the islands shall cry in their desolate houses, and dragons in /their/ pleasant palaces: and her time /is/ near to come, and her days shall not be prolonged. 
+22. And the wild beasts of the islands shall cry in their desolate houses, and dragons in /their/ pleasant palaces: and her time /is/ near to come, and her days shall not be prolonged.
 * 14
 1. For the LORD will have mercy on Jacob, and will yet choose Israel, and set them in their own land: and the strangers shall be joined with them, and they shall cleave to the house of Jacob.
 2. And the people shall take them, and bring them to their place: and the house of Israel shall possess them in the land of the LORD for servants and handmaids: and they shall take them captives, whose captives they were; and they shall rule over their oppressors.
@@ -355,7 +355,7 @@
 29. Rejoice not thou, whole Palestina, because the rod of him that smote thee is broken: for out of the serpent's root shall come forth a cockatrice, and his fruit /shall be/ a fiery flying serpent.
 30. And the firstborn of the poor shall feed, and the needy shall lie down in safety: and I will kill thy root with famine, and he shall slay thy remnant.
 31. Howl, O gate; cry, O city; thou, whole Palestina, /art/ dissolved: for there shall come from the north a smoke, and none /shall be/ alone in his appointed times.
-32. What shall /one/ then answer the messengers of the nation? That the LORD hath founded Zion, and the poor of his people shall trust in it. 
+32. What shall /one/ then answer the messengers of the nation? That the LORD hath founded Zion, and the poor of his people shall trust in it.
 * 15
 1. The burden of Moab. Because in the night Ar of Moab is laid waste, /and/ brought to silence; because in the night Kir of Moab is laid waste, /and/ brought to silence;
 2. He is gone up to Bajith, and to Dibon, the high places, to weep: Moab shall howl over Nebo, and over Medeba: on all their heads /shall be/ baldness, /and/ every beard cut off.
@@ -365,7 +365,7 @@
 6. For the waters of Nimrim shall be desolate: for the hay is withered away, the grass faileth, there is no green thing.
 7. Therefore the abundance they have gotten, and that which they have laid up, shall they carry away to the brook of the willows.
 8. For the cry is gone round about the borders of Moab; the howling thereof unto Eglaim, and the howling thereof unto Beer–elim.
-9. For the waters of Dimon shall be full of blood: for I will bring more upon Dimon, lions upon him that escapeth of Moab, and upon the remnant of the land. 
+9. For the waters of Dimon shall be full of blood: for I will bring more upon Dimon, lions upon him that escapeth of Moab, and upon the remnant of the land.
 * 16
 1. Send ye the lamb to the ruler of the land from Sela to the wilderness, unto the mount of the daughter of Zion.
 2. For it shall be, /that/, as a wandering bird cast out of the nest, /so/ the daughters of Moab shall be at the fords of Arnon.
@@ -383,7 +383,7 @@
 
 12. And it shall come to pass, when it is seen that Moab is weary on the high place, that he shall come to his sanctuary to pray; but he shall not prevail.
 13. This /is/ the word that the LORD hath spoken concerning Moab since that time.
-14. But now the LORD hath spoken, saying, Within three years, as the years of an hireling, and the glory of Moab shall be contemned, with all that great multitude; and the remnant /shall be/ very small /and/ feeble. 
+14. But now the LORD hath spoken, saying, Within three years, as the years of an hireling, and the glory of Moab shall be contemned, with all that great multitude; and the remnant /shall be/ very small /and/ feeble.
 * 17
 1. The burden of Damascus. Behold, Damascus is taken away from /being/ a city, and it shall be a ruinous heap.
 2. The cities of Aroer /are/ forsaken: they shall be for flocks, which shall lie down, and none shall make /them/ afraid.
@@ -401,7 +401,7 @@
 
 12. Woe to the multitude of many people, /which/ make a noise like the noise of the seas; and to the rushing of nations, /that/ make a rushing like the rushing of mighty waters!
 13. The nations shall rush like the rushing of many waters: but /God/ shall rebuke them, and they shall flee far off, and shall be chased as the chaff of the mountains before the wind, and like a rolling thing before the whirlwind.
-14. And behold at eveningtide trouble; /and/ before the morning he /is/ not. This /is/ the portion of them that spoil us, and the lot of them that rob us. 
+14. And behold at eveningtide trouble; /and/ before the morning he /is/ not. This /is/ the portion of them that spoil us, and the lot of them that rob us.
 * 18
 1. Woe to the land shadowing with wings, which /is/ beyond the rivers of Ethiopia:
 2. That sendeth ambassadors by the sea, even in vessels of bulrushes upon the waters, /saying/, Go, ye swift messengers, to a nation scattered and peeled, to a people terrible from their beginning hitherto; a nation meted out and trodden down, whose land the rivers have spoiled!
@@ -410,7 +410,7 @@
 5. For afore the harvest, when the bud is perfect, and the sour grape is ripening in the flower, he shall both cut off the sprigs with pruning hooks, and take away /and/ cut down the branches.
 6. They shall be left together unto the fowls of the mountains, and to the beasts of the earth: and the fowls shall summer upon them, and all the beasts of the earth shall winter upon them.
 
-7. In that time shall the present be brought unto the LORD of hosts of a people scattered and peeled, and from a people terrible from their beginning hitherto; a nation meted out and trodden under foot, whose land the rivers have spoiled, to the place of the name of the LORD of hosts, the mount Zion. 
+7. In that time shall the present be brought unto the LORD of hosts of a people scattered and peeled, and from a people terrible from their beginning hitherto; a nation meted out and trodden under foot, whose land the rivers have spoiled, to the place of the name of the LORD of hosts, the mount Zion.
 * 19
 1. The burden of Egypt. Behold, the LORD rideth upon a swift cloud, and shall come into Egypt: and the idols of Egypt shall be moved at his presence, and the heart of Egypt shall melt in the midst of it.
 2. And I will set the Egyptians against the Egyptians: and they shall fight every one against his brother, and every one against his neighbour; city against city, /and/ kingdom against kingdom.
@@ -439,14 +439,14 @@
 
 23. In that day shall there be a highway out of Egypt to Assyria, and the Assyrian shall come into Egypt, and the Egyptian into Assyria, and the Egyptians shall serve with the Assyrians.
 24. In that day shall Israel be the third with Egypt and with Assyria, /even/ a blessing in the midst of the land:
-25. Whom the LORD of hosts shall bless, saying, Blessed /be/ Egypt my people, and Assyria the work of my hands, and Israel mine inheritance. 
+25. Whom the LORD of hosts shall bless, saying, Blessed /be/ Egypt my people, and Assyria the work of my hands, and Israel mine inheritance.
 * 20
 1. In the year that Tartan came unto Ashdod, (when Sargon the king of Assyria sent him,) and fought against Ashdod, and took it;
 2. At the same time spake the LORD by Isaiah the son of Amoz, saying, Go and loose the sackcloth from off thy loins, and put off thy shoe from thy foot. And he did so, walking naked and barefoot.
 3. And the LORD said, Like as my servant Isaiah hath walked naked and barefoot three years /for/ a sign and wonder upon Egypt and upon Ethiopia;
 4. So shall the king of Assyria lead away the Egyptians prisoners, and the Ethiopians captives, young and old, naked and barefoot, even with /their/ buttocks uncovered, to the shame of Egypt.
 5. And they shall be afraid and ashamed of Ethiopia their expectation, and of Egypt their glory.
-6. And the inhabitant of this isle shall say in that day, Behold, such /is/ our expectation, whither we flee for help to be delivered from the king of Assyria: and how shall we escape? 
+6. And the inhabitant of this isle shall say in that day, Behold, such /is/ our expectation, whither we flee for help to be delivered from the king of Assyria: and how shall we escape?
 * 21
 1. The burden of the desert of the sea. As whirlwinds in the south pass through; /so/ it cometh from the desert, from a terrible land.
 2. A grievous vision is declared unto me; the treacherous dealer dealeth treacherously, and the spoiler spoileth. Go up, O Elam: besiege, O Media; all the sighing thereof have I made to cease.
@@ -466,7 +466,7 @@
 14. The inhabitants of the land of Tema brought water to him that was thirsty, they prevented with their bread him that fled.
 15. For they fled from the swords, from the drawn sword, and from the bent bow, and from the grievousness of war.
 16. For thus hath the Lord said unto me, Within a year, according to the years of an hireling, and all the glory of Kedar shall fail:
-17. And the residue of the number of archers, the mighty men of the children of Kedar, shall be diminished: for the LORD God of Israel hath spoken /it/. 
+17. And the residue of the number of archers, the mighty men of the children of Kedar, shall be diminished: for the LORD God of Israel hath spoken /it/.
 * 22
 1. The burden of the valley of vision. What aileth thee now, that thou art wholly gone up to the housetops?
 2. Thou that art full of stirs, a tumultuous city, a joyous city: thy slain /men are/ not slain with the sword, nor dead in battle.
@@ -495,7 +495,7 @@
 22. And the key of the house of David will I lay upon his shoulder; so he shall open, and none shall shut; and he shall shut, and none shall open.
 23. And I will fasten him /as/ a nail in a sure place; and he shall be for a glorious throne to his father's house.
 24. And they shall hang upon him all the glory of his father's house, the offspring and the issue, all vessels of small quantity, from the vessels of cups, even to all the vessels of flagons.
-25. In that day, saith the LORD of hosts, shall the nail that is fastened in the sure place be removed, and be cut down, and fall; and the burden that /was/ upon it shall be cut off: for the LORD hath spoken /it/. 
+25. In that day, saith the LORD of hosts, shall the nail that is fastened in the sure place be removed, and be cut down, and fall; and the burden that /was/ upon it shall be cut off: for the LORD hath spoken /it/.
 * 23
 1. The burden of Tyre. Howl, ye ships of Tarshish; for it is laid waste, so that there is no house, no entering in: from the land of Chittim it is revealed to them.
 2. Be still, ye inhabitants of the isle; thou whom the merchants of Zidon, that pass over the sea, have replenished.
@@ -515,7 +515,7 @@
 16. Take an harp, go about the city, thou harlot that hast been forgotten; make sweet melody, sing many songs, that thou mayest be remembered.
 
 17. And it shall come to pass after the end of seventy years, that the LORD will visit Tyre, and she shall turn to her hire, and shall commit fornication with all the kingdoms of the world upon the face of the earth.
-18. And her merchandise and her hire shall be holiness to the LORD: it shall not be treasured nor laid up; for her merchandise shall be for them that dwell before the LORD, to eat sufficiently, and for durable clothing. 
+18. And her merchandise and her hire shall be holiness to the LORD: it shall not be treasured nor laid up; for her merchandise shall be for them that dwell before the LORD, to eat sufficiently, and for durable clothing.
 * 24
 1. Behold, the LORD maketh the earth empty, and maketh it waste, and turneth it upside down, and scattereth abroad the inhabitants thereof.
 2. And it shall be, as with the people, so with the priest; as with the servant, so with his master; as with the maid, so with her mistress; as with the buyer, so with the seller; as with the lender, so with the borrower; as with the taker of usury, so with the giver of usury to him.
@@ -541,7 +541,7 @@
 20. The earth shall reel to and fro like a drunkard, and shall be removed like a cottage; and the transgression thereof shall be heavy upon it; and it shall fall, and not rise again.
 21. And it shall come to pass in that day, /that/ the LORD shall punish the host of the high ones /that are/ on high, and the kings of the earth upon the earth.
 22. And they shall be gathered together, /as/ prisoners are gathered in the pit, and shall be shut up in the prison, and after many days shall they be visited.
-23. Then the moon shall be confounded, and the sun ashamed, when the LORD of hosts shall reign in mount Zion, and in Jerusalem, and before his ancients gloriously. 
+23. Then the moon shall be confounded, and the sun ashamed, when the LORD of hosts shall reign in mount Zion, and in Jerusalem, and before his ancients gloriously.
 * 25
 1. O LORD, thou /art/ my God; I will exalt thee, I will praise thy name; for thou hast done wonderful /things; thy/ counsels of old /are/ faithfulness /and/ truth.
 2. For thou hast made of a city an heap; /of/ a defenced city a ruin: a palace of strangers to be no city; it shall never be built.
@@ -556,7 +556,7 @@
 9. And it shall be said in that day, Lo, this /is/ our God; we have waited for him, and he will save us: this /is/ the LORD; we have waited for him, we will be glad and rejoice in his salvation.
 10. For in this mountain shall the hand of the LORD rest, and Moab shall be trodden down under him, even as straw is trodden down for the dunghill.
 11. And he shall spread forth his hands in the midst of them, as he that swimmeth spreadeth forth /his hands/ to swim: and he shall bring down their pride together with the spoils of their hands.
-12. And the fortress of the high fort of thy walls shall he bring down, lay low, /and/ bring to the ground, /even/ to the dust. 
+12. And the fortress of the high fort of thy walls shall he bring down, lay low, /and/ bring to the ground, /even/ to the dust.
 * 26
 1. In that day shall this song be sung in the land of Judah; We have a strong city; salvation will /God/ appoint /for/ walls and bulwarks.
 2. Open ye the gates, that the righteous nation which keepeth the truth may enter in.
@@ -581,7 +581,7 @@
 19. Thy dead /men/ shall live, /together with/ my dead body shall they arise. Awake and sing, ye that dwell in dust: for thy dew /is as/ the dew of herbs, and the earth shall cast out the dead.
 
 20. Come, my people, enter thou into thy chambers, and shut thy doors about thee: hide thyself as it were for a little moment, until the indignation be overpast.
-21. For, behold, the LORD cometh out of his place to punish the inhabitants of the earth for their iniquity: the earth also shall disclose her blood, and shall no more cover her slain. 
+21. For, behold, the LORD cometh out of his place to punish the inhabitants of the earth for their iniquity: the earth also shall disclose her blood, and shall no more cover her slain.
 * 27
 1. In that day the LORD with his sore and great and strong sword shall punish leviathan the piercing serpent, even leviathan that crooked serpent; and he shall slay the dragon that /is/ in the sea.
 2. In that day sing ye unto her, A vineyard of red wine.
@@ -597,7 +597,7 @@
 11. When the boughs thereof are withered, they shall be broken off: the women come, /and/ set them on fire: for it /is/ a people of no understanding: therefore he that made them will not have mercy on them, and he that formed them will shew them no favour.
 
 12. And it shall come to pass in that day, /that/ the LORD shall beat off from the channel of the river unto the stream of Egypt, and ye shall be gathered one by one, O ye children of Israel.
-13. And it shall come to pass in that day, /that/ the great trumpet shall be blown, and they shall come which were ready to perish in the land of Assyria, and the outcasts in the land of Egypt, and shall worship the LORD in the holy mount at Jerusalem. 
+13. And it shall come to pass in that day, /that/ the great trumpet shall be blown, and they shall come which were ready to perish in the land of Assyria, and the outcasts in the land of Egypt, and shall worship the LORD in the holy mount at Jerusalem.
 * 28
 1. Woe to the crown of pride, to the drunkards of Ephraim, whose glorious beauty /is/ a fading flower, which /are/ on the head of the fat valleys of them that are overcome with wine!
 2. Behold, the Lord hath a mighty and strong one, /which/ as a tempest of hail /and/ a destroying storm, as a flood of mighty waters overflowing, shall cast down to the earth with the hand.
@@ -634,7 +634,7 @@
 26. For his God doth instruct him to discretion, /and/ doth teach him.
 27. For the fitches are not threshed with a threshing instrument, neither is a cart wheel turned about upon the cummin; but the fitches are beaten out with a staff, and the cummin with a rod.
 28. Bread /corn/ is bruised; because he will not ever be threshing it, nor break /it with/ the wheel of his cart, nor bruise it /with/ his horsemen.
-29. This also cometh forth from the LORD of hosts, /which/ is wonderful in counsel, /and/ excellent in working. 
+29. This also cometh forth from the LORD of hosts, /which/ is wonderful in counsel, /and/ excellent in working.
 * 29
 1. Woe to Ariel, to Ariel, the city /where/ David dwelt! add ye year to year; let them kill sacrifices.
 2. Yet I will distress Ariel, and there shall be heaviness and sorrow: and it shall be unto me as Ariel.
@@ -663,7 +663,7 @@
 21. That make a man an offender for a word, and lay a snare for him that reproveth in the gate, and turn aside the just for a thing of nought.
 22. Therefore thus saith the LORD, who redeemed Abraham, concerning the house of Jacob, Jacob shall not now be ashamed, neither shall his face now wax pale.
 23. But when he seeth his children, the work of mine hands, in the midst of him, they shall sanctify my name, and sanctify the Holy One of Jacob, and shall fear the God of Israel.
-24. They also that erred in spirit shall come to understanding, and they that murmured shall learn doctrine. 
+24. They also that erred in spirit shall come to understanding, and they that murmured shall learn doctrine.
 * 30
 1. Woe to the rebellious children, saith the LORD, that take counsel, but not of me; and that cover with a covering, but not of my spirit, that they may add sin to sin:
 2. That walk to go down into Egypt, and have not asked at my mouth; to strengthen themselves in the strength of Pharaoh, and to trust in the shadow of Egypt!
@@ -700,7 +700,7 @@
 30. And the LORD shall cause his glorious voice to be heard, and shall shew the lighting down of his arm, with the indignation of /his/ anger, and /with/ the flame of a devouring fire, /with/ scattering, and tempest, and hailstones.
 31. For through the voice of the LORD shall the Assyrian be beaten down, /which/ smote with a rod.
 32. And /in/ every place where the grounded staff shall pass, which the LORD shall lay upon him, /it/ shall be with tabrets and harps: and in battles of shaking will he fight with it.
-33. For Tophet /is/ ordained of old; yea, for the king it is prepared; he hath made /it/ deep /and/ large: the pile thereof /is/ fire and much wood; the breath of the LORD, like a stream of brimstone, doth kindle it. 
+33. For Tophet /is/ ordained of old; yea, for the king it is prepared; he hath made /it/ deep /and/ large: the pile thereof /is/ fire and much wood; the breath of the LORD, like a stream of brimstone, doth kindle it.
 * 31
 1. Woe to them that go down to Egypt for help; and stay on horses, and trust in chariots, because /they are/ many; and in horsemen, because they are very strong; but they look not unto the Holy One of Israel, neither seek the LORD!
 2. Yet he also /is/ wise, and will bring evil, and will not call back his words: but will arise against the house of the evildoers, and against the help of them that work iniquity.
@@ -712,7 +712,7 @@
 7. For in that day every man shall cast away his idols of silver, and his idols of gold, which your own hands have made unto you /for/ a sin.
 
 8. Then shall the Assyrian fall with the sword, not of a mighty man; and the sword, not of a mean man, shall devour him: but he shall flee from the sword, and his young men shall be discomfited.
-9. And he shall pass over to his strong hold for fear, and his princes shall be afraid of the ensign, saith the LORD, whose fire /is/ in Zion, and his furnace in Jerusalem. 
+9. And he shall pass over to his strong hold for fear, and his princes shall be afraid of the ensign, saith the LORD, whose fire /is/ in Zion, and his furnace in Jerusalem.
 * 32
 1. Behold, a king shall reign in righteousness, and princes shall rule in judgment.
 2. And a man shall be as an hiding place from the wind, and a covert from the tempest; as rivers of water in a dry place, as the shadow of a great rock in a weary land.
@@ -734,7 +734,7 @@
 17. And the work of righteousness shall be peace; and the effect of righteousness quietness and assurance for ever.
 18. And my people shall dwell in a peaceable habitation, and in sure dwellings, and in quiet resting places;
 19. When it shall hail, coming down on the forest; and the city shall be low in a low place.
-20. Blessed /are/ ye that sow beside all waters, that send forth /thither/ the feet of the ox and the ass. 
+20. Blessed /are/ ye that sow beside all waters, that send forth /thither/ the feet of the ox and the ass.
 * 33
 1. Woe to thee that spoilest, and thou /wast/ not spoiled; and dealest treacherously, and they dealt not treacherously with thee! when thou shalt cease to spoil, thou shalt be spoiled; /and/ when thou shalt make an end to deal treacherously, they shall deal treacherously with thee.
 2. O LORD, be gracious unto us; we have waited for thee: be thou their arm every morning, our salvation also in the time of trouble.
@@ -760,7 +760,7 @@
 21. But there the glorious LORD /will be/ unto us a place of broad rivers /and/ streams; wherein shall go no galley with oars, neither shall gallant ship pass thereby.
 22. For the LORD /is/ our judge, the LORD /is/ our lawgiver, the LORD /is/ our king; he will save us.
 23. Thy tacklings are loosed; they could not well strengthen their mast, they could not spread the sail: then is the prey of a great spoil divided; the lame take the prey.
-24. And the inhabitant shall not say, I am sick: the people that dwell therein /shall be/ forgiven /their/ iniquity. 
+24. And the inhabitant shall not say, I am sick: the people that dwell therein /shall be/ forgiven /their/ iniquity.
 * 34
 1. Come near, ye nations, to hear; and hearken, ye people: let the earth hear, and all that is therein; the world, and all things that come forth of it.
 2. For the indignation of the LORD /is/ upon all nations, and /his/ fury upon all their armies: he hath utterly destroyed them, he hath delivered them to the slaughter.
@@ -780,7 +780,7 @@
 15. There shall the great owl make her nest, and lay, and hatch, and gather under her shadow: there shall the vultures also be gathered, every one with her mate.
 
 16. Seek ye out of the book of the LORD, and read: no one of these shall fail, none shall want her mate: for my mouth it hath commanded, and his spirit it hath gathered them.
-17. And he hath cast the lot for them, and his hand hath divided it unto them by line: they shall possess it for ever, from generation to generation shall they dwell therein. 
+17. And he hath cast the lot for them, and his hand hath divided it unto them by line: they shall possess it for ever, from generation to generation shall they dwell therein.
 * 35
 1. The wilderness and the solitary place shall be glad for them; and the desert shall rejoice, and blossom as the rose.
 2. It shall blossom abundantly, and rejoice even with joy and singing: the glory of Lebanon shall be given unto it, the excellency of Carmel and Sharon, they shall see the glory of the LORD, /and/ the excellency of our God.
@@ -792,7 +792,7 @@
 7. And the parched ground shall become a pool, and the thirsty land springs of water: in the habitation of dragons, where each lay, /shall be/ grass with reeds and rushes.
 8. And an highway shall be there, and a way, and it shall be called The way of holiness; the unclean shall not pass over it; but it /shall be/ for those: the wayfaring men, though fools, shall not err /therein/.
 9. No lion shall be there, nor /any/ ravenous beast shall go up thereon, it shall not be found there; but the redeemed shall walk /there/:
-10. And the ransomed of the LORD shall return, and come to Zion with songs and everlasting joy upon their heads: they shall obtain joy and gladness, and sorrow and sighing shall flee away. 
+10. And the ransomed of the LORD shall return, and come to Zion with songs and everlasting joy upon their heads: they shall obtain joy and gladness, and sorrow and sighing shall flee away.
 * 36
 1. Now it came to pass in the fourteenth year of king Hezekiah, /that/ Sennacherib king of Assyria came up against all the defenced cities of Judah, and took them.
 2. And the king of Assyria sent Rabshakeh from Lachish to Jerusalem unto king Hezekiah with a great army. And he stood by the conduit of the upper pool in the highway of the fuller's field.
@@ -819,7 +819,7 @@
 20. Who /are they/ among all the gods of these lands, that have delivered their land out of my hand, that the LORD should deliver Jerusalem out of my hand?
 21. But they held their peace, and answered him not a word: for the king's commandment was, saying, Answer him not.
 
-22. Then came Eliakim, the son of Hilkiah, that /was/ over the household, and Shebna the scribe, and Joah, the son of Asaph, the recorder, to Hezekiah with /their/ clothes rent, and told him the words of Rabshakeh. 
+22. Then came Eliakim, the son of Hilkiah, that /was/ over the household, and Shebna the scribe, and Joah, the son of Asaph, the recorder, to Hezekiah with /their/ clothes rent, and told him the words of Rabshakeh.
 * 37
 1. And it came to pass, when king Hezekiah heard /it/, that he rent his clothes, and covered himself with sackcloth, and went into the house of the LORD.
 2. And he sent Eliakim, who /was/ over the household, and Shebna the scribe, and the elders of the priests covered with sackcloth, unto Isaiah the prophet the son of Amoz.
@@ -863,7 +863,7 @@
 36. Then the angel of the LORD went forth, and smote in the camp of the Assyrians a hundred and fourscore and five thousand: and when they arose early in the morning, behold, they /were/ all dead corpses.
 
 37. So Sennacherib king of Assyria departed, and went and returned, and dwelt at Nineveh.
-38. And it came to pass, as he was worshipping in the house of Nisroch his god, that Adrammelech and Sharezer his sons smote him with the sword; and they escaped into the land of Armenia: and Esar–haddon his son reigned in his stead. 
+38. And it came to pass, as he was worshipping in the house of Nisroch his god, that Adrammelech and Sharezer his sons smote him with the sword; and they escaped into the land of Armenia: and Esar–haddon his son reigned in his stead.
 * 38
 1. In those days was Hezekiah sick unto death. And Isaiah the prophet the son of Amoz came unto him, and said unto him, Thus saith the LORD, Set thine house in order: for thou shalt die, and not live.
 2. Then Hezekiah turned his face toward the wall, and prayed unto the LORD,
@@ -888,7 +888,7 @@
 19. The living, the living, he shall praise thee, as I /do/ this day: the father to the children shall make known thy truth.
 20. The LORD /was ready/ to save me: therefore we will sing my songs to the stringed instruments all the days of our life in the house of the LORD.
 21. For Isaiah had said, Let them take a lump of figs, and lay /it/ for a plaister upon the boil, and he shall recover.
-22. Hezekiah also had said, What /is/ the sign that I shall go up to the house of the LORD? 
+22. Hezekiah also had said, What /is/ the sign that I shall go up to the house of the LORD?
 * 39
 1. At that time Merodach–baladan, the son of Baladan, king of Babylon, sent letters and a present to Hezekiah: for he had heard that he had been sick, and was recovered.
 2. And Hezekiah was glad of them, and shewed them the house of his precious things, the silver, and the gold, and the spices, and the precious ointment, and all the house of his armour, and all that was found in his treasures: there was nothing in his house, nor in all his dominion, that Hezekiah shewed them not.
@@ -898,7 +898,7 @@
 5. Then said Isaiah to Hezekiah, Hear the word of the LORD of hosts:
 6. Behold, the days come, that all that /is/ in thine house, and /that/ which thy fathers have laid up in store until this day, shall be carried to Babylon: nothing shall be left, saith the LORD.
 7. And of thy sons that shall issue from thee, which thou shalt beget, shall they take away; and they shall be eunuchs in the palace of the king of Babylon.
-8. Then said Hezekiah to Isaiah, Good /is/ the word of the LORD which thou hast spoken. He said moreover, For there shall be peace and truth in my days. 
+8. Then said Hezekiah to Isaiah, Good /is/ the word of the LORD which thou hast spoken. He said moreover, For there shall be peace and truth in my days.
 * 40
 1. Comfort ye, comfort ye my people, saith your God.
 2. Speak ye comfortably to Jerusalem, and cry unto her, that her warfare is accomplished, that her iniquity is pardoned: for she hath received of the LORD's hand double for all her sins.
@@ -935,7 +935,7 @@
 28. Hast thou not known? hast thou not heard, /that/ the everlasting God, the LORD, the Creator of the ends of the earth, fainteth not, neither is weary? /there is/ no searching of his understanding.
 29. He giveth power to the faint; and to /them that have/ no might he increaseth strength.
 30. Even the youths shall faint and be weary, and the young men shall utterly fall:
-31. But they that wait upon the LORD shall renew /their/ strength; they shall mount up with wings as eagles; they shall run, and not be weary; /and/ they shall walk, and not faint. 
+31. But they that wait upon the LORD shall renew /their/ strength; they shall mount up with wings as eagles; they shall run, and not be weary; /and/ they shall walk, and not faint.
 * 41
 1. Keep silence before me, O islands; and let the people renew /their/ strength: let them come near; then let them speak: let us come near together to judgment.
 2. Who raised up the righteous /man/ from the east, called him to his foot, gave the nations before him, and made /him/ rule over kings? he gave /them/ as the dust to his sword, /and/ as driven stubble to his bow.
@@ -966,7 +966,7 @@
 26. Who hath declared from the beginning, that we may know? and beforetime, that we may say, /He is/ righteous? yea, /there is/ none that sheweth, yea, /there is/ none that declareth, yea, /there is/ none that heareth your words.
 27. The first /shall say/ to Zion, Behold, behold them: and I will give to Jerusalem one that bringeth good tidings.
 28. For I beheld, and /there was/ no man; even among them, and /there was/ no counsellor, that, when I asked of them, could answer a word.
-29. Behold, they /are/ all vanity; their works /are/ nothing: their molten images /are/ wind and confusion. 
+29. Behold, they /are/ all vanity; their works /are/ nothing: their molten images /are/ wind and confusion.
 * 42
 1. Behold my servant, whom I uphold; mine elect, /in whom/ my soul delighteth; I have put my spirit upon him: he shall bring forth judgment to the Gentiles.
 2. He shall not cry, nor lift up, nor cause his voice to be heard in the street.
@@ -994,7 +994,7 @@
 22. But this /is/ a people robbed and spoiled; /they are/ all of them snared in holes, and they are hid in prison houses: they are for a prey, and none delivereth; for a spoil, and none saith, Restore.
 23. Who among you will give ear to this? /who/ will hearken and hear for the time to come?
 24. Who gave Jacob for a spoil, and Israel to the robbers? did not the LORD, he against whom we have sinned? for they would not walk in his ways, neither were they obedient unto his law.
-25. Therefore he hath poured upon him the fury of his anger, and the strength of battle: and it hath set him on fire round about, yet he knew not; and it burned him, yet he laid /it/ not to heart. 
+25. Therefore he hath poured upon him the fury of his anger, and the strength of battle: and it hath set him on fire round about, yet he knew not; and it burned him, yet he laid /it/ not to heart.
 * 43
 1. But now thus saith the LORD that created thee, O Jacob, and he that formed thee, O Israel, Fear not: for I have redeemed thee, I have called /thee/ by thy name; thou /art/ mine.
 2. When thou passest through the waters, I /will be/ with thee; and through the rivers, they shall not overflow thee: when thou walkest through the fire, thou shalt not be burned; neither shall the flame kindle upon thee.
@@ -1027,7 +1027,7 @@
 25. I, /even/ I, /am/ he that blotteth out thy transgressions for mine own sake, and will not remember thy sins.
 26. Put me in remembrance: let us plead together: declare thou, that thou mayest be justified.
 27. Thy first father hath sinned, and thy teachers have transgressed against me.
-28. Therefore I have profaned the princes of the sanctuary, and have given Jacob to the curse, and Israel to reproaches. 
+28. Therefore I have profaned the princes of the sanctuary, and have given Jacob to the curse, and Israel to reproaches.
 * 44
 1. Yet now hear, O Jacob my servant; and Israel, whom I have chosen:
 2. Thus saith the LORD that made thee, and formed thee from the womb, /which/ will help thee; Fear not, O Jacob, my servant; and thou, Jesurun, whom I have chosen.
@@ -1058,7 +1058,7 @@
 25. That frustrateth the tokens of the liars, and maketh diviners mad; that turneth wise /men/ backward, and maketh their knowledge foolish;
 26. That confirmeth the word of his servant, and performeth the counsel of his messengers; that saith to Jerusalem, Thou shalt be inhabited; and to the cities of Judah, Ye shall be built, and I will raise up the decayed places thereof:
 27. That saith to the deep, Be dry, and I will dry up thy rivers:
-28. That saith of Cyrus, /He is/ my shepherd, and shall perform all my pleasure: even saying to Jerusalem, Thou shalt be built; and to the temple, Thy foundation shall be laid. 
+28. That saith of Cyrus, /He is/ my shepherd, and shall perform all my pleasure: even saying to Jerusalem, Thou shalt be built; and to the temple, Thy foundation shall be laid.
 * 45
 1. Thus saith the LORD to his anointed, to Cyrus, whose right hand I have holden, to subdue nations before him; and I will loose the loins of kings, to open before him the two leaved gates; and the gates shall not be shut;
 2. I will go before thee, and make the crooked places straight: I will break in pieces the gates of brass, and cut in sunder the bars of iron:
@@ -1086,7 +1086,7 @@
 22. Look unto me, and be ye saved, all the ends of the earth: for I /am/ God, and /there is/ none else.
 23. I have sworn by myself, the word is gone out of my mouth /in/ righteousness, and shall not return, That unto me every knee shall bow, every tongue shall swear.
 24. Surely, shall /one/ say, in the LORD have I righteousness and strength: /even/ to him shall /men/ come; and all that are incensed against him shall be ashamed.
-25. In the LORD shall all the seed of Israel be justified, and shall glory. 
+25. In the LORD shall all the seed of Israel be justified, and shall glory.
 * 46
 1. Bel boweth down, Nebo stoopeth, their idols were upon the beasts, and upon the cattle: your carriages /were/ heavy loaden; /they are/ a burden to the weary /beast/.
 2. They stoop, they bow down together; they could not deliver the burden, but themselves are gone into captivity.
@@ -1103,7 +1103,7 @@
 11. Calling a ravenous bird from the east, the man that executeth my counsel from a far country: yea, I have spoken /it/, I will also bring it to pass; I have purposed /it/, I will also do it.
 
 12. Hearken unto me, ye stouthearted, that /are/ far from righteousness:
-13. I bring near my righteousness; it shall not be far off, and my salvation shall not tarry: and I will place salvation in Zion for Israel my glory. 
+13. I bring near my righteousness; it shall not be far off, and my salvation shall not tarry: and I will place salvation in Zion for Israel my glory.
 * 47
 1. Come down, and sit in the dust, O virgin daughter of Babylon, sit on the ground: /there is/ no throne, O daughter of the Chaldeans: for thou shalt no more be called tender and delicate.
 2. Take the millstones, and grind meal: uncover thy locks, make bare the leg, uncover the thigh, pass over the rivers.
@@ -1123,7 +1123,7 @@
 12. Stand now with thine enchantments, and with the multitude of thy sorceries, wherein thou hast laboured from thy youth; if so be thou shalt be able to profit, if so be thou mayest prevail.
 13. Thou art wearied in the multitude of thy counsels. Let now the astrologers, the stargazers, the monthly prognosticators, stand up, and save thee from /these things/ that shall come upon thee.
 14. Behold, they shall be as stubble; the fire shall burn them; they shall not deliver themselves from the power of the flame: /there shall/ not /be/ a coal to warm at, /nor/ fire to sit before it.
-15. Thus shall they be unto thee with whom thou hast laboured, /even/ thy merchants, from thy youth: they shall wander every one to his quarter; none shall save thee. 
+15. Thus shall they be unto thee with whom thou hast laboured, /even/ thy merchants, from thy youth: they shall wander every one to his quarter; none shall save thee.
 * 48
 1. Hear ye this, O house of Jacob, which are called by the name of Israel, and are come forth out of the waters of Judah, which swear by the name of the LORD, and make mention of the God of Israel, /but/ not in truth, nor in righteousness.
 2. For they call themselves of the holy city, and stay themselves upon the God of Israel; The LORD of hosts /is/ his name.
@@ -1150,7 +1150,7 @@
 
 20. Go ye forth of Babylon, flee ye from the Chaldeans, with a voice of singing declare ye, tell this, utter it /even/ to the end of the earth; say ye, The LORD hath redeemed his servant Jacob.
 21. And they thirsted not /when/ he led them through the deserts: he caused the waters to flow out of the rock for them: he clave the rock also, and the waters gushed out.
-22. /There is/ no peace, saith the LORD, unto the wicked. 
+22. /There is/ no peace, saith the LORD, unto the wicked.
 * 49
 1. Listen, O isles, unto me; and hearken, ye people, from far; The LORD hath called me from the womb; from the bowels of my mother hath he made mention of my name.
 2. And he hath made my mouth like a sharp sword; in the shadow of his hand hath he hid me, and made me a polished shaft; in his quiver hath he hid me;
@@ -1181,7 +1181,7 @@
 
 24. Shall the prey be taken from the mighty, or the lawful captive delivered?
 25. But thus saith the LORD, Even the captives of the mighty shall be taken away, and the prey of the terrible shall be delivered: for I will contend with him that contendeth with thee, and I will save thy children.
-26. And I will feed them that oppress thee with their own flesh; and they shall be drunken with their own blood, as with sweet wine: and all flesh shall know that I the LORD /am/ thy Saviour and thy Redeemer, the mighty One of Jacob. 
+26. And I will feed them that oppress thee with their own flesh; and they shall be drunken with their own blood, as with sweet wine: and all flesh shall know that I the LORD /am/ thy Saviour and thy Redeemer, the mighty One of Jacob.
 * 50
 1. Thus saith the LORD, Where /is/ the bill of your mother's divorcement, whom I have put away? or which of my creditors /is it/ to whom I have sold you? Behold, for your iniquities have ye sold yourselves, and for your transgressions is your mother put away.
 2. Wherefore, when I came, /was there/ no man? when I called, /was there/ none to answer? Is my hand shortened at all, that it cannot redeem? or have I no power to deliver? behold, at my rebuke I dry up the sea, I make the rivers a wilderness: their fish stinketh, because /there is/ no water, and dieth for thirst.
@@ -1196,7 +1196,7 @@
 9. Behold, the Lord GOD will help me; who /is/ he /that/ shall condemn me? lo, they all shall wax old as a garment; the moth shall eat them up.
 
 10. Who /is/ among you that feareth the LORD, that obeyeth the voice of his servant, that walketh /in/ darkness, and hath no light? let him trust in the name of the LORD, and stay upon his God.
-11. Behold, all ye that kindle a fire, that compass /yourselves/ about with sparks: walk in the light of your fire, and in the sparks /that/ ye have kindled. This shall ye have of mine hand; ye shall lie down in sorrow. 
+11. Behold, all ye that kindle a fire, that compass /yourselves/ about with sparks: walk in the light of your fire, and in the sparks /that/ ye have kindled. This shall ye have of mine hand; ye shall lie down in sorrow.
 * 51
 1. Hearken to me, ye that follow after righteousness, ye that seek the LORD: look unto the rock /whence/ ye are hewn, and to the hole of the pit /whence/ ye are digged.
 2. Look unto Abraham your father, and unto Sarah /that/ bare you: for I called him alone, and blessed him, and increased him.
@@ -1225,7 +1225,7 @@
 
 21. Therefore hear now this, thou afflicted, and drunken, but not with wine:
 22. Thus saith thy Lord the LORD, and thy God /that/ pleadeth the cause of his people, Behold, I have taken out of thine hand the cup of trembling, /even/ the dregs of the cup of my fury; thou shalt no more drink it again:
-23. But I will put it into the hand of them that afflict thee; which have said to thy soul, Bow down, that we may go over: and thou hast laid thy body as the ground, and as the street, to them that went over. 
+23. But I will put it into the hand of them that afflict thee; which have said to thy soul, Bow down, that we may go over: and thou hast laid thy body as the ground, and as the street, to them that went over.
 * 52
 1. Awake, awake; put on thy strength, O Zion; put on thy beautiful garments, O Jerusalem, the holy city: for henceforth there shall no more come into thee the uncircumcised and the unclean.
 2. Shake thyself from the dust; arise, /and/ sit down, O Jerusalem: loose thyself from the bands of thy neck, O captive daughter of Zion.
@@ -1245,7 +1245,7 @@
 
 13. Behold, my servant shall deal prudently, he shall be exalted and extolled, and be very high.
 14. As many were astonied at thee; his visage was so marred more than any man, and his form more than the sons of men:
-15. So shall he sprinkle many nations; the kings shall shut their mouths at him: for /that/ which had not been told them shall they see; and /that/ which they had not heard shall they consider. 
+15. So shall he sprinkle many nations; the kings shall shut their mouths at him: for /that/ which had not been told them shall they see; and /that/ which they had not heard shall they consider.
 * 53
 1. Who hath believed our report? and to whom is the arm of the LORD revealed?
 2. For he shall grow up before him as a tender plant, and as a root out of a dry ground: he hath no form nor comeliness; and when we shall see him, /there is/ no beauty that we should desire him.
@@ -1260,7 +1260,7 @@
 
 10. Yet it pleased the LORD to bruise him; he hath put /him/ to grief: when thou shalt make his soul an offering for sin, he shall see /his/ seed, he shall prolong /his/ days, and the pleasure of the LORD shall prosper in his hand.
 11. He shall see of the travail of his soul, /and/ shall be satisfied: by his knowledge shall my righteous servant justify many; for he shall bear their iniquities.
-12. Therefore will I divide him /a portion/ with the great, and he shall divide the spoil with the strong; because he hath poured out his soul unto death: and he was numbered with the transgressors; and he bare the sin of many, and made intercession for the transgressors. 
+12. Therefore will I divide him /a portion/ with the great, and he shall divide the spoil with the strong; because he hath poured out his soul unto death: and he was numbered with the transgressors; and he bare the sin of many, and made intercession for the transgressors.
 * 54
 1. Sing, O barren, thou /that/ didst not bear; break forth into singing, and cry aloud, thou /that/ didst not travail with child: for more /are/ the children of the desolate than the children of the married wife, saith the LORD.
 2. Enlarge the place of thy tent, and let them stretch forth the curtains of thine habitations: spare not, lengthen thy cords, and strengthen thy stakes;
@@ -1280,7 +1280,7 @@
 15. Behold, they shall surely gather together, /but/ not by me: whosoever shall gather together against thee shall fall for thy sake.
 16. Behold, I have created the smith that bloweth the coals in the fire, and that bringeth forth an instrument for his work; and I have created the waster to destroy.
 
-17. No weapon that is formed against thee shall prosper; and every tongue /that/ shall rise against thee in judgment thou shalt condemn. This /is/ the heritage of the servants of the LORD, and their righteousness /is/ of me, saith the LORD. 
+17. No weapon that is formed against thee shall prosper; and every tongue /that/ shall rise against thee in judgment thou shalt condemn. This /is/ the heritage of the servants of the LORD, and their righteousness /is/ of me, saith the LORD.
 * 55
 1. Ho, every one that thirsteth, come ye to the waters, and he that hath no money; come ye, buy, and eat; yea, come, buy wine and milk without money and without price.
 2. Wherefore do ye spend money for /that which is/ not bread? and your labour for /that which/ satisfieth not? hearken diligently unto me, and eat ye /that which is/ good, and let your soul delight itself in fatness.
@@ -1296,7 +1296,7 @@
 10. For as the rain cometh down, and the snow from heaven, and returneth not thither, but watereth the earth, and maketh it bring forth and bud, that it may give seed to the sower, and bread to the eater:
 11. So shall my word be that goeth forth out of my mouth: it shall not return unto me void, but it shall accomplish that which I please, and it shall prosper /in the thing/ whereto I sent it.
 12. For ye shall go out with joy, and be led forth with peace: the mountains and the hills shall break forth before you into singing, and all the trees of the field shall clap /their/ hands.
-13. Instead of the thorn shall come up the fir tree, and instead of the brier shall come up the myrtle tree: and it shall be to the LORD for a name, for an everlasting sign /that/ shall not be cut off. 
+13. Instead of the thorn shall come up the fir tree, and instead of the brier shall come up the myrtle tree: and it shall be to the LORD for a name, for an everlasting sign /that/ shall not be cut off.
 * 56
 1. Thus saith the LORD, Keep ye judgment, and do justice: for my salvation /is/ near to come, and my righteousness to be revealed.
 2. Blessed /is/ the man /that/ doeth this, and the son of man /that/ layeth hold on it; that keepeth the sabbath from polluting it, and keepeth his hand from doing any evil.
@@ -1311,7 +1311,7 @@
 9. All ye beasts of the field, come to devour, /yea/, all ye beasts in the forest.
 10. His watchmen /are/ blind: they are all ignorant, they /are/ all dumb dogs, they cannot bark; sleeping, lying down, loving to slumber.
 11. Yea, /they are/ greedy dogs /which/ can never have enough, and they /are/ shepherds /that/ cannot understand: they all look to their own way, every one for his gain, from his quarter.
-12. Come ye, /say they/, I will fetch wine, and we will fill ourselves with strong drink; and to morrow shall be as this day, /and/ much more abundant. 
+12. Come ye, /say they/, I will fetch wine, and we will fill ourselves with strong drink; and to morrow shall be as this day, /and/ much more abundant.
 * 57
 1. The righteous perisheth, and no man layeth /it/ to heart: and merciful men /are/ taken away, none considering that the righteous is taken away from the evil /to come/.
 2. He shall enter into peace: they shall rest in their beds, /each one/ walking /in/ his uprightness.
@@ -1335,7 +1335,7 @@
 18. I have seen his ways, and will heal him: I will lead him also, and restore comforts unto him and to his mourners.
 19. I create the fruit of the lips; Peace, peace to /him that is/ far off, and to /him that is/ near, saith the LORD; and I will heal him.
 20. But the wicked /are/ like the troubled sea, when it cannot rest, whose waters cast up mire and dirt.
-21. /There is/ no peace, saith my God, to the wicked. 
+21. /There is/ no peace, saith my God, to the wicked.
 * 58
 1. Cry aloud, spare not, lift up thy voice like a trumpet, and shew my people their transgression, and the house of Jacob their sins.
 2. Yet they seek me daily, and delight to know my ways, as a nation that did righteousness, and forsook not the ordinance of their God: they ask of me the ordinances of justice; they take delight in approaching to God.
@@ -1353,7 +1353,7 @@
 12. And /they that shall be/ of thee shall build the old waste places: thou shalt raise up the foundations of many generations; and thou shalt be called, The repairer of the breach, The restorer of paths to dwell in.
 
 13. If thou turn away thy foot from the sabbath, /from/ doing thy pleasure on my holy day; and call the sabbath a delight, the holy of the LORD, honourable; and shalt honour him, not doing thine own ways, nor finding thine own pleasure, nor speaking /thine own/ words:
-14. Then shalt thou delight thyself in the LORD; and I will cause thee to ride upon the high places of the earth, and feed thee with the heritage of Jacob thy father: for the mouth of the LORD hath spoken /it/. 
+14. Then shalt thou delight thyself in the LORD; and I will cause thee to ride upon the high places of the earth, and feed thee with the heritage of Jacob thy father: for the mouth of the LORD hath spoken /it/.
 * 59
 1. Behold, the LORD's hand is not shortened, that it cannot save; neither his ear heavy, that it cannot hear:
 2. But your iniquities have separated between you and your God, and your sins have hid /his/ face from you, that he will not hear.
@@ -1378,7 +1378,7 @@
 19. So shall they fear the name of the LORD from the west, and his glory from the rising of the sun. When the enemy shall come in like a flood, the Spirit of the LORD shall lift up a standard against him.
 
 20. And the Redeemer shall come to Zion, and unto them that turn from transgression in Jacob, saith the LORD.
-21. As for me, this /is/ my covenant with them, saith the LORD; My spirit that /is/ upon thee, and my words which I have put in thy mouth, shall not depart out of thy mouth, nor out of the mouth of thy seed, nor out of the mouth of thy seed's seed, saith the LORD, from henceforth and for ever. 
+21. As for me, this /is/ my covenant with them, saith the LORD; My spirit that /is/ upon thee, and my words which I have put in thy mouth, shall not depart out of thy mouth, nor out of the mouth of thy seed, nor out of the mouth of thy seed's seed, saith the LORD, from henceforth and for ever.
 * 60
 1. Arise, shine; for thy light is come, and the glory of the LORD is risen upon thee.
 2. For, behold, the darkness shall cover the earth, and gross darkness the people: but the LORD shall arise upon thee, and his glory shall be seen upon thee.
@@ -1401,7 +1401,7 @@
 19. The sun shall be no more thy light by day; neither for brightness shall the moon give light unto thee: but the LORD shall be unto thee an everlasting light, and thy God thy glory.
 20. Thy sun shall no more go down; neither shall thy moon withdraw itself: for the LORD shall be thine everlasting light, and the days of thy mourning shall be ended.
 21. Thy people also /shall be/ all righteous: they shall inherit the land for ever, the branch of my planting, the work of my hands, that I may be glorified.
-22. A little one shall become a thousand, and a small one a strong nation: I the LORD will hasten it in his time. 
+22. A little one shall become a thousand, and a small one a strong nation: I the LORD will hasten it in his time.
 * 61
 1. The Spirit of the Lord GOD /is/ upon me; because the LORD hath anointed me to preach good tidings unto the meek; he hath sent me to bind up the brokenhearted, to proclaim liberty to the captives, and the opening of the prison to /them that are/ bound;
 2. To proclaim the acceptable year of the LORD, and the day of vengeance of our God; to comfort all that mourn;
@@ -1415,7 +1415,7 @@
 8. For I the LORD love judgment, I hate robbery for burnt offering; and I will direct their work in truth, and I will make an everlasting covenant with them.
 9. And their seed shall be known among the Gentiles, and their offspring among the people: all that see them shall acknowledge them, that they /are/ the seed /which/ the LORD hath blessed.
 10. I will greatly rejoice in the LORD, my soul shall be joyful in my God; for he hath clothed me with the garments of salvation, he hath covered me with the robe of righteousness, as a bridegroom decketh /himself/ with ornaments, and as a bride adorneth /herself/ with her jewels.
-11. For as the earth bringeth forth her bud, and as the garden causeth the things that are sown in it to spring forth; so the Lord GOD will cause righteousness and praise to spring forth before all the nations. 
+11. For as the earth bringeth forth her bud, and as the garden causeth the things that are sown in it to spring forth; so the Lord GOD will cause righteousness and praise to spring forth before all the nations.
 * 62
 1. For Zion's sake will I not hold my peace, and for Jerusalem's sake I will not rest, until the righteousness thereof go forth as brightness, and the salvation thereof as a lamp /that/ burneth.
 2. And the Gentiles shall see thy righteousness, and all kings thy glory: and thou shalt be called by a new name, which the mouth of the LORD shall name.
@@ -1430,7 +1430,7 @@
 
 10. Go through, go through the gates; prepare ye the way of the people; cast up, cast up the highway; gather out the stones; lift up a standard for the people.
 11. Behold, the LORD hath proclaimed unto the end of the world, Say ye to the daughter of Zion, Behold, thy salvation cometh; behold, his reward /is/ with him, and his work before him.
-12. And they shall call them, The holy people, The redeemed of the LORD: and thou shalt be called, Sought out, A city not forsaken. 
+12. And they shall call them, The holy people, The redeemed of the LORD: and thou shalt be called, Sought out, A city not forsaken.
 * 63
 1. Who /is/ this that cometh from Edom, with dyed garments from Bozrah? this /that is/ glorious in his apparel, travelling in the greatness of his strength? I that speak in righteousness, mighty to save.
 2. Wherefore /art thou/ red in thine apparel, and thy garments like him that treadeth in the winefat?
@@ -1454,7 +1454,7 @@
 
 17. O LORD, why hast thou made us to err from thy ways, /and/ hardened our heart from thy fear? Return for thy servants' sake, the tribes of thine inheritance.
 18. The people of thy holiness have possessed /it/ but a little while: our adversaries have trodden down thy sanctuary.
-19. We are /thine/: thou never barest rule over them; they were not called by thy name. 
+19. We are /thine/: thou never barest rule over them; they were not called by thy name.
 * 64
 1. Oh that thou wouldest rend the heavens, that thou wouldest come down, that the mountains might flow down at thy presence,
 2. As /when/ the melting fire burneth, the fire causeth the waters to boil, to make thy name known to thine adversaries, /that/ the nations may tremble at thy presence!
@@ -1468,7 +1468,7 @@
 9. Be not wroth very sore, O LORD, neither remember iniquity for ever: behold, see, we beseech thee, we /are/ all thy people.
 10. Thy holy cities are a wilderness, Zion is a wilderness, Jerusalem a desolation.
 11. Our holy and our beautiful house, where our fathers praised thee, is burned up with fire: and all our pleasant things are laid waste.
-12. Wilt thou refrain thyself for these /things/, O LORD? wilt thou hold thy peace, and afflict us very sore? 
+12. Wilt thou refrain thyself for these /things/, O LORD? wilt thou hold thy peace, and afflict us very sore?
 * 65
 1. I am sought of /them that/ asked not /for me/; I am found of /them that/ sought me not: I said, Behold me, behold me, unto a nation /that/ was not called by my name.
 2. I have spread out my hands all the day unto a rebellious people, which walketh in a way /that was/ not good, after their own thoughts;
@@ -1497,7 +1497,7 @@
 22. They shall not build, and another inhabit; they shall not plant, and another eat: for as the days of a tree /are/ the days of my people, and mine elect shall long enjoy the work of their hands.
 23. They shall not labour in vain, nor bring forth for trouble; for they /are/ the seed of the blessed of the LORD, and their offspring with them.
 24. And it shall come to pass, that before they call, I will answer; and while they are yet speaking, I will hear.
-25. The wolf and the lamb shall feed together, and the lion shall eat straw like the bullock: and dust /shall be/ the serpent's meat. They shall not hurt nor destroy in all my holy mountain, saith the LORD. 
+25. The wolf and the lamb shall feed together, and the lion shall eat straw like the bullock: and dust /shall be/ the serpent's meat. They shall not hurt nor destroy in all my holy mountain, saith the LORD.
 * 66
 1. Thus saith the LORD, The heaven /is/ my throne, and the earth /is/ my footstool: where /is/ the house that ye build unto me? and where /is/ the place of my rest?
 2. For all those /things/ hath mine hand made, and all those /things/ have been, saith the LORD: but to this /man/ will I look, /even/ to /him that is/ poor and of a contrite spirit, and trembleth at my word.
@@ -1523,4 +1523,4 @@
 21. And I will also take of them for priests /and/ for Levites, saith the LORD.
 22. For as the new heavens and the new earth, which I will make, shall remain before me, saith the LORD, so shall your seed and your name remain.
 23. And it shall come to pass, /that/ from one new moon to another, and from one sabbath to another, shall all flesh come to worship before me, saith the LORD.
-24. And they shall go forth, and look upon the carcases of the men that have transgressed against me: for their worm shall not die, neither shall their fire be quenched; and they shall be an abhorring unto all flesh.  
+24. And they shall go forth, and look upon the carcases of the men that have transgressed against me: for their worm shall not die, neither shall their fire be quenched; and they shall be an abhorring unto all flesh.

--- a/24_JER.org
+++ b/24_JER.org
@@ -21,7 +21,7 @@
 
 17. Thou therefore gird up thy loins, and arise, and speak unto them all that I command thee: be not dismayed at their faces, lest I confound thee before them.
 18. For, behold, I have made thee this day a defenced city, and an iron pillar, and brasen walls against the whole land, against the kings of Judah, against the princes thereof, against the priests thereof, and against the people of the land.
-19. And they shall fight against thee; but they shall not prevail against thee; for I /am/ with thee, saith the LORD, to deliver thee. 
+19. And they shall fight against thee; but they shall not prevail against thee; for I /am/ with thee, saith the LORD, to deliver thee.
 * 2
 1. Moreover the word of the LORD came to me, saying,
 2. Go and cry in the ears of Jerusalem, saying, Thus saith the LORD; I remember thee, the kindness of thy youth, the love of thine espousals, when thou wentest after me in the wilderness, in a land /that was/ not sown.
@@ -64,7 +64,7 @@
 34. Also in thy skirts is found the blood of the souls of the poor innocents: I have not found it by secret search, but upon all these.
 35. Yet thou sayest, Because I am innocent, surely his anger shall turn from me. Behold, I will plead with thee, because thou sayest, I have not sinned.
 36. Why gaddest thou about so much to change thy way? thou also shalt be ashamed of Egypt, as thou wast ashamed of Assyria.
-37. Yea, thou shalt go forth from him, and thine hands upon thine head: for the LORD hath rejected thy confidences, and thou shalt not prosper in them. 
+37. Yea, thou shalt go forth from him, and thine hands upon thine head: for the LORD hath rejected thy confidences, and thou shalt not prosper in them.
 * 3
 1. They say, If a man put away his wife, and she go from him, and become another man's, shall he return unto her again? shall not that land be greatly polluted? but thou hast played the harlot with many lovers; yet return again to me, saith the LORD.
 2. Lift up thine eyes unto the high places, and see where thou hast not been lien with. In the ways hast thou sat for them, as the Arabian in the wilderness; and thou hast polluted the land with thy whoredoms and with thy wickedness.
@@ -93,7 +93,7 @@
 22. Return, ye backsliding children, /and/ I will heal your backslidings. Behold, we come unto thee; for thou /art/ the LORD our God.
 23. Truly in vain /is salvation hoped for/ from the hills, /and from/ the multitude of mountains: truly in the LORD our God /is/ the salvation of Israel.
 24. For shame hath devoured the labour of our fathers from our youth; their flocks and their herds, their sons and their daughters.
-25. We lie down in our shame, and our confusion covereth us: for we have sinned against the LORD our God, we and our fathers, from our youth even unto this day, and have not obeyed the voice of the LORD our God. 
+25. We lie down in our shame, and our confusion covereth us: for we have sinned against the LORD our God, we and our fathers, from our youth even unto this day, and have not obeyed the voice of the LORD our God.
 * 4
 1. If thou wilt return, O Israel, saith the LORD, return unto me: and if thou wilt put away thine abominations out of my sight, then shalt thou not remove.
 2. And thou shalt swear, The LORD liveth, in truth, in judgment, and in righteousness; and the nations shall bless themselves in him, and in him shall they glory.
@@ -127,7 +127,7 @@
 28. For this shall the earth mourn, and the heavens above be black: because I have spoken /it/, I have purposed /it/, and will not repent, neither will I turn back from it.
 29. The whole city shall flee for the noise of the horsemen and bowmen; they shall go into thickets, and climb up upon the rocks: every city /shall be/ forsaken, and not a man dwell therein.
 30. And /when/ thou /art/ spoiled, what wilt thou do? Though thou clothest thyself with crimson, though thou deckest thee with ornaments of gold, though thou rentest thy face with painting, in vain shalt thou make thyself fair; /thy/ lovers will despise thee, they will seek thy life.
-31. For I have heard a voice as of a woman in travail, /and/ the anguish as of her that bringeth forth her first child, the voice of the daughter of Zion, /that/ bewaileth herself, /that/ spreadeth her hands, /saying/, Woe /is/ me now! for my soul is wearied because of murderers. 
+31. For I have heard a voice as of a woman in travail, /and/ the anguish as of her that bringeth forth her first child, the voice of the daughter of Zion, /that/ bewaileth herself, /that/ spreadeth her hands, /saying/, Woe /is/ me now! for my soul is wearied because of murderers.
 * 5
 1. Run ye to and fro through the streets of Jerusalem, and see now, and know, and seek in the broad places thereof, if ye can find a man, if there be /any/ that executeth judgment, that seeketh the truth; and I will pardon it.
 2. And though they say, The LORD liveth; surely they swear falsely.
@@ -164,7 +164,7 @@
 29. Shall I not visit for these /things/? saith the LORD: shall not my soul be avenged on such a nation as this?
 
 30. A wonderful and horrible thing is committed in the land;
-31. The prophets prophesy falsely, and the priests bear rule by their means; and my people love /to have it/ so: and what will ye do in the end thereof? 
+31. The prophets prophesy falsely, and the priests bear rule by their means; and my people love /to have it/ so: and what will ye do in the end thereof?
 * 6
 1. O ye children of Benjamin, gather yourselves to flee out of the midst of Jerusalem, and blow the trumpet in Tekoa, and set up a sign of fire in Beth–haccerem: for evil appeareth out of the north, and great destruction.
 2. I have likened the daughter of Zion to a comely and delicate /woman/.
@@ -199,7 +199,7 @@
 27. I have set thee /for/ a tower /and/ a fortress among my people, that thou mayest know and try their way.
 28. They /are/ all grievous revolters, walking with slanders: /they are/ brass and iron; they /are/ all corrupters.
 29. The bellows are burned, the lead is consumed of the fire; the founder melteth in vain: for the wicked are not plucked away.
-30. Reprobate silver shall /men/ call them, because the LORD hath rejected them. 
+30. Reprobate silver shall /men/ call them, because the LORD hath rejected them.
 * 7
 1. The word that came to Jeremiah from the LORD, saying,
 2. Stand in the gate of the LORD's house, and proclaim there this word, and say, Hear the word of the LORD, all /ye of/ Judah, that enter in at these gates to worship the LORD.
@@ -239,7 +239,7 @@
 
 32. Therefore, behold, the days come, saith the LORD, that it shall no more be called Tophet, nor the valley of the son of Hinnom, but the valley of slaughter: for they shall bury in Tophet, till there be no place.
 33. And the carcases of this people shall be meat for the fowls of the heaven, and for the beasts of the earth; and none shall fray /them/ away.
-34. Then will I cause to cease from the cities of Judah, and from the streets of Jerusalem, the voice of mirth, and the voice of gladness, the voice of the bridegroom, and the voice of the bride: for the land shall be desolate. 
+34. Then will I cause to cease from the cities of Judah, and from the streets of Jerusalem, the voice of mirth, and the voice of gladness, the voice of the bridegroom, and the voice of the bride: for the land shall be desolate.
 * 8
 1. At that time, saith the LORD, they shall bring out the bones of the kings of Judah, and the bones of his princes, and the bones of the priests, and the bones of the prophets, and the bones of the inhabitants of Jerusalem, out of their graves:
 2. And they shall spread them before the sun, and the moon, and all the host of heaven, whom they have loved, and whom they have served, and after whom they have walked, and whom they have sought, and whom they have worshipped: they shall not be gathered, nor be buried; they shall be for dung upon the face of the earth.
@@ -265,7 +265,7 @@
 19. Behold the voice of the cry of the daughter of my people because of them that dwell in a far country: /Is/ not the LORD in Zion? /is/ not her king in her? Why have they provoked me to anger with their graven images, /and/ with strange vanities?
 20. The harvest is past, the summer is ended, and we are not saved.
 21. For the hurt of the daughter of my people am I hurt; I am black; astonishment hath taken hold on me.
-22. /Is there/ no balm in Gilead; /is there/ no physician there? why then is not the health of the daughter of my people recovered? 
+22. /Is there/ no balm in Gilead; /is there/ no physician there? why then is not the health of the daughter of my people recovered?
 * 9
 1. Oh that my head were waters, and mine eyes a fountain of tears, that I might weep day and night for the slain of the daughter of my people!
 2. Oh that I had in the wilderness a lodging place of wayfaring men; that I might leave my people, and go from them! for they /be/ all adulterers, an assembly of treacherous men.
@@ -297,7 +297,7 @@
 24. But let him that glorieth glory in this, that he understandeth and knoweth me, that I /am/ the LORD which exercise lovingkindness, judgment, and righteousness, in the earth: for in these /things/ I delight, saith the LORD.
 
 25. Behold, the days come, saith the LORD, that I will punish all /them which are/ circumcised with the uncircumcised;
-26. Egypt, and Judah, and Edom, and the children of Ammon, and Moab, and all /that are/ in the utmost corners, that dwell in the wilderness: for all /these/ nations /are/ uncircumcised, and all the house of Israel /are/ uncircumcised in the heart. 
+26. Egypt, and Judah, and Edom, and the children of Ammon, and Moab, and all /that are/ in the utmost corners, that dwell in the wilderness: for all /these/ nations /are/ uncircumcised, and all the house of Israel /are/ uncircumcised in the heart.
 * 10
 1. Hear ye the word which the LORD speaketh unto you, O house of Israel:
 2. Thus saith the LORD, Learn not the way of the heathen, and be not dismayed at the signs of heaven; for the heathen are dismayed at them.
@@ -326,7 +326,7 @@
 
 23. O LORD, I know that the way of man /is/ not in himself: /it is/ not in man that walketh to direct his steps.
 24. O LORD, correct me, but with judgment; not in thine anger, lest thou bring me to nothing.
-25. Pour out thy fury upon the heathen that know thee not, and upon the families that call not on thy name: for they have eaten up Jacob, and devoured him, and consumed him, and have made his habitation desolate. 
+25. Pour out thy fury upon the heathen that know thee not, and upon the families that call not on thy name: for they have eaten up Jacob, and devoured him, and consumed him, and have made his habitation desolate.
 * 11
 1. The word that came to Jeremiah from the LORD, saying,
 2. Hear ye the words of this covenant, and speak unto the men of Judah, and to the inhabitants of Jerusalem;
@@ -352,7 +352,7 @@
 20. But, O LORD of hosts, that judgest righteously, that triest the reins and the heart, let me see thy vengeance on them: for unto thee have I revealed my cause.
 21. Therefore thus saith the LORD of the men of Anathoth, that seek thy life, saying, Prophesy not in the name of the LORD, that thou die not by our hand:
 22. Therefore thus saith the LORD of hosts, Behold, I will punish them: the young men shall die by the sword; their sons and their daughters shall die by famine:
-23. And there shall be no remnant of them: for I will bring evil upon the men of Anathoth, /even/ the year of their visitation. 
+23. And there shall be no remnant of them: for I will bring evil upon the men of Anathoth, /even/ the year of their visitation.
 * 12
 1. Righteous /art/ thou, O LORD, when I plead with thee: yet let me talk with thee of /thy/ judgments: Wherefore doth the way of the wicked prosper? /wherefore/ are all they happy that deal very treacherously?
 2. Thou hast planted them, yea, they have taken root: they grow, yea, they bring forth fruit: thou /art/ near in their mouth, and far from their reins.
@@ -373,7 +373,7 @@
 14. Thus saith the LORD against all mine evil neighbours, that touch the inheritance which I have caused my people Israel to inherit; Behold, I will pluck them out of their land, and pluck out the house of Judah from among them.
 15. And it shall come to pass, after that I have plucked them out I will return, and have compassion on them, and will bring them again, every man to his heritage, and every man to his land.
 16. And it shall come to pass, if they will diligently learn the ways of my people, to swear by my name, The LORD liveth; as they taught my people to swear by Baal; then shall they be built in the midst of my people.
-17. But if they will not obey, I will utterly pluck up and destroy that nation, saith the LORD. 
+17. But if they will not obey, I will utterly pluck up and destroy that nation, saith the LORD.
 * 13
 1. Thus saith the LORD unto me, Go and get thee a linen girdle, and put it upon thy loins, and put it not in water.
 2. So I got a girdle according to the word of the LORD, and put /it/ on my loins.
@@ -404,7 +404,7 @@
 24. Therefore will I scatter them as the stubble that passeth away by the wind of the wilderness.
 25. This /is/ thy lot, the portion of thy measures from me, saith the LORD; because thou hast forgotten me, and trusted in falsehood.
 26. Therefore will I discover thy skirts upon thy face, that thy shame may appear.
-27. I have seen thine adulteries, and thy neighings, the lewdness of thy whoredom, /and/ thine abominations on the hills in the fields. Woe unto thee, O Jerusalem! wilt thou not be made clean? when /shall it/ once /be/? 
+27. I have seen thine adulteries, and thy neighings, the lewdness of thy whoredom, /and/ thine abominations on the hills in the fields. Woe unto thee, O Jerusalem! wilt thou not be made clean? when /shall it/ once /be/?
 * 14
 1. The word of the LORD that came to Jeremiah concerning the dearth.
 2. Judah mourneth, and the gates thereof languish; they are black unto the ground; and the cry of Jerusalem is gone up.
@@ -431,7 +431,7 @@
 19. Hast thou utterly rejected Judah? hath thy soul lothed Zion? why hast thou smitten us, and /there is/ no healing for us? we looked for peace, and /there is/ no good; and for the time of healing, and behold trouble!
 20. We acknowledge, O LORD, our wickedness, /and/ the iniquity of our fathers: for we have sinned against thee.
 21. Do not abhor /us/, for thy name's sake, do not disgrace the throne of thy glory: remember, break not thy covenant with us.
-22. Are there /any/ among the vanities of the Gentiles that can cause rain? or can the heavens give showers? /art/ not thou he, O LORD our God? therefore we will wait upon thee: for thou hast made all these /things/. 
+22. Are there /any/ among the vanities of the Gentiles that can cause rain? or can the heavens give showers? /art/ not thou he, O LORD our God? therefore we will wait upon thee: for thou hast made all these /things/.
 * 15
 1. Then said the LORD unto me, Though Moses and Samuel stood before me, /yet/ my mind /could/ not /be/ toward this people: cast /them/ out of my sight, and let them go forth.
 2. And it shall come to pass, if they say unto thee, Whither shall we go forth? then thou shalt tell them, Thus saith the LORD; Such as /are/ for death, to death; and such as /are/ for the sword, to the sword; and such as /are/ for the famine, to the famine; and such as /are/ for the captivity, to the captivity.
@@ -456,7 +456,7 @@
 
 19. Therefore thus saith the LORD, If thou return, then will I bring thee again, /and/ thou shalt stand before me: and if thou take forth the precious from the vile, thou shalt be as my mouth: let them return unto thee; but return not thou unto them.
 20. And I will make thee unto this people a fenced brasen wall: and they shall fight against thee, but they shall not prevail against thee: for I /am/ with thee to save thee and to deliver thee, saith the LORD.
-21. And I will deliver thee out of the hand of the wicked, and I will redeem thee out of the hand of the terrible. 
+21. And I will deliver thee out of the hand of the wicked, and I will redeem thee out of the hand of the terrible.
 * 16
 1. The word of the LORD came also unto me, saying,
 2. Thou shalt not take thee a wife, neither shalt thou have sons or daughters in this place.
@@ -481,7 +481,7 @@
 18. And first I will recompense their iniquity and their sin double; because they have defiled my land, they have filled mine inheritance with the carcases of their detestable and abominable things.
 19. O LORD, my strength, and my fortress, and my refuge in the day of affliction, the Gentiles shall come unto thee from the ends of the earth, and shall say, Surely our fathers have inherited lies, vanity, and /things/ wherein /there is/ no profit.
 20. Shall a man make gods unto himself, and they /are/ no gods?
-21. Therefore, behold, I will this once cause them to know, I will cause them to know mine hand and my might; and they shall know that my name /is/ The LORD. 
+21. Therefore, behold, I will this once cause them to know, I will cause them to know mine hand and my might; and they shall know that my name /is/ The LORD.
 * 17
 1. The sin of Judah /is/ written with a pen of iron, /and/ with the point of a diamond: /it is/ graven upon the table of their heart, and upon the horns of your altars;
 2. Whilst their children remember their altars and their groves by the green trees upon the high hills.
@@ -514,7 +514,7 @@
 24. And it shall come to pass, if ye diligently hearken unto me, saith the LORD, to bring in no burden through the gates of this city on the sabbath day, but hallow the sabbath day, to do no work therein;
 25. Then shall there enter into the gates of this city kings and princes sitting upon the throne of David, riding in chariots and on horses, they, and their princes, the men of Judah, and the inhabitants of Jerusalem: and this city shall remain for ever.
 26. And they shall come from the cities of Judah, and from the places about Jerusalem, and from the land of Benjamin, and from the plain, and from the mountains, and from the south, bringing burnt offerings, and sacrifices, and meat offerings, and incense, and bringing sacrifices of praise, unto the house of the LORD.
-27. But if ye will not hearken unto me to hallow the sabbath day, and not to bear a burden, even entering in at the gates of Jerusalem on the sabbath day; then will I kindle a fire in the gates thereof, and it shall devour the palaces of Jerusalem, and it shall not be quenched. 
+27. But if ye will not hearken unto me to hallow the sabbath day, and not to bear a burden, even entering in at the gates of Jerusalem on the sabbath day; then will I kindle a fire in the gates thereof, and it shall devour the palaces of Jerusalem, and it shall not be quenched.
 * 18
 1. The word which came to Jeremiah from the LORD, saying,
 2. Arise, and go down to the potter's house, and there I will cause thee to hear my words.
@@ -540,7 +540,7 @@
 20. Shall evil be recompensed for good? for they have digged a pit for my soul. Remember that I stood before thee to speak good for them, /and/ to turn away thy wrath from them.
 21. Therefore deliver up their children to the famine, and pour out their /blood/ by the force of the sword; and let their wives be bereaved of their children, and /be/ widows; and let their men be put to death; /let/ their young men /be/ slain by the sword in battle.
 22. Let a cry be heard from their houses, when thou shalt bring a troop suddenly upon them: for they have digged a pit to take me, and hid snares for my feet.
-23. Yet, LORD, thou knowest all their counsel against me to slay /me/: forgive not their iniquity, neither blot out their sin from thy sight, but let them be overthrown before thee; deal /thus/ with them in the time of thine anger. 
+23. Yet, LORD, thou knowest all their counsel against me to slay /me/: forgive not their iniquity, neither blot out their sin from thy sight, but let them be overthrown before thee; deal /thus/ with them in the time of thine anger.
 * 19
 1. Thus saith the LORD, Go and get a potter's earthen bottle, and /take/ of the ancients of the people, and of the ancients of the priests;
 2. And go forth unto the valley of the son of Hinnom, which /is/ by the entry of the east gate, and proclaim there the words that I shall tell thee,
@@ -556,7 +556,7 @@
 12. Thus will I do unto this place, saith the LORD, and to the inhabitants thereof, and /even/ make this city as Tophet:
 13. And the houses of Jerusalem, and the houses of the kings of Judah, shall be defiled as the place of Tophet, because of all the houses upon whose roofs they have burned incense unto all the host of heaven, and have poured out drink offerings unto other gods.
 14. Then came Jeremiah from Tophet, whither the LORD had sent him to prophesy; and he stood in the court of the LORD's house; and said to all the people,
-15. Thus saith the LORD of hosts, the God of Israel; Behold, I will bring upon this city and upon all her towns all the evil that I have pronounced against it, because they have hardened their necks, that they might not hear my words. 
+15. Thus saith the LORD of hosts, the God of Israel; Behold, I will bring upon this city and upon all her towns all the evil that I have pronounced against it, because they have hardened their necks, that they might not hear my words.
 * 20
 1. Now Pashur the son of Immer the priest, who /was/ also chief governor in the house of the LORD, heard that Jeremiah prophesied these things.
 2. Then Pashur smote Jeremiah the prophet, and put him in the stocks that /were/ in the high gate of Benjamin, which /was/ by the house of the LORD.
@@ -578,7 +578,7 @@
 15. Cursed /be/ the man who brought tidings to my father, saying, A man child is born unto thee; making him very glad.
 16. And let that man be as the cities which the LORD overthrew, and repented not: and let him hear the cry in the morning, and the shouting at noontide;
 17. Because he slew me not from the womb; or that my mother might have been my grave, and her womb /to be/ always great /with me/.
-18. Wherefore came I forth out of the womb to see labour and sorrow, that my days should be consumed with shame? 
+18. Wherefore came I forth out of the womb to see labour and sorrow, that my days should be consumed with shame?
 * 21
 1. The word which came unto Jeremiah from the LORD, when king Zedekiah sent unto him Pashur the son of Melchiah, and Zephaniah the son of Maaseiah the priest, saying,
 2. Enquire, I pray thee, of the LORD for us; for Nebuchadrezzar king of Babylon maketh war against us; if so be that the LORD will deal with us according to all his wondrous works, that he may go up from us.
@@ -596,7 +596,7 @@
 11. And touching the house of the king of Judah, /say/, Hear ye the word of the LORD;
 12. O house of David, thus saith the LORD; Execute judgment in the morning, and deliver /him that is/ spoiled out of the hand of the oppressor, lest my fury go out like fire, and burn that none can quench /it/, because of the evil of your doings.
 13. Behold, I /am/ against thee, O inhabitant of the valley, /and/ rock of the plain, saith the LORD; which say, Who shall come down against us? or who shall enter into our habitations?
-14. But I will punish you according to the fruit of your doings, saith the LORD: and I will kindle a fire in the forest thereof, and it shall devour all things round about it. 
+14. But I will punish you according to the fruit of your doings, saith the LORD: and I will kindle a fire in the forest thereof, and it shall devour all things round about it.
 * 22
 1. Thus saith the LORD; Go down to the house of the king of Judah, and speak there this word,
 2. And say, Hear the word of the LORD, O king of Judah, that sittest upon the throne of David, thou, and thy servants, and thy people that enter in by these gates:
@@ -630,7 +630,7 @@
 27. But to the land whereunto they desire to return, thither shall they not return.
 28. /Is/ this man Coniah a despised broken idol? /is he/ a vessel wherein /is/ no pleasure? wherefore are they cast out, he and his seed, and are cast into a land which they know not?
 29. O earth, earth, earth, hear the word of the LORD.
-30. Thus saith the LORD, Write ye this man childless, a man /that/ shall not prosper in his days: for no man of his seed shall prosper, sitting upon the throne of David, and ruling any more in Judah. 
+30. Thus saith the LORD, Write ye this man childless, a man /that/ shall not prosper in his days: for no man of his seed shall prosper, sitting upon the throne of David, and ruling any more in Judah.
 * 23
 1. Woe be unto the pastors that destroy and scatter the sheep of my pasture! saith the LORD.
 2. Therefore thus saith the LORD God of Israel against the pastors that feed my people; Ye have scattered my flock, and driven them away, and have not visited them: behold, I will visit upon you the evil of your doings, saith the LORD.
@@ -674,7 +674,7 @@
 37. Thus shalt thou say to the prophet, What hath the LORD answered thee? and, What hath the LORD spoken?
 38. But since ye say, The burden of the LORD; therefore thus saith the LORD; Because ye say this word, The burden of the LORD, and I have sent unto you, saying, Ye shall not say, The burden of the LORD;
 39. Therefore, behold, I, even I, will utterly forget you, and I will forsake you, and the city that I gave you and your fathers, /and cast you/ out of my presence:
-40. And I will bring an everlasting reproach upon you, and a perpetual shame, which shall not be forgotten. 
+40. And I will bring an everlasting reproach upon you, and a perpetual shame, which shall not be forgotten.
 * 24
 1. The LORD shewed me, and, behold, two baskets of figs /were/ set before the temple of the LORD, after that Nebuchadrezzar king of Babylon had carried away captive Jeconiah the son of Jehoiakim king of Judah, and the princes of Judah, with the carpenters and smiths, from Jerusalem, and had brought them to Babylon.
 2. One basket /had/ very good figs, /even/ like the figs /that are/ first ripe: and the other basket /had/ very naughty figs, which could not be eaten, they were so bad.
@@ -687,7 +687,7 @@
 
 8. And as the evil figs, which cannot be eaten, they are so evil; surely thus saith the LORD, So will I give Zedekiah the king of Judah, and his princes, and the residue of Jerusalem, that remain in this land, and them that dwell in the land of Egypt:
 9. And I will deliver them to be removed into all the kingdoms of the earth for /their/ hurt, /to be/ a reproach and a proverb, a taunt and a curse, in all places whither I shall drive them.
-10. And I will send the sword, the famine, and the pestilence, among them, till they be consumed from off the land that I gave unto them and to their fathers. 
+10. And I will send the sword, the famine, and the pestilence, among them, till they be consumed from off the land that I gave unto them and to their fathers.
 * 25
 1. The word that came to Jeremiah concerning all the people of Judah in the fourth year of Jehoiakim the son of Josiah king of Judah, that /was/ the first year of Nebuchadrezzar king of Babylon;
 2. The which Jeremiah the prophet spake unto all the people of Judah, and to all the inhabitants of Jerusalem, saying,
@@ -730,7 +730,7 @@
 35. And the shepherds shall have no way to flee, nor the principal of the flock to escape.
 36. A voice of the cry of the shepherds, and an howling of the principal of the flock, /shall be heard/: for the LORD hath spoiled their pasture.
 37. And the peaceable habitations are cut down because of the fierce anger of the LORD.
-38. He hath forsaken his covert, as the lion: for their land is desolate because of the fierceness of the oppressor, and because of his fierce anger. 
+38. He hath forsaken his covert, as the lion: for their land is desolate because of the fierceness of the oppressor, and because of his fierce anger.
 * 26
 1. In the beginning of the reign of Jehoiakim the son of Josiah king of Judah came this word from the LORD, saying,
 2. Thus saith the LORD; Stand in the court of the LORD's house, and speak unto all the cities of Judah, which come to worship in the LORD's house, all the words that I command thee to speak unto them; diminish not a word:
@@ -759,7 +759,7 @@
 21. And when Jehoiakim the king, with all his mighty men, and all the princes, heard his words, the king sought to put him to death: but when Urijah heard it, he was afraid, and fled, and went into Egypt;
 22. And Jehoiakim the king sent men into Egypt, /namely/, Elnathan the son of Achbor, and /certain/ men with him into Egypt.
 23. And they fetched forth Urijah out of Egypt, and brought him unto Jehoiakim the king; who slew him with the sword, and cast his dead body into the graves of the common people.
-24. Nevertheless the hand of Ahikam the son of Shaphan was with Jeremiah, that they should not give him into the hand of the people to put him to death. 
+24. Nevertheless the hand of Ahikam the son of Shaphan was with Jeremiah, that they should not give him into the hand of the people to put him to death.
 * 27
 1. In the beginning of the reign of Jehoiakim the son of Josiah king of Judah came this word unto Jeremiah from the LORD, saying,
 2. Thus saith the LORD to me; Make thee bonds and yokes, and put them upon thy neck,
@@ -784,7 +784,7 @@
 19. For thus saith the LORD of hosts concerning the pillars, and concerning the sea, and concerning the bases, and concerning the residue of the vessels that remain in this city,
 20. Which Nebuchadnezzar king of Babylon took not, when he carried away captive Jeconiah the son of Jehoiakim king of Judah from Jerusalem to Babylon, and all the nobles of Judah and Jerusalem;
 21. Yea, thus saith the LORD of hosts, the God of Israel, concerning the vessels that remain /in/ the house of the LORD, and /in/ the house of the king of Judah and of Jerusalem;
-22. They shall be carried to Babylon, and there shall they be until the day that I visit them, saith the LORD; then will I bring them up, and restore them to this place. 
+22. They shall be carried to Babylon, and there shall they be until the day that I visit them, saith the LORD; then will I bring them up, and restore them to this place.
 * 28
 1. And it came to pass the same year, in the beginning of the reign of Zedekiah king of Judah, in the fourth year, /and/ in the fifth month, /that/ Hananiah the son of Azur the prophet, which /was/ of Gibeon, spake unto me in the house of the LORD, in the presence of the priests and of all the people, saying,
 2. Thus speaketh the LORD of hosts, the God of Israel, saying, I have broken the yoke of the king of Babylon.
@@ -806,7 +806,7 @@
 
 15. Then said the prophet Jeremiah unto Hananiah the prophet, Hear now, Hananiah; The LORD hath not sent thee; but thou makest this people to trust in a lie.
 16. Therefore thus saith the LORD; Behold, I will cast thee from off the face of the earth: this year thou shalt die, because thou hast taught rebellion against the LORD.
-17. So Hananiah the prophet died the same year in the seventh month. 
+17. So Hananiah the prophet died the same year in the seventh month.
 * 29
 1. Now these /are/ the words of the letter that Jeremiah the prophet sent from Jerusalem unto the residue of the elders which were carried away captives, and to the priests, and to the prophets, and to all the people whom Nebuchadnezzar had carried away captive from Jerusalem to Babylon;
 2. (After that Jeconiah the king, and the queen, and the eunuchs, the princes of Judah and Jerusalem, and the carpenters, and the smiths, were departed from Jerusalem;)
@@ -845,7 +845,7 @@
 
 30. Then came the word of the LORD unto Jeremiah, saying,
 31. Send to all them of the captivity, saying, Thus saith the LORD concerning Shemaiah the Nehelamite; Because that Shemaiah hath prophesied unto you, and I sent him not, and he caused you to trust in a lie:
-32. Therefore thus saith the LORD; Behold, I will punish Shemaiah the Nehelamite, and his seed: he shall not have a man to dwell among this people; neither shall he behold the good that I will do for my people, saith the LORD; because he hath taught rebellion against the LORD. 
+32. Therefore thus saith the LORD; Behold, I will punish Shemaiah the Nehelamite, and his seed: he shall not have a man to dwell among this people; neither shall he behold the good that I will do for my people, saith the LORD; because he hath taught rebellion against the LORD.
 * 30
 1. The word that came to Jeremiah from the LORD, saying,
 2. Thus speaketh the LORD God of Israel, saying, Write thee all the words that I have spoken unto thee in a book.
@@ -873,7 +873,7 @@
 21. And their nobles shall be of themselves, and their governor shall proceed from the midst of them; and I will cause him to draw near, and he shall approach unto me: for who /is/ this that engaged his heart to approach unto me? saith the LORD.
 22. And ye shall be my people, and I will be your God.
 23. Behold, the whirlwind of the LORD goeth forth with fury, a continuing whirlwind: it shall fall with pain upon the head of the wicked.
-24. The fierce anger of the LORD shall not return, until he have done /it/, and until he have performed the intents of his heart: in the latter days ye shall consider it. 
+24. The fierce anger of the LORD shall not return, until he have done /it/, and until he have performed the intents of his heart: in the latter days ye shall consider it.
 * 31
 1. At the same time, saith the LORD, will I be the God of all the families of Israel, and they shall be my people.
 2. Thus saith the LORD, The people /which were/ left of the sword found grace in the wilderness; /even/ Israel, when I went to cause him to rest.
@@ -922,7 +922,7 @@
 
 38. Behold, the days come, saith the LORD, that the city shall be built to the LORD from the tower of Hananeel unto the gate of the corner.
 39. And the measuring line shall yet go forth over against it upon the hill Gareb, and shall compass about to Goath.
-40. And the whole valley of the dead bodies, and of the ashes, and all the fields unto the brook of Kidron, unto the corner of the horse gate toward the east, /shall be/ holy unto the LORD; it shall not be plucked up, nor thrown down any more for ever. 
+40. And the whole valley of the dead bodies, and of the ashes, and all the fields unto the brook of Kidron, unto the corner of the horse gate toward the east, /shall be/ holy unto the LORD; it shall not be plucked up, nor thrown down any more for ever.
 * 32
 1. The word that came to Jeremiah from the LORD in the tenth year of Zedekiah king of Judah, which /was/ the eighteenth year of Nebuchadrezzar.
 2. For then the king of Babylon's army besieged Jerusalem: and Jeremiah the prophet was shut up in the court of the prison, which /was/ in the king of Judah's house.
@@ -972,7 +972,7 @@
 41. Yea, I will rejoice over them to do them good, and I will plant them in this land assuredly with my whole heart and with my whole soul.
 42. For thus saith the LORD; Like as I have brought all this great evil upon this people, so will I bring upon them all the good that I have promised them.
 43. And fields shall be bought in this land, whereof ye say, /It is/ desolate without man or beast; it is given into the hand of the Chaldeans.
-44. Men shall buy fields for money, and subscribe evidences, and seal /them/, and take witnesses in the land of Benjamin, and in the places about Jerusalem, and in the cities of Judah, and in the cities of the mountains, and in the cities of the valley, and in the cities of the south: for I will cause their captivity to return, saith the LORD. 
+44. Men shall buy fields for money, and subscribe evidences, and seal /them/, and take witnesses in the land of Benjamin, and in the places about Jerusalem, and in the cities of Judah, and in the cities of the mountains, and in the cities of the valley, and in the cities of the south: for I will cause their captivity to return, saith the LORD.
 * 33
 1. Moreover the word of the LORD came unto Jeremiah the second time, while he was yet shut up in the court of the prison, saying,
 2. Thus saith the LORD the maker thereof, the LORD that formed it, to establish it; the LORD /is/ his name;
@@ -1003,7 +1003,7 @@
 23. Moreover the word of the LORD came to Jeremiah, saying,
 24. Considerest thou not what this people have spoken, saying, The two families which the LORD hath chosen, he hath even cast them off? thus they have despised my people, that they should be no more a nation before them.
 25. Thus saith the LORD; If my covenant /be/ not with day and night, /and if/ I have not appointed the ordinances of heaven and earth;
-26. Then will I cast away the seed of Jacob, and David my servant, /so/ that I will not take /any/ of his seed /to be/ rulers over the seed of Abraham, Isaac, and Jacob: for I will cause their captivity to return, and have mercy on them. 
+26. Then will I cast away the seed of Jacob, and David my servant, /so/ that I will not take /any/ of his seed /to be/ rulers over the seed of Abraham, Isaac, and Jacob: for I will cause their captivity to return, and have mercy on them.
 * 34
 1. The word which came unto Jeremiah from the LORD, when Nebuchadnezzar king of Babylon, and all his army, and all the kingdoms of the earth of his dominion, and all the people, fought against Jerusalem, and against all the cities thereof, saying,
 2. Thus saith the LORD, the God of Israel; Go and speak to Zedekiah king of Judah, and tell him, Thus saith the LORD; Behold, I will give this city into the hand of the king of Babylon, and he shall burn it with fire:
@@ -1028,7 +1028,7 @@
 19. The princes of Judah, and the princes of Jerusalem, the eunuchs, and the priests, and all the people of the land, which passed between the parts of the calf;
 20. I will even give them into the hand of their enemies, and into the hand of them that seek their life: and their dead bodies shall be for meat unto the fowls of the heaven, and to the beasts of the earth.
 21. And Zedekiah king of Judah and his princes will I give into the hand of their enemies, and into the hand of them that seek their life, and into the hand of the king of Babylon's army, which are gone up from you.
-22. Behold, I will command, saith the LORD, and cause them to return to this city; and they shall fight against it, and take it, and burn it with fire: and I will make the cities of Judah a desolation without an inhabitant. 
+22. Behold, I will command, saith the LORD, and cause them to return to this city; and they shall fight against it, and take it, and burn it with fire: and I will make the cities of Judah a desolation without an inhabitant.
 * 35
 1. The word which came unto Jeremiah from the LORD in the days of Jehoiakim the son of Josiah king of Judah, saying,
 2. Go unto the house of the Rechabites, and speak unto them, and bring them into the house of the LORD, into one of the chambers, and give them wine to drink.
@@ -1050,7 +1050,7 @@
 17. Therefore thus saith the LORD God of hosts, the God of Israel; Behold, I will bring upon Judah and upon all the inhabitants of Jerusalem all the evil that I have pronounced against them: because I have spoken unto them, but they have not heard; and I have called unto them, but they have not answered.
 
 18. And Jeremiah said unto the house of the Rechabites, Thus saith the LORD of hosts, the God of Israel; Because ye have obeyed the commandment of Jonadab your father, and kept all his precepts, and done according unto all that he hath commanded you:
-19. Therefore thus saith the LORD of hosts, the God of Israel; Jonadab the son of Rechab shall not want a man to stand before me for ever. 
+19. Therefore thus saith the LORD of hosts, the God of Israel; Jonadab the son of Rechab shall not want a man to stand before me for ever.
 * 36
 1. And it came to pass in the fourth year of Jehoiakim the son of Josiah king of Judah, /that/ this word came unto Jeremiah from the LORD, saying,
 2. Take thee a roll of a book, and write therein all the words that I have spoken unto thee against Israel, and against Judah, and against all the nations, from the day I spake unto thee, from the days of Josiah, even unto this day.
@@ -1087,7 +1087,7 @@
 30. Therefore thus saith the LORD of Jehoiakim king of Judah; He shall have none to sit upon the throne of David: and his dead body shall be cast out in the day to the heat, and in the night to the frost.
 31. And I will punish him and his seed and his servants for their iniquity; and I will bring upon them, and upon the inhabitants of Jerusalem, and upon the men of Judah, all the evil that I have pronounced against them; but they hearkened not.
 
-32. Then took Jeremiah another roll, and gave it to Baruch the scribe, the son of Neriah; who wrote therein from the mouth of Jeremiah all the words of the book which Jehoiakim king of Judah had burned in the fire: and there were added besides unto them many like words. 
+32. Then took Jeremiah another roll, and gave it to Baruch the scribe, the son of Neriah; who wrote therein from the mouth of Jeremiah all the words of the book which Jehoiakim king of Judah had burned in the fire: and there were added besides unto them many like words.
 * 37
 1. And king Zedekiah the son of Josiah reigned instead of Coniah the son of Jehoiakim, whom Nebuchadrezzar king of Babylon made king in the land of Judah.
 2. But neither he, nor his servants, nor the people of the land, did hearken unto the words of the LORD, which he spake by the prophet Jeremiah.
@@ -1112,7 +1112,7 @@
 18. Moreover Jeremiah said unto king Zedekiah, What have I offended against thee, or against thy servants, or against this people, that ye have put me in prison?
 19. Where /are/ now your prophets which prophesied unto you, saying, The king of Babylon shall not come against you, nor against this land?
 20. Therefore hear now, I pray thee, O my lord the king: let my supplication, I pray thee, be accepted before thee; that thou cause me not to return to the house of Jonathan the scribe, lest I die there.
-21. Then Zedekiah the king commanded that they should commit Jeremiah into the court of the prison, and that they should give him daily a piece of bread out of the bakers' street, until all the bread in the city were spent. Thus Jeremiah remained in the court of the prison. 
+21. Then Zedekiah the king commanded that they should commit Jeremiah into the court of the prison, and that they should give him daily a piece of bread out of the bakers' street, until all the bread in the city were spent. Thus Jeremiah remained in the court of the prison.
 * 38
 1. Then Shephatiah the son of Mattan, and Gedaliah the son of Pashur, and Jucal the son of Shelemiah, and Pashur the son of Malchiah, heard the words that Jeremiah had spoken unto all the people, saying,
 2. Thus saith the LORD, He that remaineth in this city shall die by the sword, by the famine, and by the pestilence: but he that goeth forth to the Chaldeans shall live; for he shall have his life for a prey, and shall live.
@@ -1144,7 +1144,7 @@
 25. But if the princes hear that I have talked with thee, and they come unto thee, and say unto thee, Declare unto us now what thou hast said unto the king, hide it not from us, and we will not put thee to death; also what the king said unto thee:
 26. Then thou shalt say unto them, I presented my supplication before the king, that he would not cause me to return to Jonathan's house, to die there.
 27. Then came all the princes unto Jeremiah, and asked him: and he told them according to all these words that the king had commanded. So they left off speaking with him; for the matter was not perceived.
-28. So Jeremiah abode in the court of the prison until the day that Jerusalem was taken: and he was /there/ when Jerusalem was taken. 
+28. So Jeremiah abode in the court of the prison until the day that Jerusalem was taken: and he was /there/ when Jerusalem was taken.
 * 39
 1. In the ninth year of Zedekiah king of Judah, in the tenth month, came Nebuchadrezzar king of Babylon and all his army against Jerusalem, and they besieged it.
 2. /And/ in the eleventh year of Zedekiah, in the fourth month, the ninth /day/ of the month, the city was broken up.
@@ -1167,7 +1167,7 @@
 15. Now the word of the LORD came unto Jeremiah, while he was shut up in the court of the prison, saying,
 16. Go and speak to Ebed–melech the Ethiopian, saying, Thus saith the LORD of hosts, the God of Israel; Behold, I will bring my words upon this city for evil, and not for good; and they shall be /accomplished/ in that day before thee.
 17. But I will deliver thee in that day, saith the LORD: and thou shalt not be given into the hand of the men of whom thou /art/ afraid.
-18. For I will surely deliver thee, and thou shalt not fall by the sword, but thy life shall be for a prey unto thee: because thou hast put thy trust in me, saith the LORD. 
+18. For I will surely deliver thee, and thou shalt not fall by the sword, but thy life shall be for a prey unto thee: because thou hast put thy trust in me, saith the LORD.
 * 40
 1. The word that came to Jeremiah from the LORD, after that Nebuzar–adan the captain of the guard had let him go from Ramah, when he had taken him being bound in chains among all that were carried away captive of Jerusalem and Judah, which were carried away captive unto Babylon.
 2. And the captain of the guard took Jeremiah, and said unto him, The LORD thy God hath pronounced this evil upon this place.
@@ -1186,7 +1186,7 @@
 13. Moreover Johanan the son of Kareah, and all the captains of the forces that /were/ in the fields, came to Gedaliah to Mizpah,
 14. And said unto him, Dost thou certainly know that Baalis the king of the Ammonites hath sent Ishmael the son of Nethaniah to slay thee? But Gedaliah the son of Ahikam believed them not.
 15. Then Johanan the son of Kareah spake to Gedaliah in Mizpah secretly, saying, Let me go, I pray thee, and I will slay Ishmael the son of Nethaniah, and no man shall know /it/: wherefore should he slay thee, that all the Jews which are gathered unto thee should be scattered, and the remnant in Judah perish?
-16. But Gedaliah the son of Ahikam said unto Johanan the son of Kareah, Thou shalt not do this thing: for thou speakest falsely of Ishmael. 
+16. But Gedaliah the son of Ahikam said unto Johanan the son of Kareah, Thou shalt not do this thing: for thou speakest falsely of Ishmael.
 * 41
 1. Now it came to pass in the seventh month, /that/ Ishmael the son of Nethaniah the son of Elishama, of the seed royal, and the princes of the king, even ten men with him, came unto Gedaliah the son of Ahikam to Mizpah; and there they did eat bread together in Mizpah.
 2. Then arose Ishmael the son of Nethaniah, and the ten men that were with him, and smote Gedaliah the son of Ahikam the son of Shaphan with the sword, and slew him, whom the king of Babylon had made governor over the land.
@@ -1206,7 +1206,7 @@
 15. But Ishmael the son of Nethaniah escaped from Johanan with eight men, and went to the Ammonites.
 16. Then took Johanan the son of Kareah, and all the captains of the forces that /were/ with him, all the remnant of the people whom he had recovered from Ishmael the son of Nethaniah, from Mizpah, after /that/ he had slain Gedaliah the son of Ahikam, /even/ mighty men of war, and the women, and the children, and the eunuchs, whom he had brought again from Gibeon:
 17. And they departed, and dwelt in the habitation of Chimham, which is by Beth–lehem, to go to enter into Egypt,
-18. Because of the Chaldeans: for they were afraid of them, because Ishmael the son of Nethaniah had slain Gedaliah the son of Ahikam, whom the king of Babylon made governor in the land. 
+18. Because of the Chaldeans: for they were afraid of them, because Ishmael the son of Nethaniah had slain Gedaliah the son of Ahikam, whom the king of Babylon made governor in the land.
 * 42
 1. Then all the captains of the forces, and Johanan the son of Kareah, and Jezaniah the son of Hoshaiah, and all the people from the least even unto the greatest, came near,
 2. And said unto Jeremiah the prophet, Let, we beseech thee, our supplication be accepted before thee, and pray for us unto the LORD thy God, /even/ for all this remnant; (for we are left /but/ a few of many, as thine eyes do behold us:)
@@ -1232,7 +1232,7 @@
 19. The LORD hath said concerning you, O ye remnant of Judah; Go ye not into Egypt: know certainly that I have admonished you this day.
 20. For ye dissembled in your hearts, when ye sent me unto the LORD your God, saying, Pray for us unto the LORD our God; and according unto all that the LORD our God shall say, so declare unto us, and we will do /it/.
 21. And /now/ I have this day declared /it/ to you; but ye have not obeyed the voice of the LORD your God, nor any /thing/ for the which he hath sent me unto you.
-22. Now therefore know certainly that ye shall die by the sword, by the famine, and by the pestilence, in the place whither ye desire to go /and/ to sojourn. 
+22. Now therefore know certainly that ye shall die by the sword, by the famine, and by the pestilence, in the place whither ye desire to go /and/ to sojourn.
 * 43
 1. And it came to pass, /that/ when Jeremiah had made an end of speaking unto all the people all the words of the LORD their God, for which the LORD their God had sent him to them, /even/ all these words,
 2. Then spake Azariah the son of Hoshaiah, and Johanan the son of Kareah, and all the proud men, saying unto Jeremiah, Thou speakest falsely: the LORD our God hath not sent thee to say, Go not into Egypt to sojourn there:
@@ -1247,7 +1247,7 @@
 10. And say unto them, Thus saith the LORD of hosts, the God of Israel; Behold, I will send and take Nebuchadrezzar the king of Babylon, my servant, and will set his throne upon these stones that I have hid; and he shall spread his royal pavilion over them.
 11. And when he cometh, he shall smite the land of Egypt, /and deliver/ such /as are/ for death to death; and such /as are/ for captivity to captivity; and such /as are/ for the sword to the sword.
 12. And I will kindle a fire in the houses of the gods of Egypt; and he shall burn them, and carry them away captives: and he shall array himself with the land of Egypt, as a shepherd putteth on his garment; and he shall go forth from thence in peace.
-13. He shall break also the images of Beth–shemesh, that /is/ in the land of Egypt; and the houses of the gods of the Egyptians shall he burn with fire. 
+13. He shall break also the images of Beth–shemesh, that /is/ in the land of Egypt; and the houses of the gods of the Egyptians shall he burn with fire.
 * 44
 1. The word that came to Jeremiah concerning all the Jews which dwell in the land of Egypt, which dwell at Migdol, and at Tahpanhes, and at Noph, and in the country of Pathros, saying,
 2. Thus saith the LORD of hosts, the God of Israel; Ye have seen all the evil that I have brought upon Jerusalem, and upon all the cities of Judah; and, behold, this day they /are/ a desolation, and no man dwelleth therein,
@@ -1282,14 +1282,14 @@
 28. Yet a small number that escape the sword shall return out of the land of Egypt into the land of Judah, and all the remnant of Judah, that are gone into the land of Egypt to sojourn there, shall know whose words shall stand, mine, or theirs.
 
 29. And this /shall be/ a sign unto you, saith the LORD, that I will punish you in this place, that ye may know that my words shall surely stand against you for evil:
-30. Thus saith the LORD; Behold, I will give Pharaoh–hophra king of Egypt into the hand of his enemies, and into the hand of them that seek his life; as I gave Zedekiah king of Judah into the hand of Nebuchadrezzar king of Babylon, his enemy, and that sought his life. 
+30. Thus saith the LORD; Behold, I will give Pharaoh–hophra king of Egypt into the hand of his enemies, and into the hand of them that seek his life; as I gave Zedekiah king of Judah into the hand of Nebuchadrezzar king of Babylon, his enemy, and that sought his life.
 * 45
 1. The word that Jeremiah the prophet spake unto Baruch the son of Neriah, when he had written these words in a book at the mouth of Jeremiah, in the fourth year of Jehoiakim the son of Josiah king of Judah, saying,
 2. Thus saith the LORD, the God of Israel, unto thee, O Baruch;
 3. Thou didst say, Woe is me now! for the LORD hath added grief to my sorrow; I fainted in my sighing, and I find no rest.
 
 4. Thus shalt thou say unto him, The LORD saith thus; Behold, /that/ which I have built will I break down, and that which I have planted I will pluck up, even this whole land.
-5. And seekest thou great things for thyself? seek /them/ not: for, behold, I will bring evil upon all flesh, saith the LORD: but thy life will I give unto thee for a prey in all places whither thou goest. 
+5. And seekest thou great things for thyself? seek /them/ not: for, behold, I will bring evil upon all flesh, saith the LORD: but thy life will I give unto thee for a prey in all places whither thou goest.
 * 46
 1. The word of the LORD which came to Jeremiah the prophet against the Gentiles;
 2. Against Egypt, against the army of Pharaoh–necho king of Egypt, which was by the river Euphrates in Carchemish, which Nebuchadrezzar king of Babylon smote in the fourth year of Jehoiakim the son of Josiah king of Judah.
@@ -1320,7 +1320,7 @@
 26. And I will deliver them into the hand of those that seek their lives, and into the hand of Nebuchadrezzar king of Babylon, and into the hand of his servants: and afterward it shall be inhabited, as in the days of old, saith the LORD.
 
 27. But fear not thou, O my servant Jacob, and be not dismayed, O Israel: for, behold, I will save thee from afar off, and thy seed from the land of their captivity; and Jacob shall return, and be in rest and at ease, and none shall make /him/ afraid.
-28. Fear thou not, O Jacob my servant, saith the LORD: for I /am/ with thee; for I will make a full end of all the nations whither I have driven thee: but I will not make a full end of thee, but correct thee in measure; yet will I not leave thee wholly unpunished. 
+28. Fear thou not, O Jacob my servant, saith the LORD: for I /am/ with thee; for I will make a full end of all the nations whither I have driven thee: but I will not make a full end of thee, but correct thee in measure; yet will I not leave thee wholly unpunished.
 * 47
 1. The word of the LORD that came to Jeremiah the prophet against the Philistines, before that Pharaoh smote Gaza.
 2. Thus saith the LORD; Behold, waters rise up out of the north, and shall be an overflowing flood, and shall overflow the land, and all that is therein; the city, and them that dwell therein: then the men shall cry, and all the inhabitants of the land shall howl.
@@ -1328,7 +1328,7 @@
 4. Because of the day that cometh to spoil all the Philistines, /and/ to cut off from Tyrus and Zidon every helper that remaineth: for the LORD will spoil the Philistines, the remnant of the country of Caphtor.
 5. Baldness is come upon Gaza; Ashkelon is cut off /with/ the remnant of their valley: how long wilt thou cut thyself?
 6. O thou sword of the LORD, how long /will it be/ ere thou be quiet? put up thyself into thy scabbard, rest, and be still.
-7. How can it be quiet, seeing the LORD hath given it a charge against Ashkelon, and against the sea shore? there hath he appointed it. 
+7. How can it be quiet, seeing the LORD hath given it a charge against Ashkelon, and against the sea shore? there hath he appointed it.
 * 48
 1. Against Moab thus saith the LORD of hosts, the God of Israel; Woe unto Nebo! for it is spoiled: Kiriathaim is confounded /and/ taken: Misgab is confounded and dismayed.
 2. /There shall be/ no more praise of Moab: in Heshbon they have devised evil against it; come, and let us cut it off from /being/ a nation. Also thou shalt be cut down, O Madmen; the sword shall pursue thee.
@@ -1381,7 +1381,7 @@
 45. They that fled stood under the shadow of Heshbon because of the force: but a fire shall come forth out of Heshbon, and a flame from the midst of Sihon, and shall devour the corner of Moab, and the crown of the head of the tumultuous ones.
 46. Woe be unto thee, O Moab! the people of Chemosh perisheth: for thy sons are taken captives, and thy daughters captives.
 
-47. Yet will I bring again the captivity of Moab in the latter days, saith the LORD. Thus far /is/ the judgment of Moab. 
+47. Yet will I bring again the captivity of Moab in the latter days, saith the LORD. Thus far /is/ the judgment of Moab.
 * 49
 1. Concerning the Ammonites, thus saith the LORD; Hath Israel no sons? hath he no heir? why /then/ doth their king inherit Gad, and his people dwell in his cities?
 2. Therefore, behold, the days come, saith the LORD, that I will cause an alarm of war to be heard in Rabbah of the Ammonites; and it shall be a desolate heap, and her daughters shall be burned with fire: then shall Israel be heir unto them that were his heirs, saith the LORD.
@@ -1427,7 +1427,7 @@
 37. For I will cause Elam to be dismayed before their enemies, and before them that seek their life: and I will bring evil upon them, /even/ my fierce anger, saith the LORD; and I will send the sword after them, till I have consumed them:
 38. And I will set my throne in Elam, and will destroy from thence the king and the princes, saith the LORD.
 
-39. But it shall come to pass in the latter days, /that/ I will bring again the captivity of Elam, saith the LORD. 
+39. But it shall come to pass in the latter days, /that/ I will bring again the captivity of Elam, saith the LORD.
 * 50
 1. The word that the LORD spake against Babylon /and/ against the land of the Chaldeans by Jeremiah the prophet.
 2. Declare ye among the nations, and publish, and set up a standard; publish, /and/ conceal not: say, Babylon is taken, Bel is confounded, Merodach is broken in pieces; her idols are confounded, her images are broken in pieces.
@@ -1480,7 +1480,7 @@
 43. The king of Babylon hath heard the report of them, and his hands waxed feeble: anguish took hold of him, /and/ pangs as of a woman in travail.
 44. Behold, he shall come up like a lion from the swelling of Jordan unto the habitation of the strong: but I will make them suddenly run away from her: and who /is/ a chosen /man, that/ I may appoint over her? for who /is/ like me? and who will appoint me the time? and who /is/ that shepherd that will stand before me?
 45. Therefore hear ye the counsel of the LORD, that he hath taken against Babylon; and his purposes, that he hath purposed against the land of the Chaldeans: Surely the least of the flock shall draw them out: surely he shall make /their/ habitation desolate with them.
-46. At the noise of the taking of Babylon the earth is moved, and the cry is heard among the nations. 
+46. At the noise of the taking of Babylon the earth is moved, and the cry is heard among the nations.
 * 51
 1. Thus saith the LORD; Behold, I will raise up against Babylon, and against them that dwell in the midst of them that rise up against me, a destroying wind;
 2. And will send unto Babylon fanners, that shall fan her, and shall empty her land: for in the day of trouble they shall be against her round about.
@@ -1546,7 +1546,7 @@
 61. And Jeremiah said to Seraiah, When thou comest to Babylon, and shalt see, and shalt read all these words;
 62. Then shalt thou say, O LORD, thou hast spoken against this place, to cut it off, that none shall remain in it, neither man nor beast, but that it shall be desolate for ever.
 63. And it shall be, when thou hast made an end of reading this book, /that/ thou shalt bind a stone to it, and cast it into the midst of Euphrates:
-64. And thou shalt say, Thus shall Babylon sink, and shall not rise from the evil that I will bring upon her: and they shall be weary. Thus far /are/ the words of Jeremiah. 
+64. And thou shalt say, Thus shall Babylon sink, and shall not rise from the evil that I will bring upon her: and they shall be weary. Thus far /are/ the words of Jeremiah.
 * 52
 1. Zedekiah /was/ one and twenty years old when he began to reign, and he reigned eleven years in Jerusalem. And his mother's name /was/ Hamutal the daughter of Jeremiah of Libnah.
 2. And he did /that which was/ evil in the eyes of the LORD, according to all that Jehoiakim had done.
@@ -1586,4 +1586,4 @@
 31. And it came to pass in the seven and thirtieth year of the captivity of Jehoiachin king of Judah, in the twelfth month, in the five and twentieth /day/ of the month, /that/ Evil–merodach king of Babylon in the /first/ year of his reign lifted up the head of Jehoiachin king of Judah, and brought him forth out of prison,
 32. And spake kindly unto him, and set his throne above the throne of the kings that /were/ with him in Babylon,
 33. And changed his prison garments: and he did continually eat bread before him all the days of his life.
-34. And /for/ his diet, there was a continual diet given him of the king of Babylon, every day a portion until the day of his death, all the days of his life.  
+34. And /for/ his diet, there was a continual diet given him of the king of Babylon, every day a portion until the day of his death, all the days of his life.

--- a/25_LAM.org
+++ b/25_LAM.org
@@ -23,7 +23,7 @@
 19. I called for my lovers, /but/ they deceived me: my priests and mine elders gave up the ghost in the city, while they sought their meat to relieve their souls.
 20. Behold, O LORD; for I /am/ in distress: my bowels are troubled; mine heart is turned within me; for I have grievously rebelled: abroad the sword bereaveth, at home /there is/ as death.
 21. They have heard that I sigh: /there is/ none to comfort me: all mine enemies have heard of my trouble; they are glad that thou hast done /it/: thou wilt bring the day /that/ thou hast called, and they shall be like unto me.
-22. Let all their wickedness come before thee; and do unto them, as thou hast done unto me for all my transgressions: for my sighs /are/ many, and my heart /is/ faint. 
+22. Let all their wickedness come before thee; and do unto them, as thou hast done unto me for all my transgressions: for my sighs /are/ many, and my heart /is/ faint.
 * 2
 1. How hath the Lord covered the daughter of Zion with a cloud in his anger, /and/ cast down from heaven unto the earth the beauty of Israel, and remembered not his footstool in the day of his anger!
 2. The Lord hath swallowed up all the habitations of Jacob, and hath not pitied: he hath thrown down in his wrath the strong holds of the daughter of Judah; he hath brought /them/ down to the ground: he hath polluted the kingdom and the princes thereof.
@@ -47,7 +47,7 @@
 
 20. Behold, O LORD, and consider to whom thou hast done this. Shall the women eat their fruit, /and/ children of a span long? shall the priest and the prophet be slain in the sanctuary of the Lord?
 21. The young and the old lie on the ground in the streets: my virgins and my young men are fallen by the sword; thou hast slain /them/ in the day of thine anger; thou hast killed, /and/ not pitied.
-22. Thou hast called as in a solemn day my terrors round about, so that in the day of the LORD's anger none escaped nor remained: those that I have swaddled and brought up hath mine enemy consumed. 
+22. Thou hast called as in a solemn day my terrors round about, so that in the day of the LORD's anger none escaped nor remained: those that I have swaddled and brought up hath mine enemy consumed.
 * 3
 1. I /am/ the man /that/ hath seen affliction by the rod of his wrath.
 2. He hath led me, and brought /me into/ darkness, but not /into/ light.
@@ -118,7 +118,7 @@
 
 64. Render unto them a recompence, O LORD, according to the work of their hands.
 65. Give them sorrow of heart, thy curse unto them.
-66. Persecute and destroy them in anger from under the heavens of the LORD. 
+66. Persecute and destroy them in anger from under the heavens of the LORD.
 * 4
 1. How is the gold become dim! /how/ is the most fine gold changed! the stones of the sanctuary are poured out in the top of every street.
 2. The precious sons of Zion, comparable to fine gold, how are they esteemed as earthen pitchers, the work of the hands of the potter!
@@ -144,7 +144,7 @@
 
 21. Rejoice and be glad, O daughter of Edom, that dwellest in the land of Uz; the cup also shall pass through unto thee: thou shalt be drunken, and shalt make thyself naked.
 
-22. The punishment of thine iniquity is accomplished, O daughter of Zion; he will no more carry thee away into captivity: he will visit thine iniquity, O daughter of Edom; he will discover thy sins. 
+22. The punishment of thine iniquity is accomplished, O daughter of Zion; he will no more carry thee away into captivity: he will visit thine iniquity, O daughter of Edom; he will discover thy sins.
 * 5
 1. Remember, O LORD, what is come upon us: consider, and behold our reproach.
 2. Our inheritance is turned to strangers, our houses to aliens.
@@ -167,4 +167,4 @@
 19. Thou, O LORD, remainest for ever; thy throne from generation to generation.
 20. Wherefore dost thou forget us for ever, /and/ forsake us so long time?
 21. Turn thou us unto thee, O LORD, and we shall be turned; renew our days as of old.
-22. But thou hast utterly rejected us; thou art very wroth against us.  
+22. But thou hast utterly rejected us; thou art very wroth against us.

--- a/26_EZE.org
+++ b/26_EZE.org
@@ -30,7 +30,7 @@
 
 26. And above the firmament that /was/ over their heads /was/ the likeness of a throne, as the appearance of a sapphire stone: and upon the likeness of the throne /was/ the likeness as the appearance of a man above upon it.
 27. And I saw as the colour of amber, as the appearance of fire round about within it, from the appearance of his loins even upward, and from the appearance of his loins even downward, I saw as it were the appearance of fire, and it had brightness round about.
-28. As the appearance of the bow that is in the cloud in the day of rain, so /was/ the appearance of the brightness round about. This /was/ the appearance of the likeness of the glory of the LORD. And when I saw /it/, I fell upon my face, and I heard a voice of one that spake. 
+28. As the appearance of the bow that is in the cloud in the day of rain, so /was/ the appearance of the brightness round about. This /was/ the appearance of the likeness of the glory of the LORD. And when I saw /it/, I fell upon my face, and I heard a voice of one that spake.
 * 2
 1. And he said unto me, Son of man, stand upon thy feet, and I will speak unto thee.
 2. And the spirit entered into me when he spake unto me, and set me upon my feet, that I heard him that spake unto me.
@@ -43,7 +43,7 @@
 8. But thou, son of man, hear what I say unto thee; Be not thou rebellious like that rebellious house: open thy mouth, and eat that I give thee.
 
 9. And when I looked, behold, an hand /was/ sent unto me; and, lo, a roll of a book /was/ therein;
-10. And he spread it before me; and it /was/ written within and without: and /there was/ written therein lamentations, and mourning, and woe. 
+10. And he spread it before me; and it /was/ written within and without: and /there was/ written therein lamentations, and mourning, and woe.
 * 3
 1. Moreover he said unto me, Son of man, eat that thou findest; eat this roll, and go speak unto the house of Israel.
 2. So I opened my mouth, and he caused me to eat that roll.
@@ -74,7 +74,7 @@
 24. Then the spirit entered into me, and set me upon my feet, and spake with me, and said unto me, Go, shut thyself within thine house.
 25. But thou, O son of man, behold, they shall put bands upon thee, and shall bind thee with them, and thou shalt not go out among them:
 26. And I will make thy tongue cleave to the roof of thy mouth, that thou shalt be dumb, and shalt not be to them a reprover: for they /are/ a rebellious house.
-27. But when I speak with thee, I will open thy mouth, and thou shalt say unto them, Thus saith the Lord GOD; He that heareth, let him hear; and he that forbeareth, let him forbear: for they /are/ a rebellious house. 
+27. But when I speak with thee, I will open thy mouth, and thou shalt say unto them, Thus saith the Lord GOD; He that heareth, let him hear; and he that forbeareth, let him forbear: for they /are/ a rebellious house.
 * 4
 1. Thou also, son of man, take thee a tile, and lay it before thee, and pourtray upon it the city, /even/ Jerusalem:
 2. And lay siege against it, and build a fort against it, and cast a mount against it; set the camp also against it, and set /battering/ rams against it round about.
@@ -93,7 +93,7 @@
 14. Then said I, Ah Lord GOD! behold, my soul hath not been polluted: for from my youth up even till now have I not eaten of that which dieth of itself, or is torn in pieces; neither came there abominable flesh into my mouth.
 15. Then he said unto me, Lo, I have given thee cow's dung for man's dung, and thou shalt prepare thy bread therewith.
 16. Moreover he said unto me, Son of man, behold, I will break the staff of bread in Jerusalem: and they shall eat bread by weight, and with care; and they shall drink water by measure, and with astonishment:
-17. That they may want bread and water, and be astonied one with another, and consume away for their iniquity. 
+17. That they may want bread and water, and be astonied one with another, and consume away for their iniquity.
 * 5
 1. And thou, son of man, take thee a sharp knife, take thee a barber's razor, and cause /it/ to pass upon thine head and upon thy beard: then take thee balances to weigh, and divide the /hair/.
 2. Thou shalt burn with fire a third part in the midst of the city, when the days of the siege are fulfilled: and thou shalt take a third part, /and/ smite about it with a knife: and a third part thou shalt scatter in the wind; and I will draw out a sword after them.
@@ -113,7 +113,7 @@
 14. Moreover I will make thee waste, and a reproach among the nations that /are/ round about thee, in the sight of all that pass by.
 15. So it shall be a reproach and a taunt, an instruction and an astonishment unto the nations that /are/ round about thee, when I shall execute judgments in thee in anger and in fury and in furious rebukes. I the LORD have spoken /it/.
 16. When I shall send upon them the evil arrows of famine, which shall be for /their/ destruction, /and/ which I will send to destroy you: and I will increase the famine upon you, and will break your staff of bread:
-17. So will I send upon you famine and evil beasts, and they shall bereave thee; and pestilence and blood shall pass through thee; and I will bring the sword upon thee. I the LORD have spoken /it/. 
+17. So will I send upon you famine and evil beasts, and they shall bereave thee; and pestilence and blood shall pass through thee; and I will bring the sword upon thee. I the LORD have spoken /it/.
 * 6
 1. And the word of the LORD came unto me, saying,
 2. Son of man, set thy face toward the mountains of Israel, and prophesy against them,
@@ -130,7 +130,7 @@
 11. Thus saith the Lord GOD; Smite with thine hand, and stamp with thy foot, and say, Alas for all the evil abominations of the house of Israel! for they shall fall by the sword, by the famine, and by the pestilence.
 12. He that is far off shall die of the pestilence; and he that is near shall fall by the sword; and he that remaineth and is besieged shall die by the famine: thus will I accomplish my fury upon them.
 13. Then shall ye know that I /am/ the LORD, when their slain /men/ shall be among their idols round about their altars, upon every high hill, in all the tops of the mountains, and under every green tree, and under every thick oak, the place where they did offer sweet savour to all their idols.
-14. So will I stretch out my hand upon them, and make the land desolate, yea, more desolate than the wilderness toward Diblath, in all their habitations: and they shall know that I /am/ the LORD. 
+14. So will I stretch out my hand upon them, and make the land desolate, yea, more desolate than the wilderness toward Diblath, in all their habitations: and they shall know that I /am/ the LORD.
 * 7
 1. Moreover the word of the LORD came unto me, saying,
 2. Also, thou son of man, thus saith the Lord GOD unto the land of Israel; An end, the end is come upon the four corners of the land.
@@ -161,7 +161,7 @@
 24. Wherefore I will bring the worst of the heathen, and they shall possess their houses: I will also make the pomp of the strong to cease; and their holy places shall be defiled.
 25. Destruction cometh; and they shall seek peace, and /there shall be/ none.
 26. Mischief shall come upon mischief, and rumour shall be upon rumour; then shall they seek a vision of the prophet; but the law shall perish from the priest, and counsel from the ancients.
-27. The king shall mourn, and the prince shall be clothed with desolation, and the hands of the people of the land shall be troubled: I will do unto them after their way, and according to their deserts will I judge them; and they shall know that I /am/ the LORD. 
+27. The king shall mourn, and the prince shall be clothed with desolation, and the hands of the people of the land shall be troubled: I will do unto them after their way, and according to their deserts will I judge them; and they shall know that I /am/ the LORD.
 * 8
 1. And it came to pass in the sixth year, in the sixth /month/, in the fifth /day/ of the month, /as/ I sat in mine house, and the elders of Judah sat before me, that the hand of the Lord GOD fell there upon me.
 2. Then I beheld, and lo a likeness as the appearance of fire: from the appearance of his loins even downward, fire; and from his loins even upward, as the appearance of brightness, as the colour of amber.
@@ -185,7 +185,7 @@
 16. And he brought me into the inner court of the LORD's house, and, behold, at the door of the temple of the LORD, between the porch and the altar, /were/ about five and twenty men, with their backs toward the temple of the LORD, and their faces toward the east; and they worshipped the sun toward the east.
 
 17. Then he said unto me, Hast thou seen /this/, O son of man? Is it a light thing to the house of Judah that they commit the abominations which they commit here? for they have filled the land with violence, and have returned to provoke me to anger: and, lo, they put the branch to their nose.
-18. Therefore will I also deal in fury: mine eye shall not spare, neither will I have pity: and though they cry in mine ears with a loud voice, /yet/ will I not hear them. 
+18. Therefore will I also deal in fury: mine eye shall not spare, neither will I have pity: and though they cry in mine ears with a loud voice, /yet/ will I not hear them.
 * 9
 1. He cried also in mine ears with a loud voice, saying, Cause them that have charge over the city to draw near, even every man /with/ his destroying weapon in his hand.
 2. And, behold, six men came from the way of the higher gate, which lieth toward the north, and every man a slaughter weapon in his hand; and one man among them /was/ clothed with linen, with a writer's inkhorn by his side: and they went in, and stood beside the brasen altar.
@@ -199,7 +199,7 @@
 8. And it came to pass, while they were slaying them, and I was left, that I fell upon my face, and cried, and said, Ah Lord GOD! wilt thou destroy all the residue of Israel in thy pouring out of thy fury upon Jerusalem?
 9. Then said he unto me, The iniquity of the house of Israel and Judah /is/ exceeding great, and the land is full of blood, and the city full of perverseness: for they say, The LORD hath forsaken the earth, and the LORD seeth not.
 10. And as for me also, mine eye shall not spare, neither will I have pity, /but/ I will recompense their way upon their head.
-11. And, behold, the man clothed with linen, which /had/ the inkhorn by his side, reported the matter, saying, I have done as thou hast commanded me. 
+11. And, behold, the man clothed with linen, which /had/ the inkhorn by his side, reported the matter, saying, I have done as thou hast commanded me.
 * 10
 1. Then I looked, and, behold, in the firmament that was above the head of the cherubims there appeared over them as it were a sapphire stone, as the appearance of the likeness of a throne.
 2. And he spake unto the man clothed with linen, and said, Go in between the wheels, /even/ under the cherub, and fill thine hand with coals of fire from between the cherubims, and scatter /them/ over the city. And he went in in my sight.
@@ -223,7 +223,7 @@
 19. And the cherubims lifted up their wings, and mounted up from the earth in my sight: when they went out, the wheels also /were/ beside them, and /every one/ stood at the door of the east gate of the LORD's house; and the glory of the God of Israel /was/ over them above.
 20. This /is/ the living creature that I saw under the God of Israel by the river of Chebar; and I knew that they /were/ the cherubims.
 21. Every one had four faces apiece, and every one four wings; and the likeness of the hands of a man /was/ under their wings.
-22. And the likeness of their faces /was/ the same faces which I saw by the river of Chebar, their appearances and themselves: they went every one straight forward. 
+22. And the likeness of their faces /was/ the same faces which I saw by the river of Chebar, their appearances and themselves: they went every one straight forward.
 * 11
 1. Moreover the spirit lifted me up, and brought me unto the east gate of the LORD's house, which looketh eastward: and behold at the door of the gate five and twenty men; among whom I saw Jaazaniah the son of Azur, and Pelatiah the son of Benaiah, princes of the people.
 2. Then said he unto me, Son of man, these /are/ the men that devise mischief, and give wicked counsel in this city:
@@ -253,7 +253,7 @@
 23. And the glory of the LORD went up from the midst of the city, and stood upon the mountain which /is/ on the east side of the city.
 
 24. Afterwards the spirit took me up, and brought me in a vision by the Spirit of God into Chaldea, to them of the captivity. So the vision that I had seen went up from me.
-25. Then I spake unto them of the captivity all the things that the LORD had shewed me. 
+25. Then I spake unto them of the captivity all the things that the LORD had shewed me.
 * 12
 1. The word of the LORD also came unto me, saying,
 2. Son of man, thou dwellest in the midst of a rebellious house, which have eyes to see, and see not; they have ears to hear, and hear not: for they /are/ a rebellious house.
@@ -286,7 +286,7 @@
 
 26. Again the word of the LORD came to me, saying,
 27. Son of man, behold, /they of/ the house of Israel say, The vision that he seeth /is/ for many days /to come/, and he prophesieth of the times /that are/ far off.
-28. Therefore say unto them, Thus saith the Lord GOD; There shall none of my words be prolonged any more, but the word which I have spoken shall be done, saith the Lord GOD. 
+28. Therefore say unto them, Thus saith the Lord GOD; There shall none of my words be prolonged any more, but the word which I have spoken shall be done, saith the Lord GOD.
 * 13
 1. And the word of the LORD came unto me, saying,
 2. Son of man, prophesy against the prophets of Israel that prophesy, and say thou unto them that prophesy out of their own hearts, Hear ye the word of the LORD;
@@ -312,7 +312,7 @@
 20. Wherefore thus saith the Lord GOD; Behold, I /am/ against your pillows, wherewith ye there hunt the souls to make /them/ fly, and I will tear them from your arms, and will let the souls go, /even/ the souls that ye hunt to make /them/ fly.
 21. Your kerchiefs also will I tear, and deliver my people out of your hand, and they shall be no more in your hand to be hunted; and ye shall know that I /am/ the LORD.
 22. Because with lies ye have made the heart of the righteous sad, whom I have not made sad; and strengthened the hands of the wicked, that he should not return from his wicked way, by promising him life:
-23. Therefore ye shall see no more vanity, nor divine divinations: for I will deliver my people out of your hand: and ye shall know that I /am/ the LORD. 
+23. Therefore ye shall see no more vanity, nor divine divinations: for I will deliver my people out of your hand: and ye shall know that I /am/ the LORD.
 * 14
 1. Then came certain of the elders of Israel unto me, and sat before me.
 2. And the word of the LORD came unto me, saying,
@@ -342,7 +342,7 @@
 21. For thus saith the Lord GOD; How much more when I send my four sore judgments upon Jerusalem, the sword, and the famine, and the noisome beast, and the pestilence, to cut off from it man and beast?
 
 22. Yet, behold, therein shall be left a remnant that shall be brought forth, /both/ sons and daughters: behold, they shall come forth unto you, and ye shall see their way and their doings: and ye shall be comforted concerning the evil that I have brought upon Jerusalem, /even/ concerning all that I have brought upon it.
-23. And they shall comfort you, when ye see their ways and their doings: and ye shall know that I have not done without cause all that I have done in it, saith the Lord GOD. 
+23. And they shall comfort you, when ye see their ways and their doings: and ye shall know that I have not done without cause all that I have done in it, saith the Lord GOD.
 * 15
 1. And the word of the LORD came unto me, saying,
 2. Son of man, What is the vine tree more than any tree, /or than/ a branch which is among the trees of the forest?
@@ -352,7 +352,7 @@
 
 6. Therefore thus saith the Lord GOD; As the vine tree among the trees of the forest, which I have given to the fire for fuel, so will I give the inhabitants of Jerusalem.
 7. And I will set my face against them; they shall go out from /one/ fire, and /another/ fire shall devour them; and ye shall know that I /am/ the LORD, when I set my face against them.
-8. And I will make the land desolate, because they have committed a trespass, saith the Lord GOD. 
+8. And I will make the land desolate, because they have committed a trespass, saith the Lord GOD.
 * 16
 1. Again the word of the LORD came unto me, saying,
 2. Son of man, cause Jerusalem to know her abominations,
@@ -421,7 +421,7 @@
 60. Nevertheless I will remember my covenant with thee in the days of thy youth, and I will establish unto thee an everlasting covenant.
 61. Then thou shalt remember thy ways, and be ashamed, when thou shalt receive thy sisters, thine elder and thy younger: and I will give them unto thee for daughters, but not by thy covenant.
 62. And I will establish my covenant with thee; and thou shalt know that I /am/ the LORD:
-63. That thou mayest remember, and be confounded, and never open thy mouth any more because of thy shame, when I am pacified toward thee for all that thou hast done, saith the Lord GOD. 
+63. That thou mayest remember, and be confounded, and never open thy mouth any more because of thy shame, when I am pacified toward thee for all that thou hast done, saith the Lord GOD.
 * 17
 1. And the word of the LORD came unto me, saying,
 2. Son of man, put forth a riddle, and speak a parable unto the house of Israel;
@@ -448,7 +448,7 @@
 
 22. Thus saith the Lord GOD; I will also take of the highest branch of the high cedar, and will set /it/; I will crop off from the top of his young twigs a tender one, and will plant /it/ upon an high mountain and eminent:
 23. In the mountain of the height of Israel will I plant it: and it shall bring forth boughs, and bear fruit, and be a goodly cedar: and under it shall dwell all fowl of every wing; in the shadow of the branches thereof shall they dwell.
-24. And all the trees of the field shall know that I the LORD have brought down the high tree, have exalted the low tree, have dried up the green tree, and have made the dry tree to flourish: I the LORD have spoken and have done /it/. 
+24. And all the trees of the field shall know that I the LORD have brought down the high tree, have exalted the low tree, have dried up the green tree, and have made the dry tree to flourish: I the LORD have spoken and have done /it/.
 * 18
 1. The word of the LORD came unto me again, saying,
 2. What mean ye, that ye use this proverb concerning the land of Israel, saying, The fathers have eaten sour grapes, and the children's teeth are set on edge?
@@ -488,7 +488,7 @@
 30. Therefore I will judge you, O house of Israel, every one according to his ways, saith the Lord GOD. Repent, and turn /yourselves/ from all your transgressions; so iniquity shall not be your ruin.
 
 31. Cast away from you all your transgressions, whereby ye have transgressed; and make you a new heart and a new spirit: for why will ye die, O house of Israel?
-32. For I have no pleasure in the death of him that dieth, saith the Lord GOD: wherefore turn /yourselves/, and live ye. 
+32. For I have no pleasure in the death of him that dieth, saith the Lord GOD: wherefore turn /yourselves/, and live ye.
 * 19
 1. Moreover take thou up a lamentation for the princes of Israel,
 2. And say, What /is/ thy mother? A lioness: she lay down among lions, she nourished her whelps among young lions.
@@ -504,7 +504,7 @@
 11. And she had strong rods for the sceptres of them that bare rule, and her stature was exalted among the thick branches, and she appeared in her height with the multitude of her branches.
 12. But she was plucked up in fury, she was cast down to the ground, and the east wind dried up her fruit: her strong rods were broken and withered; the fire consumed them.
 13. And now she /is/ planted in the wilderness, in a dry and thirsty ground.
-14. And fire is gone out of a rod of her branches, /which/ hath devoured her fruit, so that she hath no strong rod /to be/ a sceptre to rule. This /is/ a lamentation, and shall be for a lamentation. 
+14. And fire is gone out of a rod of her branches, /which/ hath devoured her fruit, so that she hath no strong rod /to be/ a sceptre to rule. This /is/ a lamentation, and shall be for a lamentation.
 * 20
 1. And it came to pass in the seventh year, in the fifth /month/, the tenth /day/ of the month, /that/ certain of the elders of Israel came to enquire of the LORD, and sat before me.
 2. Then came the word of the LORD unto me, saying,
@@ -559,7 +559,7 @@
 46. Son of man, set thy face toward the south, and drop /thy word/ toward the south, and prophesy against the forest of the south field;
 47. And say to the forest of the south, Hear the word of the LORD; Thus saith the Lord GOD; Behold, I will kindle a fire in thee, and it shall devour every green tree in thee, and every dry tree: the flaming flame shall not be quenched, and all faces from the south to the north shall be burned therein.
 48. And all flesh shall see that I the LORD have kindled it: it shall not be quenched.
-49. Then said I, Ah Lord GOD! they say of me, Doth he not speak parables? 
+49. Then said I, Ah Lord GOD! they say of me, Doth he not speak parables?
 * 21
 1. And the word of the LORD came unto me, saying,
 2. Son of man, set thy face toward Jerusalem, and drop /thy word/ toward the holy places, and prophesy against the land of Israel,
@@ -596,7 +596,7 @@
 29. Whiles they see vanity unto thee, whiles they divine a lie unto thee, to bring thee upon the necks of /them that are/ slain, of the wicked, whose day is come, when their iniquity /shall have/ an end.
 30. Shall I cause /it/ to return into his sheath? I will judge thee in the place where thou wast created, in the land of thy nativity.
 31. And I will pour out mine indignation upon thee, I will blow against thee in the fire of my wrath, and deliver thee into the hand of brutish men, /and/ skilful to destroy.
-32. Thou shalt be for fuel to the fire; thy blood shall be in the midst of the land; thou shalt be no /more/ remembered: for I the LORD have spoken /it/. 
+32. Thou shalt be for fuel to the fire; thy blood shall be in the midst of the land; thou shalt be no /more/ remembered: for I the LORD have spoken /it/.
 * 22
 1. Moreover the word of the LORD came unto me, saying,
 2. Now, thou son of man, wilt thou judge, wilt thou judge the bloody city? yea, thou shalt shew her all her abominations.
@@ -630,7 +630,7 @@
 28. And her prophets have daubed them with untempered /morter/, seeing vanity, and divining lies unto them, saying, Thus saith the Lord GOD, when the LORD hath not spoken.
 29. The people of the land have used oppression, and exercised robbery, and have vexed the poor and needy: yea, they have oppressed the stranger wrongfully.
 30. And I sought for a man among them, that should make up the hedge, and stand in the gap before me for the land, that I should not destroy it: but I found none.
-31. Therefore have I poured out mine indignation upon them; I have consumed them with the fire of my wrath: their own way have I recompensed upon their heads, saith the Lord GOD. 
+31. Therefore have I poured out mine indignation upon them; I have consumed them with the fire of my wrath: their own way have I recompensed upon their heads, saith the Lord GOD.
 * 23
 1. The word of the LORD came again unto me, saying,
 2. Son of man, there were two women, the daughters of one mother:
@@ -683,7 +683,7 @@
 46. For thus saith the Lord GOD; I will bring up a company upon them, and will give them to be removed and spoiled.
 47. And the company shall stone them with stones, and dispatch them with their swords; they shall slay their sons and their daughters, and burn up their houses with fire.
 48. Thus will I cause lewdness to cease out of the land, that all women may be taught not to do after your lewdness.
-49. And they shall recompense your lewdness upon you, and ye shall bear the sins of your idols: and ye shall know that I /am/ the Lord GOD. 
+49. And they shall recompense your lewdness upon you, and ye shall bear the sins of your idols: and ye shall know that I /am/ the Lord GOD.
 * 24
 1. Again in the ninth year, in the tenth month, in the tenth /day/ of the month, the word of the LORD came unto me, saying,
 2. Son of man, write thee the name of the day, /even/ of this same day: the king of Babylon set himself against Jerusalem this same day.
@@ -714,7 +714,7 @@
 24. Thus Ezekiel is unto you a sign: according to all that he hath done shall ye do: and when this cometh, ye shall know that I /am/ the Lord GOD.
 25. Also, thou son of man, /shall it/ not /be/ in the day when I take from them their strength, the joy of their glory, the desire of their eyes, and that whereupon they set their minds, their sons and their daughters,
 26. /That/ he that escapeth in that day shall come unto thee, to cause /thee/ to hear /it/ with /thine/ ears?
-27. In that day shall thy mouth be opened to him which is escaped, and thou shalt speak, and be no more dumb: and thou shalt be a sign unto them; and they shall know that I /am/ the LORD. 
+27. In that day shall thy mouth be opened to him which is escaped, and thou shalt speak, and be no more dumb: and thou shalt be a sign unto them; and they shall know that I /am/ the LORD.
 * 25
 1. The word of the LORD came again unto me, saying,
 2. Son of man, set thy face against the Ammonites, and prophesy against them;
@@ -735,7 +735,7 @@
 
 15. Thus saith the Lord GOD; Because the Philistines have dealt by revenge, and have taken vengeance with a despiteful heart, to destroy /it/ for the old hatred;
 16. Therefore thus saith the Lord GOD; Behold, I will stretch out mine hand upon the Philistines, and I will cut off the Cherethims, and destroy the remnant of the sea coast.
-17. And I will execute great vengeance upon them with furious rebukes; and they shall know that I /am/ the LORD, when I shall lay my vengeance upon them. 
+17. And I will execute great vengeance upon them with furious rebukes; and they shall know that I /am/ the LORD, when I shall lay my vengeance upon them.
 * 26
 1. And it came to pass in the eleventh year, in the first /day/ of the month, /that/ the word of the LORD came unto me, saying,
 2. Son of man, because that Tyrus hath said against Jerusalem, Aha, she is broken /that was/ the gates of the people: she is turned unto me: I shall be replenished, /now/ she is laid waste:
@@ -759,7 +759,7 @@
 18. Now shall the isles tremble in the day of thy fall; yea, the isles that /are/ in the sea shall be troubled at thy departure.
 19. For thus saith the Lord GOD; When I shall make thee a desolate city, like the cities that are not inhabited; when I shall bring up the deep upon thee, and great waters shall cover thee;
 20. When I shall bring thee down with them that descend into the pit, with the people of old time, and shall set thee in the low parts of the earth, in places desolate of old, with them that go down to the pit, that thou be not inhabited; and I shall set glory in the land of the living;
-21. I will make thee a terror, and thou /shalt be/ no /more/: though thou be sought for, yet shalt thou never be found again, saith the Lord GOD. 
+21. I will make thee a terror, and thou /shalt be/ no /more/: though thou be sought for, yet shalt thou never be found again, saith the Lord GOD.
 * 27
 1. The word of the LORD came again unto me, saying,
 2. Now, thou son of man, take up a lamentation for Tyrus;
@@ -797,7 +797,7 @@
 33. When thy wares went forth out of the seas, thou filledst many people; thou didst enrich the kings of the earth with the multitude of thy riches and of thy merchandise.
 34. In the time /when/ thou shalt be broken by the seas in the depths of the waters thy merchandise and all thy company in the midst of thee shall fall.
 35. All the inhabitants of the isles shall be astonished at thee, and their kings shall be sore afraid, they shall be troubled in /their/ countenance.
-36. The merchants among the people shall hiss at thee; thou shalt be a terror, and never /shalt be/ any more. 
+36. The merchants among the people shall hiss at thee; thou shalt be a terror, and never /shalt be/ any more.
 * 28
 1. The word of the LORD came again unto me, saying,
 2. Son of man, say unto the prince of Tyrus, Thus saith the Lord GOD; Because thine heart /is/ lifted up, and thou hast said, I /am/ a God, I sit /in/ the seat of God, in the midst of the seas; yet thou /art/ a man, and not God, though thou set thine heart as the heart of God:
@@ -827,7 +827,7 @@
 
 24. And there shall be no more a pricking brier unto the house of Israel, nor /any/ grieving thorn of all /that are/ round about them, that despised them; and they shall know that I /am/ the Lord GOD.
 25. Thus saith the Lord GOD; When I shall have gathered the house of Israel from the people among whom they are scattered, and shall be sanctified in them in the sight of the heathen, then shall they dwell in their land that I have given to my servant Jacob.
-26. And they shall dwell safely therein, and shall build houses, and plant vineyards; yea, they shall dwell with confidence, when I have executed judgments upon all those that despise them round about them; and they shall know that I /am/ the LORD their God. 
+26. And they shall dwell safely therein, and shall build houses, and plant vineyards; yea, they shall dwell with confidence, when I have executed judgments upon all those that despise them round about them; and they shall know that I /am/ the LORD their God.
 * 29
 1. In the tenth year, in the tenth /month/, in the twelfth /day/ of the month, the word of the LORD came unto me, saying,
 2. Son of man, set thy face against Pharaoh king of Egypt, and prophesy against him, and against all Egypt:
@@ -853,7 +853,7 @@
 19. Therefore thus saith the Lord GOD; Behold, I will give the land of Egypt unto Nebuchadrezzar king of Babylon; and he shall take her multitude, and take her spoil, and take her prey; and it shall be the wages for his army.
 20. I have given him the land of Egypt /for/ his labour wherewith he served against it, because they wrought for me, saith the Lord GOD.
 
-21. In that day will I cause the horn of the house of Israel to bud forth, and I will give thee the opening of the mouth in the midst of them; and they shall know that I /am/ the LORD. 
+21. In that day will I cause the horn of the house of Israel to bud forth, and I will give thee the opening of the mouth in the midst of them; and they shall know that I /am/ the LORD.
 * 30
 1. The word of the LORD came again unto me, saying,
 2. Son of man, prophesy and say, Thus saith the Lord GOD; Howl ye, Woe worth the day!
@@ -881,7 +881,7 @@
 23. And I will scatter the Egyptians among the nations, and will disperse them through the countries.
 24. And I will strengthen the arms of the king of Babylon, and put my sword in his hand: but I will break Pharaoh's arms, and he shall groan before him with the groanings of a deadly wounded /man/.
 25. But I will strengthen the arms of the king of Babylon, and the arms of Pharaoh shall fall down; and they shall know that I /am/ the LORD, when I shall put my sword into the hand of the king of Babylon, and he shall stretch it out upon the land of Egypt.
-26. And I will scatter the Egyptians among the nations, and disperse them among the countries; and they shall know that I /am/ the LORD. 
+26. And I will scatter the Egyptians among the nations, and disperse them among the countries; and they shall know that I /am/ the LORD.
 * 31
 1. And it came to pass in the eleventh year, in the third /month/, in the first /day/ of the month, /that/ the word of the LORD came unto me, saying,
 2. Son of man, speak unto Pharaoh king of Egypt, and to his multitude; Whom art thou like in thy greatness?
@@ -903,7 +903,7 @@
 16. I made the nations to shake at the sound of his fall, when I cast him down to hell with them that descend into the pit: and all the trees of Eden, the choice and best of Lebanon, all that drink water, shall be comforted in the nether parts of the earth.
 17. They also went down into hell with him unto /them that be/ slain with the sword; and /they that were/ his arm, /that/ dwelt under his shadow in the midst of the heathen.
 
-18. To whom art thou thus like in glory and in greatness among the trees of Eden? yet shalt thou be brought down with the trees of Eden unto the nether parts of the earth: thou shalt lie in the midst of the uncircumcised with /them that be/ slain by the sword. This /is/ Pharaoh and all his multitude, saith the Lord GOD. 
+18. To whom art thou thus like in glory and in greatness among the trees of Eden? yet shalt thou be brought down with the trees of Eden unto the nether parts of the earth: thou shalt lie in the midst of the uncircumcised with /them that be/ slain by the sword. This /is/ Pharaoh and all his multitude, saith the Lord GOD.
 * 32
 1. And it came to pass in the twelfth year, in the twelfth month, in the first /day/ of the month, /that/ the word of the LORD came unto me, saying,
 2. Son of man, take up a lamentation for Pharaoh king of Egypt, and say unto him, Thou art like a young lion of the nations, and thou /art/ as a whale in the seas: and thou camest forth with thy rivers, and troubledst the waters with thy feet, and fouledst their rivers.
@@ -938,7 +938,7 @@
 29. There /is/ Edom, her kings, and all her princes, which with their might are laid by /them that were/ slain by the sword: they shall lie with the uncircumcised, and with them that go down to the pit.
 30. There /be/ the princes of the north, all of them, and all the Zidonians, which are gone down with the slain; with their terror they are ashamed of their might; and they lie uncircumcised with /them that be/ slain by the sword, and bear their shame with them that go down to the pit.
 31. Pharaoh shall see them, and shall be comforted over all his multitude, /even/ Pharaoh and all his army slain by the sword, saith the Lord GOD.
-32. For I have caused my terror in the land of the living: and he shall be laid in the midst of the uncircumcised with /them that are/ slain with the sword, /even/ Pharaoh and all his multitude, saith the Lord GOD. 
+32. For I have caused my terror in the land of the living: and he shall be laid in the midst of the uncircumcised with /them that are/ slain with the sword, /even/ Pharaoh and all his multitude, saith the Lord GOD.
 * 33
 1. Again the word of the LORD came unto me, saying,
 2. Son of man, speak to the children of thy people, and say unto them, When I bring the sword upon a land, if the people of the land take a man of their coasts, and set him for their watchman:
@@ -977,7 +977,7 @@
 30. Also, thou son of man, the children of thy people still are talking against thee by the walls and in the doors of the houses, and speak one to another, every one to his brother, saying, Come, I pray you, and hear what is the word that cometh forth from the LORD.
 31. And they come unto thee as the people cometh, and they sit before thee /as/ my people, and they hear thy words, but they will not do them: for with their mouth they shew much love, /but/ their heart goeth after their covetousness.
 32. And, lo, thou /art/ unto them as a very lovely song of one that hath a pleasant voice, and can play well on an instrument: for they hear thy words, but they do them not.
-33. And when this cometh to pass, (lo, it will come,) then shall they know that a prophet hath been among them. 
+33. And when this cometh to pass, (lo, it will come,) then shall they know that a prophet hath been among them.
 * 34
 1. And the word of the LORD came unto me, saying,
 2. Son of man, prophesy against the shepherds of Israel, prophesy, and say unto them, Thus saith the Lord GOD unto the shepherds; Woe /be/ to the shepherds of Israel that do feed themselves! should not the shepherds feed the flocks?
@@ -1012,7 +1012,7 @@
 28. And they shall no more be a prey to the heathen, neither shall the beast of the land devour them; but they shall dwell safely, and none shall make /them/ afraid.
 29. And I will raise up for them a plant of renown, and they shall be no more consumed with hunger in the land, neither bear the shame of the heathen any more.
 30. Thus shall they know that I the LORD their God /am/ with them, and /that/ they, /even/ the house of Israel, /are/ my people, saith the Lord GOD.
-31. And ye my flock, the flock of my pasture, /are/ men, /and/ I /am/ your God, saith the Lord GOD. 
+31. And ye my flock, the flock of my pasture, /are/ men, /and/ I /am/ your God, saith the Lord GOD.
 * 35
 1. Moreover the word of the LORD came unto me, saying,
 2. Son of man, set thy face against mount Seir, and prophesy against it,
@@ -1028,7 +1028,7 @@
 12. And thou shalt know that I /am/ the LORD, /and that/ I have heard all thy blasphemies which thou hast spoken against the mountains of Israel, saying, They are laid desolate, they are given us to consume.
 13. Thus with your mouth ye have boasted against me, and have multiplied your words against me: I have heard /them/.
 14. Thus saith the Lord GOD; When the whole earth rejoiceth, I will make thee desolate.
-15. As thou didst rejoice at the inheritance of the house of Israel, because it was desolate, so will I do unto thee: thou shalt be desolate, O mount Seir, and all Idumea, /even/ all of it: and they shall know that I /am/ the LORD. 
+15. As thou didst rejoice at the inheritance of the house of Israel, because it was desolate, so will I do unto thee: thou shalt be desolate, O mount Seir, and all Idumea, /even/ all of it: and they shall know that I /am/ the LORD.
 * 36
 1. Also, thou son of man, prophesy unto the mountains of Israel, and say, Ye mountains of Israel, hear the word of the LORD:
 2. Thus saith the Lord GOD; Because the enemy hath said against you, Aha, even the ancient high places are ours in possession:
@@ -1071,7 +1071,7 @@
 35. And they shall say, This land that was desolate is become like the garden of Eden; and the waste and desolate and ruined cities /are become/ fenced, /and/ are inhabited.
 36. Then the heathen that are left round about you shall know that I the LORD build the ruined /places, and/ plant that that was desolate: I the LORD have spoken /it/, and I will do /it/.
 37. Thus saith the Lord GOD; I will yet /for/ this be enquired of by the house of Israel, to do /it/ for them; I will increase them with men like a flock.
-38. As the holy flock, as the flock of Jerusalem in her solemn feasts; so shall the waste cities be filled with flocks of men: and they shall know that I /am/ the LORD. 
+38. As the holy flock, as the flock of Jerusalem in her solemn feasts; so shall the waste cities be filled with flocks of men: and they shall know that I /am/ the LORD.
 * 37
 1. The hand of the LORD was upon me, and carried me out in the spirit of the LORD, and set me down in the midst of the valley which /was/ full of bones,
 2. And caused me to pass by them round about: and, behold, /there were/ very many in the open valley; and, lo, /they were/ very dry.
@@ -1104,7 +1104,7 @@
 25. And they shall dwell in the land that I have given unto Jacob my servant, wherein your fathers have dwelt; and they shall dwell therein, /even/ they, and their children, and their children's children for ever: and my servant David /shall be/ their prince for ever.
 26. Moreover I will make a covenant of peace with them; it shall be an everlasting covenant with them: and I will place them, and multiply them, and will set my sanctuary in the midst of them for evermore.
 27. My tabernacle also shall be with them: yea, I will be their God, and they shall be my people.
-28. And the heathen shall know that I the LORD do sanctify Israel, when my sanctuary shall be in the midst of them for evermore. 
+28. And the heathen shall know that I the LORD do sanctify Israel, when my sanctuary shall be in the midst of them for evermore.
 * 38
 1. And the word of the LORD came unto me, saying,
 2. Son of man, set thy face against Gog, the land of Magog, the chief prince of Meshech and Tubal, and prophesy against him,
@@ -1130,7 +1130,7 @@
 20. So that the fishes of the sea, and the fowls of the heaven, and the beasts of the field, and all creeping things that creep upon the earth, and all the men that /are/ upon the face of the earth, shall shake at my presence, and the mountains shall be thrown down, and the steep places shall fall, and every wall shall fall to the ground.
 21. And I will call for a sword against him throughout all my mountains, saith the Lord GOD: every man's sword shall be against his brother.
 22. And I will plead against him with pestilence and with blood; and I will rain upon him, and upon his bands, and upon the many people that /are/ with him, an overflowing rain, and great hailstones, fire, and brimstone.
-23. Thus will I magnify myself, and sanctify myself; and I will be known in the eyes of many nations, and they shall know that I /am/ the LORD. 
+23. Thus will I magnify myself, and sanctify myself; and I will be known in the eyes of many nations, and they shall know that I /am/ the LORD.
 * 39
 1. Therefore, thou son of man, prophesy against Gog, and say, Thus saith the Lord GOD; Behold, I /am/ against thee, O Gog, the chief prince of Meshech and Tubal:
 2. And I will turn thee back, and leave but the sixth part of thee, and will cause thee to come up from the north parts, and will bring thee upon the mountains of Israel:
@@ -1164,7 +1164,7 @@
 26. After that they have borne their shame, and all their trespasses whereby they have trespassed against me, when they dwelt safely in their land, and none made /them/ afraid.
 27. When I have brought them again from the people, and gathered them out of their enemies' lands, and am sanctified in them in the sight of many nations;
 28. Then shall they know that I /am/ the LORD their God, which caused them to be led into captivity among the heathen: but I have gathered them unto their own land, and have left none of them any more there.
-29. Neither will I hide my face any more from them: for I have poured out my spirit upon the house of Israel, saith the Lord GOD. 
+29. Neither will I hide my face any more from them: for I have poured out my spirit upon the house of Israel, saith the Lord GOD.
 * 40
 1. In the five and twentieth year of our captivity, in the beginning of the year, in the tenth /day/ of the month, in the fourteenth year after that the city was smitten, in the selfsame day the hand of the LORD was upon me, and brought me thither.
 2. In the visions of God brought he me into the land of Israel, and set me upon a very high mountain, by which /was/ as the frame of a city on the south.
@@ -1222,7 +1222,7 @@
 47. So he measured the court, an hundred cubits long, and an hundred cubits broad, foursquare; and the altar /that was/ before the house.
 
 48. And he brought me to the porch of the house, and measured /each/ post of the porch, five cubits on this side, and five cubits on that side: and the breadth of the gate /was/ three cubits on this side, and three cubits on that side.
-49. The length of the porch /was/ twenty cubits, and the breadth eleven cubits; and /he brought me/ by the steps whereby they went up to it: and /there were/ pillars by the posts, one on this side, and another on that side. 
+49. The length of the porch /was/ twenty cubits, and the breadth eleven cubits; and /he brought me/ by the steps whereby they went up to it: and /there were/ pillars by the posts, one on this side, and another on that side.
 * 41
 1. Afterward he brought me to the temple, and measured the posts, six cubits broad on the one side, and six cubits broad on the other side, /which was/ the breadth of the tabernacle.
 2. And the breadth of the door /was/ ten cubits; and the sides of the door /were/ five cubits on the one side, and five cubits on the other side: and he measured the length thereof, forty cubits: and the breadth, twenty cubits.
@@ -1249,7 +1249,7 @@
 23. And the temple and the sanctuary had two doors.
 24. And the doors had two leaves /apiece/, two turning leaves; two /leaves/ for the one door, and two leaves for the other /door/.
 25. And /there were/ made on them, on the doors of the temple, cherubims and palm trees, like as /were/ made upon the walls; and /there were/ thick planks upon the face of the porch without.
-26. And /there were/ narrow windows and palm trees on the one side and on the other side, on the sides of the porch, and /upon/ the side chambers of the house, and thick planks. 
+26. And /there were/ narrow windows and palm trees on the one side and on the other side, on the sides of the porch, and /upon/ the side chambers of the house, and thick planks.
 * 42
 1. Then he brought me forth into the utter court, the way toward the north: and he brought me into the chamber that /was/ over against the separate place, and which /was/ before the building toward the north.
 2. Before the length of an hundred cubits /was/ the north door, and the breadth /was/ fifty cubits.
@@ -1272,7 +1272,7 @@
 18. He measured the south side, five hundred reeds, with the measuring reed.
 
 19. He turned about to the west side, /and/ measured five hundred reeds with the measuring reed.
-20. He measured it by the four sides: it had a wall round about, five hundred /reeds/ long, and five hundred broad, to make a separation between the sanctuary and the profane place. 
+20. He measured it by the four sides: it had a wall round about, five hundred /reeds/ long, and five hundred broad, to make a separation between the sanctuary and the profane place.
 * 43
 1. Afterward he brought me to the gate, /even/ the gate that looketh toward the east:
 2. And, behold, the glory of the God of Israel came from the way of the east: and his voice /was/ like a noise of many waters: and the earth shined with his glory.
@@ -1304,7 +1304,7 @@
 24. And thou shalt offer them before the LORD, and the priests shall cast salt upon them, and they shall offer them up /for/ a burnt offering unto the LORD.
 25. Seven days shalt thou prepare every day a goat /for/ a sin offering: they shall also prepare a young bullock, and a ram out of the flock, without blemish.
 26. Seven days shall they purge the altar and purify it; and they shall consecrate themselves.
-27. And when these days are expired, it shall be, /that/ upon the eighth day, and /so/ forward, the priests shall make your burnt offerings upon the altar, and your peace offerings; and I will accept you, saith the Lord GOD. 
+27. And when these days are expired, it shall be, /that/ upon the eighth day, and /so/ forward, the priests shall make your burnt offerings upon the altar, and your peace offerings; and I will accept you, saith the Lord GOD.
 * 44
 1. Then he brought me back the way of the gate of the outward sanctuary which looketh toward the east; and it /was/ shut.
 2. Then said the LORD unto me; This gate shall be shut, it shall not be opened, and no man shall enter in by it; because the LORD, the God of Israel, hath entered in by it, therefore it shall be shut.
@@ -1340,7 +1340,7 @@
 28. And it shall be unto them for an inheritance: I /am/ their inheritance: and ye shall give them no possession in Israel: I /am/ their possession.
 29. They shall eat the meat offering, and the sin offering, and the trespass offering; and every dedicated thing in Israel shall be theirs.
 30. And the first of all the firstfruits of all /things/, and every oblation of all, of every /sort/ of your oblations, shall be the priest's: ye shall also give unto the priest the first of your dough, that he may cause the blessing to rest in thine house.
-31. The priests shall not eat of any thing that is dead of itself, or torn, whether it be fowl or beast. 
+31. The priests shall not eat of any thing that is dead of itself, or torn, whether it be fowl or beast.
 * 45
 1. Moreover, when ye shall divide by lot the land for inheritance, ye shall offer an oblation unto the LORD, an holy portion of the land: the length /shall be/ the length of five and twenty thousand /reeds/, and the breadth /shall be/ ten thousand. This /shall be/ holy in all the borders thereof round about.
 2. Of this there shall be for the sanctuary five hundred /in length/, with five hundred /in breadth/, square round about; and fifty cubits round about for the suburbs thereof.
@@ -1369,7 +1369,7 @@
 22. And upon that day shall the prince prepare for himself and for all the people of the land a bullock /for/ a sin offering.
 23. And seven days of the feast he shall prepare a burnt offering to the LORD, seven bullocks and seven rams without blemish daily the seven days; and a kid of the goats daily /for/ a sin offering.
 24. And he shall prepare a meat offering of an ephah for a bullock, and an ephah for a ram, and an hin of oil for an ephah.
-25. In the seventh /month/, in the fifteenth day of the month, shall he do the like in the feast of the seven days, according to the sin offering, according to the burnt offering, and according to the meat offering, and according to the oil. 
+25. In the seventh /month/, in the fifteenth day of the month, shall he do the like in the feast of the seven days, according to the sin offering, according to the burnt offering, and according to the meat offering, and according to the oil.
 * 46
 1. Thus saith the Lord GOD; The gate of the inner court that looketh toward the east shall be shut the six working days; but on the sabbath it shall be opened, and in the day of the new moon it shall be opened.
 2. And the prince shall enter by the way of the porch of /that/ gate without, and shall stand by the post of the gate, and the priests shall prepare his burnt offering and his peace offerings, and he shall worship at the threshold of the gate: then he shall go forth; but the gate shall not be shut until the evening.
@@ -1397,7 +1397,7 @@
 21. Then he brought me forth into the utter court, and caused me to pass by the four corners of the court; and, behold, in every corner of the court /there was/ a court.
 22. In the four corners of the court /there were/ courts joined of forty /cubits/ long and thirty broad: these four corners /were/ of one measure.
 23. And /there was/ a row /of building/ round about in them, round about them four, and /it was/ made with boiling places under the rows round about.
-24. Then said he unto me, These /are/ the places of them that boil, where the ministers of the house shall boil the sacrifice of the people. 
+24. Then said he unto me, These /are/ the places of them that boil, where the ministers of the house shall boil the sacrifice of the people.
 * 47
 1. Afterward he brought me again unto the door of the house; and, behold, waters issued out from under the threshold of the house eastward: for the forefront of the house /stood toward/ the east, and the waters came down from under from the right side of the house, at the south /side/ of the altar.
 2. Then brought he me out of the way of the gate northward, and led me about the way without unto the utter gate by the way that looketh eastward; and, behold, there ran out waters on the right side.
@@ -1424,7 +1424,7 @@
 21. So shall ye divide this land unto you according to the tribes of Israel.
 
 22. And it shall come to pass, /that/ ye shall divide it by lot for an inheritance unto you, and to the strangers that sojourn among you, which shall beget children among you: and they shall be unto you as born in the country among the children of Israel; they shall have inheritance with you among the tribes of Israel.
-23. And it shall come to pass, /that/ in what tribe the stranger sojourneth, there shall ye give /him/ his inheritance, saith the Lord GOD. 
+23. And it shall come to pass, /that/ in what tribe the stranger sojourneth, there shall ye give /him/ his inheritance, saith the Lord GOD.
 * 48
 1. Now these /are/ the names of the tribes. From the north end to the coast of the way of Hethlon, as one goeth to Hamath, Hazar–enan, the border of Damascus northward, to the coast of Hamath; for these are his sides east /and/ west; a /portion for/ Dan.
 2. And by the border of Dan, from the east side unto the west side, a /portion for/ Asher.
@@ -1464,4 +1464,4 @@
 32. And at the east side four thousand and five hundred: and three gates; and one gate of Joseph, one gate of Benjamin, one gate of Dan.
 33. And at the south side four thousand and five hundred measures: and three gates; one gate of Simeon, one gate of Issachar, one gate of Zebulun.
 34. At the west side four thousand and five hundred, /with/ their three gates; one gate of Gad, one gate of Asher, one gate of Naphtali.
-35. /It was/ round about eighteen thousand /measures/: and the name of the city from /that/ day /shall be/, The LORD /is/ there.  
+35. /It was/ round about eighteen thousand /measures/: and the name of the city from /that/ day /shall be/, The LORD /is/ there.

--- a/27_DAN.org
+++ b/27_DAN.org
@@ -23,7 +23,7 @@
 18. Now at the end of the days that the king had said he should bring them in, then the prince of the eunuchs brought them in before Nebuchadnezzar.
 19. And the king communed with them; and among them all was found none like Daniel, Hananiah, Mishael, and Azariah: therefore stood they before the king.
 20. And in all matters of wisdom /and/ understanding, that the king enquired of them, he found them ten times better than all the magicians /and/ astrologers that /were/ in all his realm.
-21. And Daniel continued /even/ unto the first year of king Cyrus. 
+21. And Daniel continued /even/ unto the first year of king Cyrus.
 * 2
 1. And in the second year of the reign of Nebuchadnezzar Nebuchadnezzar dreamed dreams, wherewith his spirit was troubled, and his sleep brake from him.
 2. Then the king commanded to call the magicians, and the astrologers, and the sorcerers, and the Chaldeans, for to shew the king his dreams. So they came and stood before the king.
@@ -80,7 +80,7 @@
 46. Then the king Nebuchadnezzar fell upon his face, and worshipped Daniel, and commanded that they should offer an oblation and sweet odours unto him.
 47. The king answered unto Daniel, and said, Of a truth /it is/, that your God /is/ a God of gods, and a Lord of kings, and a revealer of secrets, seeing thou couldest reveal this secret.
 48. Then the king made Daniel a great man, and gave him many great gifts, and made him ruler over the whole province of Babylon, and chief of the governors over all the wise /men/ of Babylon.
-49. Then Daniel requested of the king, and he set Shadrach, Meshach, and Abed–nego, over the affairs of the province of Babylon: but Daniel /sat/ in the gate of the king. 
+49. Then Daniel requested of the king, and he set Shadrach, Meshach, and Abed–nego, over the affairs of the province of Babylon: but Daniel /sat/ in the gate of the king.
 * 3
 1. Nebuchadnezzar the king made an image of gold, whose height /was/ threescore cubits, /and/ the breadth thereof six cubits: he set it up in the plain of Dura, in the province of Babylon.
 2. Then Nebuchadnezzar the king sent to gather together the princes, the governors, and the captains, the judges, the treasurers, the counsellors, the sheriffs, and all the rulers of the provinces, to come to the dedication of the image which Nebuchadnezzar the king had set up.
@@ -115,7 +115,7 @@
 27. And the princes, governors, and captains, and the king's counsellors, being gathered together, saw these men, upon whose bodies the fire had no power, nor was an hair of their head singed, neither were their coats changed, nor the smell of fire had passed on them.
 28. /Then/ Nebuchadnezzar spake, and said, Blessed /be/ the God of Shadrach, Meshach, and Abed–nego, who hath sent his angel, and delivered his servants that trusted in him, and have changed the king's word, and yielded their bodies, that they might not serve nor worship any god, except their own God.
 29. Therefore I make a decree, That every people, nation, and language, which speak any thing amiss against the God of Shadrach, Meshach, and Abed–nego, shall be cut in pieces, and their houses shall be made a dunghill: because there is no other God that can deliver after this sort.
-30. Then the king promoted Shadrach, Meshach, and Abed–nego, in the province of Babylon. 
+30. Then the king promoted Shadrach, Meshach, and Abed–nego, in the province of Babylon.
 * 4
 1. Nebuchadnezzar the king, unto all people, nations, and languages, that dwell in all the earth; Peace be multiplied unto you.
 2. I thought it good to shew the signs and wonders that the high God hath wrought toward me.
@@ -157,7 +157,7 @@
 34. And at the end of the days I Nebuchadnezzar lifted up mine eyes unto heaven, and mine understanding returned unto me, and I blessed the most High, and I praised and honoured him that liveth for ever, whose dominion /is/ an everlasting dominion, and his kingdom /is/ from generation to generation:
 35. And all the inhabitants of the earth /are/ reputed as nothing: and he doeth according to his will in the army of heaven, and /among/ the inhabitants of the earth: and none can stay his hand, or say unto him, What doest thou?
 36. At the same time my reason returned unto me; and for the glory of my kingdom, mine honour and brightness returned unto me; and my counsellors and my lords sought unto me; and I was established in my kingdom, and excellent majesty was added unto me.
-37. Now I Nebuchadnezzar praise and extol and honour the King of heaven, all whose works /are/ truth, and his ways judgment: and those that walk in pride he is able to abase. 
+37. Now I Nebuchadnezzar praise and extol and honour the King of heaven, all whose works /are/ truth, and his ways judgment: and those that walk in pride he is able to abase.
 * 5
 1. Belshazzar the king made a great feast to a thousand of his lords, and drank wine before the thousand.
 2. Belshazzar, whiles he tasted the wine, commanded to bring the golden and silver vessels which his father Nebuchadnezzar had taken out of the temple which /was/ in Jerusalem; that the king, and his princes, his wives, and his concubines, might drink therein.
@@ -194,7 +194,7 @@
 29. Then commanded Belshazzar, and they clothed Daniel with scarlet, and /put/ a chain of gold about his neck, and made a proclamation concerning him, that he should be the third ruler in the kingdom.
 
 30. In that night was Belshazzar the king of the Chaldeans slain.
-31. And Darius the Median took the kingdom, /being/ about threescore and two years old. 
+31. And Darius the Median took the kingdom, /being/ about threescore and two years old.
 * 6
 1. It pleased Darius to set over the kingdom an hundred and twenty princes, which should be over the whole kingdom;
 2. And over these three presidents; of whom Daniel /was/ first: that the princes might give accounts unto them, and the king should have no damage.
@@ -228,7 +228,7 @@
 25. Then king Darius wrote unto all people, nations, and languages, that dwell in all the earth; Peace be multiplied unto you.
 26. I make a decree, That in every dominion of my kingdom men tremble and fear before the God of Daniel: for he /is/ the living God, and stedfast for ever, and his kingdom /that/ which shall not be destroyed, and his dominion /shall be even/ unto the end.
 27. He delivereth and rescueth, and he worketh signs and wonders in heaven and in earth, who hath delivered Daniel from the power of the lions.
-28. So this Daniel prospered in the reign of Darius, and in the reign of Cyrus the Persian. 
+28. So this Daniel prospered in the reign of Darius, and in the reign of Cyrus the Persian.
 * 7
 1. In the first year of Belshazzar king of Babylon Daniel had a dream and visions of his head upon his bed: then he wrote the dream, /and/ told the sum of the matters.
 2. Daniel spake and said, I saw in my vision by night, and, behold, the four winds of the heaven strove upon the great sea.
@@ -259,7 +259,7 @@
 25. And he shall speak /great/ words against the most High, and shall wear out the saints of the most High, and think to change times and laws: and they shall be given into his hand until a time and times and the dividing of time.
 26. But the judgment shall sit, and they shall take away his dominion, to consume and to destroy /it/ unto the end.
 27. And the kingdom and dominion, and the greatness of the kingdom under the whole heaven, shall be given to the people of the saints of the most High, whose kingdom /is/ an everlasting kingdom, and all dominions shall serve and obey him.
-28. Hitherto /is/ the end of the matter. As for me Daniel, my cogitations much troubled me, and my countenance changed in me: but I kept the matter in my heart. 
+28. Hitherto /is/ the end of the matter. As for me Daniel, my cogitations much troubled me, and my countenance changed in me: but I kept the matter in my heart.
 * 8
 1. In the third year of the reign of king Belshazzar a vision appeared unto me, /even unto/ me Daniel, after that which appeared unto me at the first.
 2. And I saw in a vision; and it came to pass, when I saw, that I /was/ at Shushan /in/ the palace, which /is/ in the province of Elam; and I saw in a vision, and I was by the river of Ulai.
@@ -289,7 +289,7 @@
 24. And his power shall be mighty, but not by his own power: and he shall destroy wonderfully, and shall prosper, and practise, and shall destroy the mighty and the holy people.
 25. And through his policy also he shall cause craft to prosper in his hand; and he shall magnify /himself/ in his heart, and by peace shall destroy many: he shall also stand up against the Prince of princes; but he shall be broken without hand.
 26. And the vision of the evening and the morning which was told /is/ true: wherefore shut thou up the vision; for it /shall be/ for many days.
-27. And I Daniel fainted, and was sick /certain/ days; afterward I rose up, and did the king's business; and I was astonished at the vision, but none understood /it/. 
+27. And I Daniel fainted, and was sick /certain/ days; afterward I rose up, and did the king's business; and I was astonished at the vision, but none understood /it/.
 * 9
 1. In the first year of Darius the son of Ahasuerus, of the seed of the Medes, which was made king over the realm of the Chaldeans;
 2. In the first year of his reign I Daniel understood by books the number of the years, whereof the word of the LORD came to Jeremiah the prophet, that he would accomplish seventy years in the desolations of Jerusalem.
@@ -320,7 +320,7 @@
 24. Seventy weeks are determined upon thy people and upon thy holy city, to finish the transgression, and to make an end of sins, and to make reconciliation for iniquity, and to bring in everlasting righteousness, and to seal up the vision and prophecy, and to anoint the most Holy.
 25. Know therefore and understand, /that/ from the going forth of the commandment to restore and to build Jerusalem unto the Messiah the Prince /shall be/ seven weeks, and threescore and two weeks: the street shall be built again, and the wall, even in troublous times.
 26. And after threescore and two weeks shall Messiah be cut off, but not for himself: and the people of the prince that shall come shall destroy the city and the sanctuary; and the end thereof /shall be/ with a flood, and unto the end of the war desolations are determined.
-27. And he shall confirm the covenant with many for one week: and in the midst of the week he shall cause the sacrifice and the oblation to cease, and for the overspreading of abominations he shall make /it/ desolate, even until the consummation, and that determined shall be poured upon the desolate. 
+27. And he shall confirm the covenant with many for one week: and in the midst of the week he shall cause the sacrifice and the oblation to cease, and for the overspreading of abominations he shall make /it/ desolate, even until the consummation, and that determined shall be poured upon the desolate.
 * 10
 1. In the third year of Cyrus king of Persia a thing was revealed unto Daniel, whose name was called Belteshazzar; and the thing /was/ true, but the time appointed /was/ long: and he understood the thing, and had understanding of the vision.
 2. In those days I Daniel was mourning three full weeks.
@@ -343,7 +343,7 @@
 18. Then there came again and touched me /one/ like the appearance of a man, and he strengthened me,
 19. And said, O man greatly beloved, fear not: peace /be/ unto thee, be strong, yea, be strong. And when he had spoken unto me, I was strengthened, and said, Let my lord speak; for thou hast strengthened me.
 20. Then said he, Knowest thou wherefore I come unto thee? and now will I return to fight with the prince of Persia: and when I am gone forth, lo, the prince of Grecia shall come.
-21. But I will shew thee that which is noted in the scripture of truth: and /there is/ none that holdeth with me in these things, but Michael your prince. 
+21. But I will shew thee that which is noted in the scripture of truth: and /there is/ none that holdeth with me in these things, but Michael your prince.
 * 11
 1. Also I in the first year of Darius the Mede, /even/ I, stood to confirm and to strengthen him.
 2. And now will I shew thee the truth. Behold, there shall stand up yet three kings in Persia; and the fourth shall be far richer than /they/ all: and by his strength through his riches he shall stir up all against the realm of Grecia.
@@ -391,7 +391,7 @@
 42. He shall stretch forth his hand also upon the countries: and the land of Egypt shall not escape.
 43. But he shall have power over the treasures of gold and of silver, and over all the precious things of Egypt: and the Libyans and the Ethiopians /shall be/ at his steps.
 44. But tidings out of the east and out of the north shall trouble him: therefore he shall go forth with great fury to destroy, and utterly to make away many.
-45. And he shall plant the tabernacles of his palace between the seas in the glorious holy mountain; yet he shall come to his end, and none shall help him. 
+45. And he shall plant the tabernacles of his palace between the seas in the glorious holy mountain; yet he shall come to his end, and none shall help him.
 * 12
 1. And at that time shall Michael stand up, the great prince which standeth for the children of thy people: and there shall be a time of trouble, such as never was since there was a nation /even/ to that same time: and at that time thy people shall be delivered, every one that shall be found written in the book.
 2. And many of them that sleep in the dust of the earth shall awake, some to everlasting life, and some to shame /and/ everlasting contempt.
@@ -406,4 +406,4 @@
 10. Many shall be purified, and made white, and tried; but the wicked shall do wickedly: and none of the wicked shall understand; but the wise shall understand.
 11. And from the time /that/ the daily /sacrifice/ shall be taken away, and the abomination that maketh desolate set up, /there shall be/ a thousand two hundred and ninety days.
 12. Blessed /is/ he that waiteth, and cometh to the thousand three hundred and five and thirty days.
-13. But go thou thy way till the end /be/: for thou shalt rest, and stand in thy lot at the end of the days.  
+13. But go thou thy way till the end /be/: for thou shalt rest, and stand in thy lot at the end of the days.

--- a/28_HOS.org
+++ b/28_HOS.org
@@ -13,7 +13,7 @@
 9. Then said /God/, Call his name Lo–ammi: for ye /are/ not my people, and I will not be your /God/.
 
 10. Yet the number of the children of Israel shall be as the sand of the sea, which cannot be measured nor numbered; and it shall come to pass, /that/ in the place where it was said unto them, Ye /are/ not my people, /there/ it shall be said unto them, /Ye are/ the sons of the living God.
-11. Then shall the children of Judah and the children of Israel be gathered together, and appoint themselves one head, and they shall come up out of the land: for great /shall be/ the day of Jezreel. 
+11. Then shall the children of Judah and the children of Israel be gathered together, and appoint themselves one head, and they shall come up out of the land: for great /shall be/ the day of Jezreel.
 * 2
 1. Say ye unto your brethren, Ammi; and to your sisters, Ru–hamah.
 2. Plead with your mother, plead: for she /is/ not my wife, neither /am/ I her husband: let her therefore put away her whoredoms out of her sight, and her adulteries from between her breasts;
@@ -39,13 +39,13 @@
 20. I will even betroth thee unto me in faithfulness: and thou shalt know the LORD.
 21. And it shall come to pass in that day, I will hear, saith the LORD, I will hear the heavens, and they shall hear the earth;
 22. And the earth shall hear the corn, and the wine, and the oil; and they shall hear Jezreel.
-23. And I will sow her unto me in the earth; and I will have mercy upon her that had not obtained mercy; and I will say to /them which were/ not my people, Thou /art/ my people; and they shall say, /Thou art/ my God. 
+23. And I will sow her unto me in the earth; and I will have mercy upon her that had not obtained mercy; and I will say to /them which were/ not my people, Thou /art/ my people; and they shall say, /Thou art/ my God.
 * 3
 1. Then said the LORD unto me, Go yet, love a woman beloved of /her/ friend, yet an adulteress, according to the love of the LORD toward the children of Israel, who look to other gods, and love flagons of wine.
 2. So I bought her to me for fifteen /pieces/ of silver, and /for/ an homer of barley, and an half homer of barley:
 3. And I said unto her, Thou shalt abide for me many days; thou shalt not play the harlot, and thou shalt not be for /another/ man: so /will/ I also /be/ for thee.
 4. For the children of Israel shall abide many days without a king, and without a prince, and without a sacrifice, and without an image, and without an ephod, and /without/ teraphim:
-5. Afterward shall the children of Israel return, and seek the LORD their God, and David their king; and shall fear the LORD and his goodness in the latter days. 
+5. Afterward shall the children of Israel return, and seek the LORD their God, and David their king; and shall fear the LORD and his goodness in the latter days.
 * 4
 1. Hear the word of the LORD, ye children of Israel: for the LORD hath a controversy with the inhabitants of the land, because /there is/ no truth, nor mercy, nor knowledge of God in the land.
 2. By swearing, and lying, and killing, and stealing, and committing adultery, they break out, and blood toucheth blood.
@@ -68,7 +68,7 @@
 16. For Israel slideth back as a backsliding heifer: now the LORD will feed them as a lamb in a large place.
 17. Ephraim /is/ joined to idols: let him alone.
 18. Their drink is sour: they have committed whoredom continually: her rulers /with/ shame do love, Give ye.
-19. The wind hath bound her up in her wings, and they shall be ashamed because of their sacrifices. 
+19. The wind hath bound her up in her wings, and they shall be ashamed because of their sacrifices.
 * 5
 1. Hear ye this, O priests; and hearken, ye house of Israel; and give ye ear, O house of the king; for judgment /is/ toward you, because ye have been a snare on Mizpah, and a net spread upon Tabor.
 2. And the revolters are profound to make slaughter, though I /have been/ a rebuker of them all.
@@ -85,7 +85,7 @@
 13. When Ephraim saw his sickness, and Judah /saw/ his wound, then went Ephraim to the Assyrian, and sent to king Jareb: yet could he not heal you, nor cure you of your wound.
 14. For I /will be/ unto Ephraim as a lion, and as a young lion to the house of Judah: I, /even/ I, will tear and go away; I will take away, and none shall rescue /him/.
 
-15. I will go /and/ return to my place, till they acknowledge their offence, and seek my face: in their affliction they will seek me early. 
+15. I will go /and/ return to my place, till they acknowledge their offence, and seek my face: in their affliction they will seek me early.
 * 6
 1. Come, and let us return unto the LORD: for he hath torn, and he will heal us; he hath smitten, and he will bind us up.
 2. After two days will he revive us: in the third day he will raise us up, and we shall live in his sight.
@@ -98,7 +98,7 @@
 8. Gilead /is/ a city of them that work iniquity, /and is/ polluted with blood.
 9. And as troops of robbers wait for a man, /so/ the company of priests murder in the way by consent: for they commit lewdness.
 10. I have seen an horrible thing in the house of Israel: there /is/ the whoredom of Ephraim, Israel is defiled.
-11. Also, O Judah, he hath set an harvest for thee, when I returned the captivity of my people. 
+11. Also, O Judah, he hath set an harvest for thee, when I returned the captivity of my people.
 * 7
 1. When I would have healed Israel, then the iniquity of Ephraim was discovered, and the wickedness of Samaria: for they commit falsehood; and the thief cometh in, /and/ the troop of robbers spoileth without.
 2. And they consider not in their hearts /that/ I remember all their wickedness: now their own doings have beset them about; they are before my face.
@@ -116,7 +116,7 @@
 13. Woe unto them! for they have fled from me: destruction unto them! because they have transgressed against me: though I have redeemed them, yet they have spoken lies against me.
 14. And they have not cried unto me with their heart, when they howled upon their beds: they assemble themselves for corn and wine, /and/ they rebel against me.
 15. Though I have bound /and/ strengthened their arms, yet do they imagine mischief against me.
-16. They return, /but/ not to the most High: they are like a deceitful bow: their princes shall fall by the sword for the rage of their tongue: this /shall be/ their derision in the land of Egypt. 
+16. They return, /but/ not to the most High: they are like a deceitful bow: their princes shall fall by the sword for the rage of their tongue: this /shall be/ their derision in the land of Egypt.
 * 8
 1. /Set/ the trumpet to thy mouth. /He shall come/ as an eagle against the house of the LORD, because they have transgressed my covenant, and trespassed against my law.
 2. Israel shall cry unto me, My God, we know thee.
@@ -132,7 +132,7 @@
 11. Because Ephraim hath made many altars to sin, altars shall be unto him to sin.
 12. I have written to him the great things of my law, /but/ they were counted as a strange thing.
 13. They sacrifice flesh /for/ the sacrifices of mine offerings, and eat /it; but/ the LORD accepteth them not; now will he remember their iniquity, and visit their sins: they shall return to Egypt.
-14. For Israel hath forgotten his Maker, and buildeth temples; and Judah hath multiplied fenced cities: but I will send a fire upon his cities, and it shall devour the palaces thereof. 
+14. For Israel hath forgotten his Maker, and buildeth temples; and Judah hath multiplied fenced cities: but I will send a fire upon his cities, and it shall devour the palaces thereof.
 * 9
 1. Rejoice not, O Israel, for joy, as /other/ people: for thou hast gone a whoring from thy God, thou hast loved a reward upon every cornfloor.
 2. The floor and the winepress shall not feed them, and the new wine shall fail in her.
@@ -150,7 +150,7 @@
 14. Give them, O LORD: what wilt thou give? give them a miscarrying womb and dry breasts.
 15. All their wickedness /is/ in Gilgal: for there I hated them: for the wickedness of their doings I will drive them out of mine house, I will love them no more: all their princes /are/ revolters.
 16. Ephraim is smitten, their root is dried up, they shall bear no fruit: yea, though they bring forth, yet will I slay /even/ the beloved /fruit/ of their womb.
-17. My God will cast them away, because they did not hearken unto him: and they shall be wanderers among the nations. 
+17. My God will cast them away, because they did not hearken unto him: and they shall be wanderers among the nations.
 * 10
 1. Israel /is/ an empty vine, he bringeth forth fruit unto himself: according to the multitude of his fruit he hath increased the altars; according to the goodness of his land they have made goodly images.
 2. Their heart is divided; now shall they be found faulty: he shall break down their altars, he shall spoil their images.
@@ -166,7 +166,7 @@
 12. Sow to yourselves in righteousness, reap in mercy; break up your fallow ground: for /it is/ time to seek the LORD, till he come and rain righteousness upon you.
 13. Ye have plowed wickedness, ye have reaped iniquity; ye have eaten the fruit of lies: because thou didst trust in thy way, in the multitude of thy mighty men.
 14. Therefore shall a tumult arise among thy people, and all thy fortresses shall be spoiled, as Shalman spoiled Beth–arbel in the day of battle: the mother was dashed in pieces upon /her/ children.
-15. So shall Beth–el do unto you because of your great wickedness: in a morning shall the king of Israel utterly be cut off. 
+15. So shall Beth–el do unto you because of your great wickedness: in a morning shall the king of Israel utterly be cut off.
 * 11
 1. When Israel /was/ a child, then I loved him, and called my son out of Egypt.
 2. /As/ they called them, so they went from them: they sacrificed unto Baalim, and burned incense to graven images.
@@ -180,7 +180,7 @@
 9. I will not execute the fierceness of mine anger, I will not return to destroy Ephraim: for I /am/ God, and not man; the Holy One in the midst of thee: and I will not enter into the city.
 10. They shall walk after the LORD: he shall roar like a lion: when he shall roar, then the children shall tremble from the west.
 11. They shall tremble as a bird out of Egypt, and as a dove out of the land of Assyria: and I will place them in their houses, saith the LORD.
-12. Ephraim compasseth me about with lies, and the house of Israel with deceit: but Judah yet ruleth with God, and is faithful with the saints. 
+12. Ephraim compasseth me about with lies, and the house of Israel with deceit: but Judah yet ruleth with God, and is faithful with the saints.
 * 12
 1. Ephraim feedeth on wind, and followeth after the east wind: he daily increaseth lies and desolation; and they do make a covenant with the Assyrians, and oil is carried into Egypt.
 2. The LORD hath also a controversy with Judah, and will punish Jacob according to his ways; according to his doings will he recompense him.
@@ -197,7 +197,7 @@
 11. /Is there/ iniquity /in/ Gilead? surely they are vanity: they sacrifice bullocks in Gilgal; yea, their altars /are/ as heaps in the furrows of the fields.
 12. And Jacob fled into the country of Syria, and Israel served for a wife, and for a wife he kept /sheep/.
 13. And by a prophet the LORD brought Israel out of Egypt, and by a prophet was he preserved.
-14. Ephraim provoked /him/ to anger most bitterly: therefore shall he leave his blood upon him, and his reproach shall his Lord return unto him. 
+14. Ephraim provoked /him/ to anger most bitterly: therefore shall he leave his blood upon him, and his reproach shall his Lord return unto him.
 * 13
 1. When Ephraim spake trembling, he exalted himself in Israel; but when he offended in Baal, he died.
 2. And now they sin more and more, and have made them molten images of their silver, /and/ idols according to their own understanding, all of it the work of the craftsmen: they say of them, Let the men that sacrifice kiss the calves.
@@ -217,7 +217,7 @@
 14. I will ransom them from the power of the grave; I will redeem them from death: O death, I will be thy plagues; O grave, I will be thy destruction: repentance shall be hid from mine eyes.
 
 15. Though he be fruitful among /his/ brethren, an east wind shall come, the wind of the LORD shall come up from the wilderness, and his spring shall become dry, and his fountain shall be dried up: he shall spoil the treasure of all pleasant vessels.
-16. Samaria shall become desolate; for she hath rebelled against her God: they shall fall by the sword: their infants shall be dashed in pieces, and their women with child shall be ripped up. 
+16. Samaria shall become desolate; for she hath rebelled against her God: they shall fall by the sword: their infants shall be dashed in pieces, and their women with child shall be ripped up.
 * 14
 1. O Israel, return unto the LORD thy God; for thou hast fallen by thine iniquity.
 2. Take with you words, and turn to the LORD: say unto him, Take away all iniquity, and receive /us/ graciously: so will we render the calves of our lips.
@@ -228,4 +228,4 @@
 6. His branches shall spread, and his beauty shall be as the olive tree, and his smell as Lebanon.
 7. They that dwell under his shadow shall return; they shall revive /as/ the corn, and grow as the vine: the scent thereof /shall be/ as the wine of Lebanon.
 8. Ephraim /shall say/, What have I to do any more with idols? I have heard /him/, and observed him: I /am/ like a green fir tree. From me is thy fruit found.
-9. Who /is/ wise, and he shall understand these /things/? prudent, and he shall know them? for the ways of the LORD /are/ right, and the just shall walk in them: but the transgressors shall fall therein.  
+9. Who /is/ wise, and he shall understand these /things/? prudent, and he shall know them? for the ways of the LORD /are/ right, and the just shall walk in them: but the transgressors shall fall therein.

--- a/29_JOL.org
+++ b/29_JOL.org
@@ -21,7 +21,7 @@
 17. The seed is rotten under their clods, the garners are laid desolate, the barns are broken down; for the corn is withered.
 18. How do the beasts groan! the herds of cattle are perplexed, because they have no pasture; yea, the flocks of sheep are made desolate.
 19. O LORD, to thee will I cry: for the fire hath devoured the pastures of the wilderness, and the flame hath burned all the trees of the field.
-20. The beasts of the field cry also unto thee: for the rivers of waters are dried up, and the fire hath devoured the pastures of the wilderness. 
+20. The beasts of the field cry also unto thee: for the rivers of waters are dried up, and the fire hath devoured the pastures of the wilderness.
 * 2
 1. Blow ye the trumpet in Zion, and sound an alarm in my holy mountain: let all the inhabitants of the land tremble: for the day of the LORD cometh, for /it is/ nigh at hand;
 2. A day of darkness and of gloominess, a day of clouds and of thick darkness, as the morning spread upon the mountains: a great people and a strong; there hath not been ever the like, neither shall be any more after it, /even/ to the years of many generations.
@@ -59,7 +59,7 @@
 29. And also upon the servants and upon the handmaids in those days will I pour out my spirit.
 30. And I will shew wonders in the heavens and in the earth, blood, and fire, and pillars of smoke.
 31. The sun shall be turned into darkness, and the moon into blood, before the great and the terrible day of the LORD come.
-32. And it shall come to pass, /that/ whosoever shall call on the name of the LORD shall be delivered: for in mount Zion and in Jerusalem shall be deliverance, as the LORD hath said, and in the remnant whom the LORD shall call. 
+32. And it shall come to pass, /that/ whosoever shall call on the name of the LORD shall be delivered: for in mount Zion and in Jerusalem shall be deliverance, as the LORD hath said, and in the remnant whom the LORD shall call.
 * 3
 1. For, behold, in those days, and in that time, when I shall bring again the captivity of Judah and Jerusalem,
 2. I will also gather all nations, and will bring them down into the valley of Jehoshaphat, and will plead with them there for my people and /for/ my heritage Israel, whom they have scattered among the nations, and parted my land.
@@ -83,4 +83,4 @@
 18. And it shall come to pass in that day, /that/ the mountains shall drop down new wine, and the hills shall flow with milk, and all the rivers of Judah shall flow with waters, and a fountain shall come forth of the house of the LORD, and shall water the valley of Shittim.
 19. Egypt shall be a desolation, and Edom shall be a desolate wilderness, for the violence /against/ the children of Judah, because they have shed innocent blood in their land.
 20. But Judah shall dwell for ever, and Jerusalem from generation to generation.
-21. For I will cleanse their blood /that/ I have not cleansed: for the LORD dwelleth in Zion.  
+21. For I will cleanse their blood /that/ I have not cleansed: for the LORD dwelleth in Zion.

--- a/30_AMO.org
+++ b/30_AMO.org
@@ -18,7 +18,7 @@
 
 13. Thus saith the LORD; For three transgressions of the children of Ammon, and for four, I will not turn away /the punishment/ thereof; because they have ripped up the women with child of Gilead, that they might enlarge their border:
 14. But I will kindle a fire in the wall of Rabbah, and it shall devour the palaces thereof, with shouting in the day of battle, with a tempest in the day of the whirlwind:
-15. And their king shall go into captivity, he and his princes together, saith the LORD. 
+15. And their king shall go into captivity, he and his princes together, saith the LORD.
 * 2
 1. Thus saith the LORD; For three transgressions of Moab, and for four, I will not turn away /the punishment/ thereof; because he burned the bones of the king of Edom into lime:
 2. But I will send a fire upon Moab, and it shall devour the palaces of Kerioth: and Moab shall die with tumult, with shouting, /and/ with the sound of the trumpet:
@@ -38,7 +38,7 @@
 13. Behold, I am pressed under you, as a cart is pressed /that is/ full of sheaves.
 14. Therefore the flight shall perish from the swift, and the strong shall not strengthen his force, neither shall the mighty deliver himself:
 15. Neither shall he stand that handleth the bow; and /he that is/ swift of foot shall not deliver /himself/: neither shall he that rideth the horse deliver himself.
-16. And /he that is/ courageous among the mighty shall flee away naked in that day, saith the LORD. 
+16. And /he that is/ courageous among the mighty shall flee away naked in that day, saith the LORD.
 * 3
 1. Hear this word that the LORD hath spoken against you, O children of Israel, against the whole family which I brought up from the land of Egypt, saying,
 2. You only have I known of all the families of the earth: therefore I will punish you for all your iniquities.
@@ -55,7 +55,7 @@
 12. Thus saith the LORD; As the shepherd taketh out of the mouth of the lion two legs, or a piece of an ear; so shall the children of Israel be taken out that dwell in Samaria in the corner of a bed, and in Damascus /in/ a couch.
 13. Hear ye, and testify in the house of Jacob, saith the Lord GOD, the God of hosts,
 14. That in the day that I shall visit the transgressions of Israel upon him I will also visit the altars of Beth–el: and the horns of the altar shall be cut off, and fall to the ground.
-15. And I will smite the winter house with the summer house; and the houses of ivory shall perish, and the great houses shall have an end, saith the LORD. 
+15. And I will smite the winter house with the summer house; and the houses of ivory shall perish, and the great houses shall have an end, saith the LORD.
 * 4
 1. Hear this word, ye kine of Bashan, that /are/ in the mountain of Samaria, which oppress the poor, which crush the needy, which say to their masters, Bring, and let us drink.
 2. The Lord GOD hath sworn by his holiness, that, lo, the days shall come upon you, that he will take you away with hooks, and your posterity with fishhooks.
@@ -71,7 +71,7 @@
 10. I have sent among you the pestilence after the manner of Egypt: your young men have I slain with the sword, and have taken away your horses; and I have made the stink of your camps to come up unto your nostrils: yet have ye not returned unto me, saith the LORD.
 11. I have overthrown /some/ of you, as God overthrew Sodom and Gomorrah, and ye were as a firebrand plucked out of the burning: yet have ye not returned unto me, saith the LORD.
 12. Therefore thus will I do unto thee, O Israel: /and/ because I will do this unto thee, prepare to meet thy God, O Israel.
-13. For, lo, he that formeth the mountains, and createth the wind, and declareth unto man what /is/ his thought, that maketh the morning darkness, and treadeth upon the high places of the earth, The LORD, The God of hosts, /is/ his name. 
+13. For, lo, he that formeth the mountains, and createth the wind, and declareth unto man what /is/ his thought, that maketh the morning darkness, and treadeth upon the high places of the earth, The LORD, The God of hosts, /is/ his name.
 * 5
 1. Hear ye this word which I take up against you, /even/ a lamentation, O house of Israel.
 2. The virgin of Israel is fallen; she shall no more rise: she is forsaken upon her land; /there is/ none to raise her up.
@@ -101,7 +101,7 @@
 24. But let judgment run down as waters, and righteousness as a mighty stream.
 25. Have ye offered unto me sacrifices and offerings in the wilderness forty years, O house of Israel?
 26. But ye have borne the tabernacle of your Moloch and Chiun your images, the star of your god, which ye made to yourselves.
-27. Therefore will I cause you to go into captivity beyond Damascus, saith the LORD, whose name /is/ The God of hosts. 
+27. Therefore will I cause you to go into captivity beyond Damascus, saith the LORD, whose name /is/ The God of hosts.
 * 6
 1. Woe to them /that are/ at ease in Zion, and trust in the mountain of Samaria, /which are/ named chief of the nations, to whom the house of Israel came!
 2. Pass ye unto Calneh, and see; and from thence go ye to Hamath the great: then go down to Gath of the Philistines: /be they/ better than these kingdoms? or their border greater than your border?
@@ -118,7 +118,7 @@
 
 12. Shall horses run upon the rock? will /one/ plow /there/ with oxen? for ye have turned judgment into gall, and the fruit of righteousness into hemlock:
 13. Ye which rejoice in a thing of nought, which say, Have we not taken to us horns by our own strength?
-14. But, behold, I will raise up against you a nation, O house of Israel, saith the LORD the God of hosts; and they shall afflict you from the entering in of Hemath unto the river of the wilderness. 
+14. But, behold, I will raise up against you a nation, O house of Israel, saith the LORD the God of hosts; and they shall afflict you from the entering in of Hemath unto the river of the wilderness.
 * 7
 1. Thus hath the Lord GOD shewed unto me; and, behold, he formed grasshoppers in the beginning of the shooting up of the latter growth; and, lo, /it was/ the latter growth after the king's mowings.
 2. And it came to pass, /that/ when they had made an end of eating the grass of the land, then I said, O Lord GOD, forgive, I beseech thee: by whom shall Jacob arise? for he /is/ small.
@@ -141,7 +141,7 @@
 15. And the LORD took me as I followed the flock, and the LORD said unto me, Go, prophesy unto my people Israel.
 
 16. Now therefore hear thou the word of the LORD: Thou sayest, Prophesy not against Israel, and drop not /thy word/ against the house of Isaac.
-17. Therefore thus saith the LORD; Thy wife shall be an harlot in the city, and thy sons and thy daughters shall fall by the sword, and thy land shall be divided by line; and thou shalt die in a polluted land: and Israel shall surely go into captivity forth of his land. 
+17. Therefore thus saith the LORD; Thy wife shall be an harlot in the city, and thy sons and thy daughters shall fall by the sword, and thy land shall be divided by line; and thou shalt die in a polluted land: and Israel shall surely go into captivity forth of his land.
 * 8
 1. Thus hath the Lord GOD shewed unto me: and behold a basket of summer fruit.
 2. And he said, Amos, what seest thou? And I said, A basket of summer fruit. Then said the LORD unto me, The end is come upon my people of Israel; I will not again pass by them any more.
@@ -158,7 +158,7 @@
 11. Behold, the days come, saith the Lord GOD, that I will send a famine in the land, not a famine of bread, nor a thirst for water, but of hearing the words of the LORD:
 12. And they shall wander from sea to sea, and from the north even to the east, they shall run to and fro to seek the word of the LORD, and shall not find /it/.
 13. In that day shall the fair virgins and young men faint for thirst.
-14. They that swear by the sin of Samaria, and say, Thy god, O Dan, liveth; and, The manner of Beer–sheba liveth; even they shall fall, and never rise up again. 
+14. They that swear by the sin of Samaria, and say, Thy god, O Dan, liveth; and, The manner of Beer–sheba liveth; even they shall fall, and never rise up again.
 * 9
 1. I saw the Lord standing upon the altar: and he said, Smite the lintel of the door, that the posts may shake: and cut them in the head, all of them; and I will slay the last of them with the sword: he that fleeth of them shall not flee away, and he that escapeth of them shall not be delivered.
 2. Though they dig into hell, thence shall mine hand take them; though they climb up to heaven, thence will I bring them down:
@@ -175,4 +175,4 @@
 12. That they may possess the remnant of Edom, and of all the heathen, which are called by my name, saith the LORD that doeth this.
 13. Behold, the days come, saith the LORD, that the plowman shall overtake the reaper, and the treader of grapes him that soweth seed; and the mountains shall drop sweet wine, and all the hills shall melt.
 14. And I will bring again the captivity of my people of Israel, and they shall build the waste cities, and inhabit /them/; and they shall plant vineyards, and drink the wine thereof; they shall also make gardens, and eat the fruit of them.
-15. And I will plant them upon their land, and they shall no more be pulled up out of their land which I have given them, saith the LORD thy God.  
+15. And I will plant them upon their land, and they shall no more be pulled up out of their land which I have given them, saith the LORD thy God.

--- a/31_OBA.org
+++ b/31_OBA.org
@@ -23,4 +23,4 @@
 18. And the house of Jacob shall be a fire, and the house of Joseph a flame, and the house of Esau for stubble, and they shall kindle in them, and devour them; and there shall not be /any/ remaining of the house of Esau; for the LORD hath spoken /it/.
 19. And /they of/ the south shall possess the mount of Esau; and /they of/ the plain the Philistines: and they shall possess the fields of Ephraim, and the fields of Samaria: and Benjamin /shall possess/ Gilead.
 20. And the captivity of this host of the children of Israel /shall possess/ that of the Canaanites, /even/ unto Zarephath; and the captivity of Jerusalem, which /is/ in Sepharad, shall possess the cities of the south.
-21. And saviours shall come up on mount Zion to judge the mount of Esau; and the kingdom shall be the LORD's.  
+21. And saviours shall come up on mount Zion to judge the mount of Esau; and the kingdom shall be the LORD's.

--- a/32_JON.org
+++ b/32_JON.org
@@ -19,7 +19,7 @@
 15. So they took up Jonah, and cast him forth into the sea: and the sea ceased from her raging.
 16. Then the men feared the LORD exceedingly, and offered a sacrifice unto the LORD, and made vows.
 
-17. Now the LORD had prepared a great fish to swallow up Jonah. And Jonah was in the belly of the fish three days and three nights. 
+17. Now the LORD had prepared a great fish to swallow up Jonah. And Jonah was in the belly of the fish three days and three nights.
 * 2
 1. Then Jonah prayed unto the LORD his God out of the fish's belly,
 2. And said, I cried by reason of mine affliction unto the LORD, and he heard me; out of the belly of hell cried I, /and/ thou heardest my voice.
@@ -31,7 +31,7 @@
 8. They that observe lying vanities forsake their own mercy.
 9. But I will sacrifice unto thee with the voice of thanksgiving; I will pay /that/ that I have vowed. Salvation /is/ of the LORD.
 
-10. And the LORD spake unto the fish, and it vomited out Jonah upon the dry /land/. 
+10. And the LORD spake unto the fish, and it vomited out Jonah upon the dry /land/.
 * 3
 1. And the word of the LORD came unto Jonah the second time, saying,
 2. Arise, go unto Nineveh, that great city, and preach unto it the preaching that I bid thee.
@@ -44,7 +44,7 @@
 8. But let man and beast be covered with sackcloth, and cry mightily unto God: yea, let them turn every one from his evil way, and from the violence that /is/ in their hands.
 9. Who can tell /if/ God will turn and repent, and turn away from his fierce anger, that we perish not?
 
-10. And God saw their works, that they turned from their evil way; and God repented of the evil, that he had said that he would do unto them; and he did /it/ not. 
+10. And God saw their works, that they turned from their evil way; and God repented of the evil, that he had said that he would do unto them; and he did /it/ not.
 * 4
 1. But it displeased Jonah exceedingly, and he was very angry.
 2. And he prayed unto the LORD, and said, I pray thee, O LORD, /was/ not this my saying, when I was yet in my country? Therefore I fled before unto Tarshish: for I knew that thou /art/ a gracious God, and merciful, slow to anger, and of great kindness, and repentest thee of the evil.
@@ -57,4 +57,4 @@
 8. And it came to pass, when the sun did arise, that God prepared a vehement east wind; and the sun beat upon the head of Jonah, that he fainted, and wished in himself to die, and said, /It is/ better for me to die than to live.
 9. And God said to Jonah, Doest thou well to be angry for the gourd? And he said, I do well to be angry, /even/ unto death.
 10. Then said the LORD, Thou hast had pity on the gourd, for the which thou hast not laboured, neither madest it grow; which came up in a night, and perished in a night:
-11. And should not I spare Nineveh, that great city, wherein are more than sixscore thousand persons that cannot discern between their right hand and their left hand; and /also/ much cattle?  
+11. And should not I spare Nineveh, that great city, wherein are more than sixscore thousand persons that cannot discern between their right hand and their left hand; and /also/ much cattle?

--- a/33_MIC.org
+++ b/33_MIC.org
@@ -16,7 +16,7 @@
 13. O thou inhabitant of Lachish, bind the chariot to the swift beast: she /is/ the beginning of the sin to the daughter of Zion: for the transgressions of Israel were found in thee.
 14. Therefore shalt thou give presents to Moresheth–gath: the houses of Achzib /shall be/ a lie to the kings of Israel.
 15. Yet will I bring an heir unto thee, O inhabitant of Mareshah: he shall come unto Adullam the glory of Israel.
-16. Make thee bald, and poll thee for thy delicate children; enlarge thy baldness as the eagle; for they are gone into captivity from thee. 
+16. Make thee bald, and poll thee for thy delicate children; enlarge thy baldness as the eagle; for they are gone into captivity from thee.
 * 2
 1. Woe to them that devise iniquity, and work evil upon their beds! when the morning is light, they practise it, because it is in the power of their hand.
 2. And they covet fields, and take /them/ by violence; and houses, and take /them/ away: so they oppress a man and his house, even a man and his heritage.
@@ -33,7 +33,7 @@
 11. If a man walking in the spirit and falsehood do lie, /saying/, I will prophesy unto thee of wine and of strong drink; he shall even be the prophet of this people.
 
 12. I will surely assemble, O Jacob, all of thee; I will surely gather the remnant of Israel; I will put them together as the sheep of Bozrah, as the flock in the midst of their fold: they shall make great noise by reason of /the multitude of/ men.
-13. The breaker is come up before them: they have broken up, and have passed through the gate, and are gone out by it: and their king shall pass before them, and the LORD on the head of them. 
+13. The breaker is come up before them: they have broken up, and have passed through the gate, and are gone out by it: and their king shall pass before them, and the LORD on the head of them.
 * 3
 1. And I said, Hear, I pray you, O heads of Jacob, and ye princes of the house of Israel; /Is it/ not for you to know judgment?
 2. Who hate the good, and love the evil; who pluck off their skin from off them, and their flesh from off their bones;
@@ -48,7 +48,7 @@
 9. Hear this, I pray you, ye heads of the house of Jacob, and princes of the house of Israel, that abhor judgment, and pervert all equity.
 10. They build up Zion with blood, and Jerusalem with iniquity.
 11. The heads thereof judge for reward, and the priests thereof teach for hire, and the prophets thereof divine for money: yet will they lean upon the LORD, and say, /Is/ not the LORD among us? none evil can come upon us.
-12. Therefore shall Zion for your sake be plowed /as/ a field, and Jerusalem shall become heaps, and the mountain of the house as the high places of the forest. 
+12. Therefore shall Zion for your sake be plowed /as/ a field, and Jerusalem shall become heaps, and the mountain of the house as the high places of the forest.
 * 4
 1. But in the last days it shall come to pass, /that/ the mountain of the house of the LORD shall be established in the top of the mountains, and it shall be exalted above the hills; and people shall flow unto it.
 2. And many nations shall come, and say, Come, and let us go up to the mountain of the LORD, and to the house of the God of Jacob; and he will teach us of his ways, and we will walk in his paths: for the law shall go forth of Zion, and the word of the LORD from Jerusalem.
@@ -65,7 +65,7 @@
 
 11. Now also many nations are gathered against thee, that say, Let her be defiled, and let our eye look upon Zion.
 12. But they know not the thoughts of the LORD, neither understand they his counsel: for he shall gather them as the sheaves into the floor.
-13. Arise and thresh, O daughter of Zion: for I will make thine horn iron, and I will make thy hoofs brass: and thou shalt beat in pieces many people: and I will consecrate their gain unto the LORD, and their substance unto the Lord of the whole earth. 
+13. Arise and thresh, O daughter of Zion: for I will make thine horn iron, and I will make thy hoofs brass: and thou shalt beat in pieces many people: and I will consecrate their gain unto the LORD, and their substance unto the Lord of the whole earth.
 * 5
 1. Now gather thyself in troops, O daughter of troops: he hath laid siege against us: they shall smite the judge of Israel with a rod upon the cheek.
 2. But thou, Beth–lehem Ephratah, /though/ thou be little among the thousands of Judah, /yet/ out of thee shall he come forth unto me /that is/ to be ruler in Israel; whose goings forth /have been/ from of old, from everlasting.
@@ -83,7 +83,7 @@
 12. And I will cut off witchcrafts out of thine hand; and thou shalt have no /more/ soothsayers:
 13. Thy graven images also will I cut off, and thy standing images out of the midst of thee; and thou shalt no more worship the work of thine hands.
 14. And I will pluck up thy groves out of the midst of thee: so will I destroy thy cities.
-15. And I will execute vengeance in anger and fury upon the heathen, such as they have not heard. 
+15. And I will execute vengeance in anger and fury upon the heathen, such as they have not heard.
 * 6
 1. Hear ye now what the LORD saith; Arise, contend thou before the mountains, and let the hills hear thy voice.
 2. Hear ye, O mountains, the LORD's controversy, and ye strong foundations of the earth: for the LORD hath a controversy with his people, and he will plead with Israel.
@@ -103,7 +103,7 @@
 14. Thou shalt eat, but not be satisfied; and thy casting down /shall be/ in the midst of thee; and thou shalt take hold, but shalt not deliver; and /that/ which thou deliverest will I give up to the sword.
 15. Thou shalt sow, but thou shalt not reap; thou shalt tread the olives, but thou shalt not anoint thee with oil; and sweet wine, but shalt not drink wine.
 
-16. For the statutes of Omri are kept, and all the works of the house of Ahab, and ye walk in their counsels; that I should make thee a desolation, and the inhabitants thereof an hissing: therefore ye shall bear the reproach of my people. 
+16. For the statutes of Omri are kept, and all the works of the house of Ahab, and ye walk in their counsels; that I should make thee a desolation, and the inhabitants thereof an hissing: therefore ye shall bear the reproach of my people.
 * 7
 1. Woe is me! for I am as when they have gathered the summer fruits, as the grapegleanings of the vintage: /there is/ no cluster to eat: my soul desired the firstripe fruit.
 2. The good /man/ is perished out of the earth: and /there is/ none upright among men: they all lie in wait for blood; they hunt every man his brother with a net.
@@ -129,4 +129,4 @@
 17. They shall lick the dust like a serpent, they shall move out of their holes like worms of the earth: they shall be afraid of the LORD our God, and shall fear because of thee.
 18. Who /is/ a God like unto thee, that pardoneth iniquity, and passeth by the transgression of the remnant of his heritage? he retaineth not his anger for ever, because he delighteth /in/ mercy.
 19. He will turn again, he will have compassion upon us; he will subdue our iniquities; and thou wilt cast all their sins into the depths of the sea.
-20. Thou wilt perform the truth to Jacob, /and/ the mercy to Abraham, which thou hast sworn unto our fathers from the days of old.  
+20. Thou wilt perform the truth to Jacob, /and/ the mercy to Abraham, which thou hast sworn unto our fathers from the days of old.

--- a/34_NAM.org
+++ b/34_NAM.org
@@ -14,7 +14,7 @@
 12. Thus saith the LORD; Though /they be/ quiet, and likewise many, yet thus shall they be cut down, when he shall pass through. Though I have afflicted thee, I will afflict thee no more.
 13. For now will I break his yoke from off thee, and will burst thy bonds in sunder.
 14. And the LORD hath given a commandment concerning thee, /that/ no more of thy name be sown: out of the house of thy gods will I cut off the graven image and the molten image: I will make thy grave; for thou art vile.
-15. Behold upon the mountains the feet of him that bringeth good tidings, that publisheth peace! O Judah, keep thy solemn feasts, perform thy vows: for the wicked shall no more pass through thee; he is utterly cut off. 
+15. Behold upon the mountains the feet of him that bringeth good tidings, that publisheth peace! O Judah, keep thy solemn feasts, perform thy vows: for the wicked shall no more pass through thee; he is utterly cut off.
 * 2
 1. He that dasheth in pieces is come up before thy face: keep the munition, watch the way, make /thy/ loins strong, fortify /thy/ power mightily.
 2. For the LORD hath turned away the excellency of Jacob, as the excellency of Israel: for the emptiers have emptied them out, and marred their vine branches.
@@ -28,7 +28,7 @@
 10. She is empty, and void, and waste: and the heart melteth, and the knees smite together, and much pain /is/ in all loins, and the faces of them all gather blackness.
 11. Where /is/ the dwelling of the lions, and the feedingplace of the young lions, where the lion, /even/ the old lion, walked, /and/ the lion's whelp, and none made /them/ afraid?
 12. The lion did tear in pieces enough for his whelps, and strangled for his lionesses, and filled his holes with prey, and his dens with ravin.
-13. Behold, I /am/ against thee, saith the LORD of hosts, and I will burn her chariots in the smoke, and the sword shall devour thy young lions: and I will cut off thy prey from the earth, and the voice of thy messengers shall no more be heard. 
+13. Behold, I /am/ against thee, saith the LORD of hosts, and I will burn her chariots in the smoke, and the sword shall devour thy young lions: and I will cut off thy prey from the earth, and the voice of thy messengers shall no more be heard.
 * 3
 1. Woe to the bloody city! it /is/ all full of lies /and/ robbery; the prey departeth not;
 2. The noise of a whip, and the noise of the rattling of the wheels, and of the pransing horses, and of the jumping chariots.
@@ -48,4 +48,4 @@
 16. Thou hast multiplied thy merchants above the stars of heaven: the cankerworm spoileth, and flieth away.
 17. Thy crowned /are/ as the locusts, and thy captains as the great grasshoppers, which camp in the hedges in the cold day, /but/ when the sun ariseth they flee away, and their place is not known where they /are/.
 18. Thy shepherds slumber, O king of Assyria: thy nobles shall dwell /in the dust/: thy people is scattered upon the mountains, and no man gathereth /them/.
-19. /There is/ no healing of thy bruise; thy wound is grievous: all that hear the bruit of thee shall clap the hands over thee: for upon whom hath not thy wickedness passed continually?  
+19. /There is/ no healing of thy bruise; thy wound is grievous: all that hear the bruit of thee shall clap the hands over thee: for upon whom hath not thy wickedness passed continually?

--- a/35_HAB.org
+++ b/35_HAB.org
@@ -18,7 +18,7 @@
 14. And makest men as the fishes of the sea, as the creeping things, /that have/ no ruler over them?
 15. They take up all of them with the angle, they catch them in their net, and gather them in their drag: therefore they rejoice and are glad.
 16. Therefore they sacrifice unto their net, and burn incense unto their drag; because by them their portion /is/ fat, and their meat plenteous.
-17. Shall they therefore empty their net, and not spare continually to slay the nations? 
+17. Shall they therefore empty their net, and not spare continually to slay the nations?
 * 2
 1. I will stand upon my watch, and set me upon the tower, and will watch to see what he will say unto me, and what I shall answer when I am reproved.
 2. And the LORD answered me, and said, Write the vision, and make /it/ plain upon tables, that he may run that readeth it.
@@ -44,7 +44,7 @@
 
 18. What profiteth the graven image that the maker thereof hath graven it; the molten image, and a teacher of lies, that the maker of his work trusteth therein, to make dumb idols?
 19. Woe unto him that saith to the wood, Awake; to the dumb stone, Arise, it shall teach! Behold, it /is/ laid over with gold and silver, and /there is/ no breath at all in the midst of it.
-20. But the LORD /is/ in his holy temple: let all the earth keep silence before him. 
+20. But the LORD /is/ in his holy temple: let all the earth keep silence before him.
 * 3
 1. A prayer of Habakkuk the prophet upon Shigionoth.
 2. O LORD, I have heard thy speech, /and/ was afraid: O LORD, revive thy work in the midst of the years, in the midst of the years make known; in wrath remember mercy.
@@ -65,4 +65,4 @@
 
 17. Although the fig tree shall not blossom, neither /shall/ fruit /be/ in the vines; the labour of the olive shall fail, and the fields shall yield no meat; the flock shall be cut off from the fold, and /there shall be/ no herd in the stalls:
 18. Yet I will rejoice in the LORD, I will joy in the God of my salvation.
-19. The LORD God /is/ my strength, and he will make my feet like hinds' /feet/, and he will make me to walk upon mine high places. To the chief singer on my stringed instruments.  
+19. The LORD God /is/ my strength, and he will make my feet like hinds' /feet/, and he will make me to walk upon mine high places. To the chief singer on my stringed instruments.

--- a/36_ZEP.org
+++ b/36_ZEP.org
@@ -17,7 +17,7 @@
 15. That day /is/ a day of wrath, a day of trouble and distress, a day of wasteness and desolation, a day of darkness and gloominess, a day of clouds and thick darkness,
 16. A day of the trumpet and alarm against the fenced cities, and against the high towers.
 17. And I will bring distress upon men, that they shall walk like blind men, because they have sinned against the LORD: and their blood shall be poured out as dust, and their flesh as the dung.
-18. Neither their silver nor their gold shall be able to deliver them in the day of the LORD's wrath; but the whole land shall be devoured by the fire of his jealousy: for he shall make even a speedy riddance of all them that dwell in the land. 
+18. Neither their silver nor their gold shall be able to deliver them in the day of the LORD's wrath; but the whole land shall be devoured by the fire of his jealousy: for he shall make even a speedy riddance of all them that dwell in the land.
 * 2
 1. Gather yourselves together, yea, gather together, O nation not desired;
 2. Before the decree bring forth, /before/ the day pass as the chaff, before the fierce anger of the LORD come upon you, before the day of the LORD's anger come upon you.
@@ -36,7 +36,7 @@
 12. Ye Ethiopians also, ye /shall be/ slain by my sword.
 13. And he will stretch out his hand against the north, and destroy Assyria; and will make Nineveh a desolation, /and/ dry like a wilderness.
 14. And flocks shall lie down in the midst of her, all the beasts of the nations: both the cormorant and the bittern shall lodge in the upper lintels of it; /their/ voice shall sing in the windows; desolation /shall be/ in the thresholds: for he shall uncover the cedar work.
-15. This /is/ the rejoicing city that dwelt carelessly, that said in her heart, I /am/, and /there is/ none beside me: how is she become a desolation, a place for beasts to lie down in! every one that passeth by her shall hiss, /and/ wag his hand. 
+15. This /is/ the rejoicing city that dwelt carelessly, that said in her heart, I /am/, and /there is/ none beside me: how is she become a desolation, a place for beasts to lie down in! every one that passeth by her shall hiss, /and/ wag his hand.
 * 3
 1. Woe to her that is filthy and polluted, to the oppressing city!
 2. She obeyed not the voice; she received not correction; she trusted not in the LORD; she drew not near to her God.
@@ -59,4 +59,4 @@
 17. The LORD thy God in the midst of thee /is/ mighty; he will save, he will rejoice over thee with joy; he will rest in his love, he will joy over thee with singing.
 18. I will gather /them that are/ sorrowful for the solemn assembly, /who/ are of thee, /to whom/ the reproach of it /was/ a burden.
 19. Behold, at that time I will undo all that afflict thee: and I will save her that halteth, and gather her that was driven out; and I will get them praise and fame in every land where they have been put to shame.
-20. At that time will I bring you /again/, even in the time that I gather you: for I will make you a name and a praise among all people of the earth, when I turn back your captivity before your eyes, saith the LORD.  
+20. At that time will I bring you /again/, even in the time that I gather you: for I will make you a name and a praise among all people of the earth, when I turn back your captivity before your eyes, saith the LORD.

--- a/37_HAG.org
+++ b/37_HAG.org
@@ -16,7 +16,7 @@
 12. Then Zerubbabel the son of Shealtiel, and Joshua the son of Josedech, the high priest, with all the remnant of the people, obeyed the voice of the LORD their God, and the words of Haggai the prophet, as the LORD their God had sent him, and the people did fear before the LORD.
 13. Then spake Haggai the LORD's messenger in the LORD's message unto the people, saying, I /am/ with you, saith the LORD.
 14. And the LORD stirred up the spirit of Zerubbabel the son of Shealtiel, governor of Judah, and the spirit of Joshua the son of Josedech, the high priest, and the spirit of all the remnant of the people; and they came and did work in the house of the LORD of hosts, their God,
-15. In the four and twentieth day of the sixth month, in the second year of Darius the king. 
+15. In the four and twentieth day of the sixth month, in the second year of Darius the king.
 * 2
 1. In the seventh /month/, in the one and twentieth /day/ of the month, came the word of the LORD by the prophet Haggai, saying,
 2. Speak now to Zerubbabel the son of Shealtiel, governor of Judah, and to Joshua the son of Josedech, the high priest, and to the residue of the people, saying,
@@ -42,4 +42,4 @@
 20. And again the word of the LORD came unto Haggai in the four and twentieth /day/ of the month, saying,
 21. Speak to Zerubbabel, governor of Judah, saying, I will shake the heavens and the earth;
 22. And I will overthrow the throne of kingdoms, and I will destroy the strength of the kingdoms of the heathen; and I will overthrow the chariots, and those that ride in them; and the horses and their riders shall come down, every one by the sword of his brother.
-23. In that day, saith the LORD of hosts, will I take thee, O Zerubbabel, my servant, the son of Shealtiel, saith the LORD, and will make thee as a signet: for I have chosen thee, saith the LORD of hosts.  
+23. In that day, saith the LORD of hosts, will I take thee, O Zerubbabel, my servant, the son of Shealtiel, saith the LORD, and will make thee as a signet: for I have chosen thee, saith the LORD of hosts.

--- a/38_ZEC.org
+++ b/38_ZEC.org
@@ -23,7 +23,7 @@
 18. Then lifted I up mine eyes, and saw, and behold four horns.
 19. And I said unto the angel that talked with me, What /be/ these? And he answered me, These /are/ the horns which have scattered Judah, Israel, and Jerusalem.
 20. And the LORD shewed me four carpenters.
-21. Then said I, What come these to do? And he spake, saying, These /are/ the horns which have scattered Judah, so that no man did lift up his head: but these are come to fray them, to cast out the horns of the Gentiles, which lifted up /their/ horn over the land of Judah to scatter it. 
+21. Then said I, What come these to do? And he spake, saying, These /are/ the horns which have scattered Judah, so that no man did lift up his head: but these are come to fray them, to cast out the horns of the Gentiles, which lifted up /their/ horn over the land of Judah to scatter it.
 * 2
 1. I lifted up mine eyes again, and looked, and behold a man with a measuring line in his hand.
 2. Then said I, Whither goest thou? And he said unto me, To measure Jerusalem, to see what /is/ the breadth thereof, and what /is/ the length thereof.
@@ -39,7 +39,7 @@
 10. Sing and rejoice, O daughter of Zion: for, lo, I come, and I will dwell in the midst of thee, saith the LORD.
 11. And many nations shall be joined to the LORD in that day, and shall be my people: and I will dwell in the midst of thee, and thou shalt know that the LORD of hosts hath sent me unto thee.
 12. And the LORD shall inherit Judah his portion in the holy land, and shall choose Jerusalem again.
-13. Be silent, O all flesh, before the LORD: for he is raised up out of his holy habitation. 
+13. Be silent, O all flesh, before the LORD: for he is raised up out of his holy habitation.
 * 3
 1. And he shewed me Joshua the high priest standing before the angel of the LORD, and Satan standing at his right hand to resist him.
 2. And the LORD said unto Satan, The LORD rebuke thee, O Satan; even the LORD that hath chosen Jerusalem rebuke thee: /is/ not this a brand plucked out of the fire?
@@ -50,7 +50,7 @@
 7. Thus saith the LORD of hosts; If thou wilt walk in my ways, and if thou wilt keep my charge, then thou shalt also judge my house, and shalt also keep my courts, and I will give thee places to walk among these that stand by.
 8. Hear now, O Joshua the high priest, thou, and thy fellows that sit before thee: for they /are/ men wondered at: for, behold, I will bring forth my servant the BRANCH.
 9. For behold the stone that I have laid before Joshua; upon one stone /shall be/ seven eyes: behold, I will engrave the graving thereof, saith the LORD of hosts, and I will remove the iniquity of that land in one day.
-10. In that day, saith the LORD of hosts, shall ye call every man his neighbour under the vine and under the fig tree. 
+10. In that day, saith the LORD of hosts, shall ye call every man his neighbour under the vine and under the fig tree.
 * 4
 1. And the angel that talked with me came again, and waked me, as a man that is wakened out of his sleep,
 2. And said unto me, What seest thou? And I said, I have looked, and behold a candlestick all /of/ gold, with a bowl upon the top of it, and his seven lamps thereon, and seven pipes to the seven lamps, which /are/ upon the top thereof:
@@ -66,7 +66,7 @@
 11. Then answered I, and said unto him, What /are/ these two olive trees upon the right /side/ of the candlestick and upon the left /side/ thereof?
 12. And I answered again, and said unto him, What /be these/ two olive branches which through the two golden pipes empty the golden /oil/ out of themselves?
 13. And he answered me and said, Knowest thou not what these /be/? And I said, No, my lord.
-14. Then said he, These /are/ the two anointed ones, that stand by the Lord of the whole earth. 
+14. Then said he, These /are/ the two anointed ones, that stand by the Lord of the whole earth.
 * 5
 1. Then I turned, and lifted up mine eyes, and looked, and behold a flying roll.
 2. And he said unto me, What seest thou? And I answered, I see a flying roll; the length thereof /is/ twenty cubits, and the breadth thereof ten cubits.
@@ -79,7 +79,7 @@
 8. And he said, This /is/ wickedness. And he cast it into the midst of the ephah; and he cast the weight of lead upon the mouth thereof.
 9. Then lifted I up mine eyes, and looked, and, behold, there came out two women, and the wind /was/ in their wings; for they had wings like the wings of a stork: and they lifted up the ephah between the earth and the heaven.
 10. Then said I to the angel that talked with me, Whither do these bear the ephah?
-11. And he said unto me, To build it an house in the land of Shinar: and it shall be established, and set there upon her own base. 
+11. And he said unto me, To build it an house in the land of Shinar: and it shall be established, and set there upon her own base.
 * 6
 1. And I turned, and lifted up mine eyes, and looked, and, behold, there came four chariots out from between two mountains; and the mountains /were/ mountains of brass.
 2. In the first chariot /were/ red horses; and in the second chariot black horses;
@@ -96,7 +96,7 @@
 12. And speak unto him, saying, Thus speaketh the LORD of hosts, saying, Behold the man whose name /is/ The BRANCH; and he shall grow up out of his place, and he shall build the temple of the LORD:
 13. Even he shall build the temple of the LORD; and he shall bear the glory, and shall sit and rule upon his throne; and he shall be a priest upon his throne: and the counsel of peace shall be between them both.
 14. And the crowns shall be to Helem, and to Tobijah, and to Jedaiah, and to Hen the son of Zephaniah, for a memorial in the temple of the LORD.
-15. And they /that are/ far off shall come and build in the temple of the LORD, and ye shall know that the LORD of hosts hath sent me unto you. And /this/ shall come to pass, if ye will diligently obey the voice of the LORD your God. 
+15. And they /that are/ far off shall come and build in the temple of the LORD, and ye shall know that the LORD of hosts hath sent me unto you. And /this/ shall come to pass, if ye will diligently obey the voice of the LORD your God.
 * 7
 1. And it came to pass in the fourth year of king Darius, /that/ the word of the LORD came unto Zechariah in the fourth /day/ of the ninth month, /even/ in Chisleu;
 2. When they had sent unto the house of God Sherezer and Regem–melech, and their men, to pray before the LORD,
@@ -113,7 +113,7 @@
 11. But they refused to hearken, and pulled away the shoulder, and stopped their ears, that they should not hear.
 12. Yea, they made their hearts /as/ an adamant stone, lest they should hear the law, and the words which the LORD of hosts hath sent in his spirit by the former prophets: therefore came a great wrath from the LORD of hosts.
 13. Therefore it is come to pass, /that/ as he cried, and they would not hear; so they cried, and I would not hear, saith the LORD of hosts:
-14. But I scattered them with a whirlwind among all the nations whom they knew not. Thus the land was desolate after them, that no man passed through nor returned: for they laid the pleasant land desolate. 
+14. But I scattered them with a whirlwind among all the nations whom they knew not. Thus the land was desolate after them, that no man passed through nor returned: for they laid the pleasant land desolate.
 * 8
 1. Again the word of the LORD of hosts came /to me/, saying,
 2. Thus saith the LORD of hosts; I was jealous for Zion with great jealousy, and I was jealous for her with great fury.
@@ -140,7 +140,7 @@
 20. Thus saith the LORD of hosts; /It shall/ yet /come to pass/, that there shall come people, and the inhabitants of many cities:
 21. And the inhabitants of one /city/ shall go to another, saying, Let us go speedily to pray before the LORD, and to seek the LORD of hosts: I will go also.
 22. Yea, many people and strong nations shall come to seek the LORD of hosts in Jerusalem, and to pray before the LORD.
-23. Thus saith the LORD of hosts; In those days /it shall come to pass/, that ten men shall take hold out of all languages of the nations, even shall take hold of the skirt of him that is a Jew, saying, We will go with you: for we have heard /that/ God /is/ with you. 
+23. Thus saith the LORD of hosts; In those days /it shall come to pass/, that ten men shall take hold out of all languages of the nations, even shall take hold of the skirt of him that is a Jew, saying, We will go with you: for we have heard /that/ God /is/ with you.
 * 9
 1. The burden of the word of the LORD in the land of Hadrach, and Damascus /shall be/ the rest thereof: when the eyes of man, as of all the tribes of Israel, /shall be/ toward the LORD.
 2. And Hamath also shall border thereby; Tyrus, and Zidon, though it be very wise.
@@ -160,7 +160,7 @@
 14. And the LORD shall be seen over them, and his arrow shall go forth as the lightning: and the Lord GOD shall blow the trumpet, and shall go with whirlwinds of the south.
 15. The LORD of hosts shall defend them; and they shall devour, and subdue with sling stones; and they shall drink, /and/ make a noise as through wine; and they shall be filled like bowls, /and/ as the corners of the altar.
 16. And the LORD their God shall save them in that day as the flock of his people: for they /shall be as/ the stones of a crown, lifted up as an ensign upon his land.
-17. For how great /is/ his goodness, and how great /is/ his beauty! corn shall make the young men cheerful, and new wine the maids. 
+17. For how great /is/ his goodness, and how great /is/ his beauty! corn shall make the young men cheerful, and new wine the maids.
 * 10
 1. Ask ye of the LORD rain in the time of the latter rain; /so/ the LORD shall make bright clouds, and give them showers of rain, to every one grass in the field.
 2. For the idols have spoken vanity, and the diviners have seen a lie, and have told false dreams; they comfort in vain: therefore they went their way as a flock, they were troubled, because /there was/ no shepherd.
@@ -174,7 +174,7 @@
 9. And I will sow them among the people: and they shall remember me in far countries; and they shall live with their children, and turn again.
 10. I will bring them again also out of the land of Egypt, and gather them out of Assyria; and I will bring them into the land of Gilead and Lebanon; and /place/ shall not be found for them.
 11. And he shall pass through the sea with affliction, and shall smite the waves in the sea, and all the deeps of the river shall dry up: and the pride of Assyria shall be brought down, and the sceptre of Egypt shall depart away.
-12. And I will strengthen them in the LORD; and they shall walk up and down in his name, saith the LORD. 
+12. And I will strengthen them in the LORD; and they shall walk up and down in his name, saith the LORD.
 * 11
 1. Open thy doors, O Lebanon, that the fire may devour thy cedars.
 2. Howl, fir tree; for the cedar is fallen; because the mighty are spoiled: howl, O ye oaks of Bashan; for the forest of the vintage is come down.
@@ -195,7 +195,7 @@
 
 15. And the LORD said unto me, Take unto thee yet the instruments of a foolish shepherd.
 16. For, lo, I will raise up a shepherd in the land, /which/ shall not visit those that be cut off, neither shall seek the young one, nor heal that that is broken, nor feed that that standeth still: but he shall eat the flesh of the fat, and tear their claws in pieces.
-17. Woe to the idol shepherd that leaveth the flock! the sword /shall be/ upon his arm, and upon his right eye: his arm shall be clean dried up, and his right eye shall be utterly darkened. 
+17. Woe to the idol shepherd that leaveth the flock! the sword /shall be/ upon his arm, and upon his right eye: his arm shall be clean dried up, and his right eye shall be utterly darkened.
 * 12
 1. The burden of the word of the LORD for Israel, saith the LORD, which stretcheth forth the heavens, and layeth the foundation of the earth, and formeth the spirit of man within him.
 2. Behold, I will make Jerusalem a cup of trembling unto all the people round about, when they shall be in the siege both against Judah /and/ against Jerusalem.
@@ -213,7 +213,7 @@
 11. In that day shall there be a great mourning in Jerusalem, as the mourning of Hadadrimmon in the valley of Megiddon.
 12. And the land shall mourn, every family apart; the family of the house of David apart, and their wives apart; the family of the house of Nathan apart, and their wives apart;
 13. The family of the house of Levi apart, and their wives apart; the family of Shimei apart, and their wives apart;
-14. All the families that remain, every family apart, and their wives apart. 
+14. All the families that remain, every family apart, and their wives apart.
 * 13
 1. In that day there shall be a fountain opened to the house of David and to the inhabitants of Jerusalem for sin and for uncleanness.
 
@@ -225,7 +225,7 @@
 
 7. Awake, O sword, against my shepherd, and against the man /that is/ my fellow, saith the LORD of hosts: smite the shepherd, and the sheep shall be scattered: and I will turn mine hand upon the little ones.
 8. And it shall come to pass, /that/ in all the land, saith the LORD, two parts therein shall be cut off /and/ die; but the third shall be left therein.
-9. And I will bring the third part through the fire, and will refine them as silver is refined, and will try them as gold is tried: they shall call on my name, and I will hear them: I will say, It /is/ my people: and they shall say, The LORD /is/ my God. 
+9. And I will bring the third part through the fire, and will refine them as silver is refined, and will try them as gold is tried: they shall call on my name, and I will hear them: I will say, It /is/ my people: and they shall say, The LORD /is/ my God.
 * 14
 1. Behold, the day of the LORD cometh, and thy spoil shall be divided in the midst of thee.
 2. For I will gather all nations against Jerusalem to battle; and the city shall be taken, and the houses rifled, and the women ravished; and half of the city shall go forth into captivity, and the residue of the people shall not be cut off from the city.
@@ -251,4 +251,4 @@
 19. This shall be the punishment of Egypt, and the punishment of all nations that come not up to keep the feast of tabernacles.
 
 20. In that day shall there be upon the bells of the horses, HOLINESS UNTO THE LORD; and the pots in the LORD's house shall be like the bowls before the altar.
-21. Yea, every pot in Jerusalem and in Judah shall be holiness unto the LORD of hosts: and all they that sacrifice shall come and take of them, and seethe therein: and in that day there shall be no more the Canaanite in the house of the LORD of hosts.  
+21. Yea, every pot in Jerusalem and in Judah shall be holiness unto the LORD of hosts: and all they that sacrifice shall come and take of them, and seethe therein: and in that day there shall be no more the Canaanite in the house of the LORD of hosts.

--- a/39_MAL.org
+++ b/39_MAL.org
@@ -15,7 +15,7 @@
 
 12. But ye have profaned it, in that ye say, The table of the LORD /is/ polluted; and the fruit thereof, /even/ his meat, /is/ contemptible.
 13. Ye said also, Behold, what a weariness /is it/! and ye have snuffed at it, saith the LORD of hosts; and ye brought /that which was/ torn, and the lame, and the sick; thus ye brought an offering: should I accept this of your hand? saith the LORD.
-14. But cursed /be/ the deceiver, which hath in his flock a male, and voweth, and sacrificeth unto the Lord a corrupt thing: for I /am/ a great King, saith the LORD of hosts, and my name /is/ dreadful among the heathen. 
+14. But cursed /be/ the deceiver, which hath in his flock a male, and voweth, and sacrificeth unto the Lord a corrupt thing: for I /am/ a great King, saith the LORD of hosts, and my name /is/ dreadful among the heathen.
 * 2
 1. And now, O ye priests, this commandment /is/ for you.
 2. If ye will not hear, and if ye will not lay /it/ to heart, to give glory unto my name, saith the LORD of hosts, I will even send a curse upon you, and I will curse your blessings: yea, I have cursed them already, because ye do not lay /it/ to heart.
@@ -36,7 +36,7 @@
 15. And did not he make one? Yet had he the residue of the spirit. And wherefore one? That he might seek a godly seed. Therefore take heed to your spirit, and let none deal treacherously against the wife of his youth.
 16. For the LORD, the God of Israel, saith that he hateth putting away: for /one/ covereth violence with his garment, saith the LORD of hosts: therefore take heed to your spirit, that ye deal not treacherously.
 
-17. Ye have wearied the LORD with your words. Yet ye say, Wherein have we wearied /him/? When ye say, Every one that doeth evil /is/ good in the sight of the LORD, and he delighteth in them; or, Where /is/ the God of judgment? 
+17. Ye have wearied the LORD with your words. Yet ye say, Wherein have we wearied /him/? When ye say, Every one that doeth evil /is/ good in the sight of the LORD, and he delighteth in them; or, Where /is/ the God of judgment?
 * 3
 1. Behold, I will send my messenger, and he shall prepare the way before me: and the Lord, whom ye seek, shall suddenly come to his temple, even the messenger of the covenant, whom ye delight in: behold, he shall come, saith the LORD of hosts.
 2. But who may abide the day of his coming? and who shall stand when he appeareth? for he /is/ like a refiner's fire, and like fullers' soap:
@@ -59,7 +59,7 @@
 
 16. Then they that feared the LORD spake often one to another: and the LORD hearkened, and heard /it/, and a book of remembrance was written before him for them that feared the LORD, and that thought upon his name.
 17. And they shall be mine, saith the LORD of hosts, in that day when I make up my jewels; and I will spare them, as a man spareth his own son that serveth him.
-18. Then shall ye return, and discern between the righteous and the wicked, between him that serveth God and him that serveth him not. 
+18. Then shall ye return, and discern between the righteous and the wicked, between him that serveth God and him that serveth him not.
 * 4
 1. For, behold, the day cometh, that shall burn as an oven; and all the proud, yea, and all that do wickedly, shall be stubble: and the day that cometh shall burn them up, saith the LORD of hosts, that it shall leave them neither root nor branch.
 
@@ -69,4 +69,4 @@
 4. Remember ye the law of Moses my servant, which I commanded unto him in Horeb for all Israel, /with/ the statutes and judgments.
 
 5. Behold, I will send you Elijah the prophet before the coming of the great and dreadful day of the LORD:
-6. And he shall turn the heart of the fathers to the children, and the heart of the children to their fathers, lest I come and smite the earth with a curse.  
+6. And he shall turn the heart of the fathers to the children, and the heart of the children to their fathers, lest I come and smite the earth with a curse.

--- a/40_MAT.org
+++ b/40_MAT.org
@@ -25,7 +25,7 @@
 22. Now all this was done, that it might be fulfilled which was spoken of the Lord by the prophet, saying,
 23. Behold, a virgin shall be with child, and shall bring forth a son, and they shall call his name Emmanuel, which being interpreted is, God with us.
 24. Then Joseph being raised from sleep did as the angel of the Lord had bidden him, and took unto him his wife:
-25. And knew her not till she had brought forth her firstborn son: and he called his name JESUS. 
+25. And knew her not till she had brought forth her firstborn son: and he called his name JESUS.
 * 2
 1. Now when Jesus was born in Bethlehem of Judaea in the days of Herod the king, behold, there came wise men from the east to Jerusalem,
 2. Saying, Where is he that is born King of the Jews? for we have seen his star in the east, and are come to worship him.
@@ -52,7 +52,7 @@
 20. Saying, Arise, and take the young child and his mother, and go into the land of Israel: for they are dead which sought the young child's life.
 21. And he arose, and took the young child and his mother, and came into the land of Israel.
 22. But when he heard that Archelaus did reign in Judaea in the room of his father Herod, he was afraid to go thither: notwithstanding, being warned of God in a dream, he turned aside into the parts of Galilee:
-23. And he came and dwelt in a city called Nazareth: that it might be fulfilled which was spoken by the prophets, He shall be called a Nazarene. 
+23. And he came and dwelt in a city called Nazareth: that it might be fulfilled which was spoken by the prophets, He shall be called a Nazarene.
 * 3
 1. In those days came John the Baptist, preaching in the wilderness of Judaea,
 2. And saying, Repent ye: for the kingdom of heaven is at hand.
@@ -72,7 +72,7 @@
 14. But John forbad him, saying, I have need to be baptized of thee, and comest thou to me?
 15. And Jesus answering said unto him, Suffer /it to be so/ now: for thus it becometh us to fulfil all righteousness. Then he suffered him.
 16. And Jesus, when he was baptized, went up straightway out of the water: and, lo, the heavens were opened unto him, and he saw the Spirit of God descending like a dove, and lighting upon him:
-17. And lo a voice from heaven, saying, This is my beloved Son, in whom I am well pleased. 
+17. And lo a voice from heaven, saying, This is my beloved Son, in whom I am well pleased.
 * 4
 1. Then was Jesus led up of the Spirit into the wilderness to be tempted of the devil.
 2. And when he had fasted forty days and forty nights, he was afterward an hungred.
@@ -102,7 +102,7 @@
 
 23. And Jesus went about all Galilee, teaching in their synagogues, and preaching the gospel of the kingdom, and healing all manner of sickness and all manner of disease among the people.
 24. And his fame went throughout all Syria: and they brought unto him all sick people that were taken with divers diseases and torments, and those which were possessed with devils, and those which were lunatick, and those that had the palsy; and he healed them.
-25. And there followed him great multitudes of people from Galilee, and /from/ Decapolis, and /from/ Jerusalem, and /from/ Judaea, and /from/ beyond Jordan. 
+25. And there followed him great multitudes of people from Galilee, and /from/ Decapolis, and /from/ Jerusalem, and /from/ Judaea, and /from/ beyond Jordan.
 * 5
 1. And seeing the multitudes, he went up into a mountain: and when he was set, his disciples came unto him:
 2. And he opened his mouth, and taught them, saying,
@@ -158,7 +158,7 @@
 45. That ye may be the children of your Father which is in heaven: for he maketh his sun to rise on the evil and on the good, and sendeth rain on the just and on the unjust.
 46. For if ye love them which love you, what reward have ye? do not even the publicans the same?
 47. And if ye salute your brethren only, what do ye more /than others/? do not even the publicans so?
-48. Be ye therefore perfect, even as your Father which is in heaven is perfect. 
+48. Be ye therefore perfect, even as your Father which is in heaven is perfect.
 * 6
 1. Take heed that ye do not your alms before men, to be seen of them: otherwise ye have no reward of your Father which is in heaven.
 2. Therefore when thou doest /thine/ alms, do not sound a trumpet before thee, as the hypocrites do in the synagogues and in the streets, that they may have glory of men. Verily I say unto you, They have their reward.
@@ -197,7 +197,7 @@
 31. Therefore take no thought, saying, What shall we eat? or, What shall we drink? or, Wherewithal shall we be clothed?
 32. (For after all these things do the Gentiles seek:) for your heavenly Father knoweth that ye have need of all these things.
 33. But seek ye first the kingdom of God, and his righteousness; and all these things shall be added unto you.
-34. Take therefore no thought for the morrow: for the morrow shall take thought for the things of itself. Sufficient unto the day /is/ the evil thereof. 
+34. Take therefore no thought for the morrow: for the morrow shall take thought for the things of itself. Sufficient unto the day /is/ the evil thereof.
 * 7
 1. Judge not, that ye be not judged.
 2. For with what judgment ye judge, ye shall be judged: and with what measure ye mete, it shall be measured to you again.
@@ -233,7 +233,7 @@
 26. And every one that heareth these sayings of mine, and doeth them not, shall be likened unto a foolish man, which built his house upon the sand:
 27. And the rain descended, and the floods came, and the winds blew, and beat upon that house; and it fell: and great was the fall of it.
 28. And it came to pass, when Jesus had ended these sayings, the people were astonished at his doctrine:
-29. For he taught them as /one/ having authority, and not as the scribes. 
+29. For he taught them as /one/ having authority, and not as the scribes.
 * 8
 1. When he was come down from the mountain, great multitudes followed him.
 2. And, behold, there came a leper and worshipped him, saying, Lord, if thou wilt, thou canst make me clean.
@@ -244,7 +244,7 @@
 6. And saying, Lord, my servant lieth at home sick of the palsy, grievously tormented.
 7. And Jesus saith unto him, I will come and heal him.
 8. The centurion answered and said, Lord, I am not worthy that thou shouldest come under my roof: but speak the word only, and my servant shall be healed.
-9. For I am a man under authority, having soldiers under me: and I say to this /man/, Go, and he goeth; and to another, Come, and he cometh; and to my servant, Do this, and he doeth /it/. 
+9. For I am a man under authority, having soldiers under me: and I say to this /man/, Go, and he goeth; and to another, Come, and he cometh; and to my servant, Do this, and he doeth /it/.
 10. When Jesus heard /it/, he marvelled, and said to them that followed, Verily I say unto you, I have not found so great faith, no, not in Israel.
 11. And I say unto you, That many shall come from the east and west, and shall sit down with Abraham, and Isaac, and Jacob, in the kingdom of heaven.
 12. But the children of the kingdom shall be cast out into outer darkness: there shall be weeping and gnashing of teeth.
@@ -274,7 +274,7 @@
 31. So the devils besought him, saying, If thou cast us out, suffer us to go away into the herd of swine.
 32. And he said unto them, Go. And when they were come out, they went into the herd of swine: and, behold, the whole herd of swine ran violently down a steep place into the sea, and perished in the waters.
 33. And they that kept them fled, and went their ways into the city, and told every thing, and what was befallen to the possessed of the devils.
-34. And, behold, the whole city came out to meet Jesus: and when they saw him, they besought /him/ that he would depart out of their coasts. 
+34. And, behold, the whole city came out to meet Jesus: and when they saw him, they besought /him/ that he would depart out of their coasts.
 * 9
 1. And he entered into a ship, and passed over, and came into his own city.
 2. And, behold, they brought to him a man sick of the palsy, lying on a bed: and Jesus seeing their faith said unto the sick of the palsy; Son, be of good cheer; thy sins be forgiven thee.
@@ -321,7 +321,7 @@
 
 36. But when he saw the multitudes, he was moved with compassion on them, because they fainted, and were scattered abroad, as sheep having no shepherd.
 37. Then saith he unto his disciples, The harvest truly /is/ plenteous, but the labourers /are/ few;
-38. Pray ye therefore the Lord of the harvest, that he will send forth labourers into his harvest. 
+38. Pray ye therefore the Lord of the harvest, that he will send forth labourers into his harvest.
 * 10
 1. And when he had called unto /him/ his twelve disciples, he gave them power /against/ unclean spirits, to cast them out, and to heal all manner of sickness and all manner of disease.
 2. Now the names of the twelve apostles are these; The first, Simon, who is called Peter, and Andrew his brother; James /the son/ of Zebedee, and John his brother;
@@ -366,7 +366,7 @@
 
 40. He that receiveth you receiveth me, and he that receiveth me receiveth him that sent me.
 41. He that receiveth a prophet in the name of a prophet shall receive a prophet's reward; and he that receiveth a righteous man in the name of a righteous man shall receive a righteous man's reward.
-42. And whosoever shall give to drink unto one of these little ones a cup of cold /water/ only in the name of a disciple, verily I say unto you, he shall in no wise lose his reward. 
+42. And whosoever shall give to drink unto one of these little ones a cup of cold /water/ only in the name of a disciple, verily I say unto you, he shall in no wise lose his reward.
 * 11
 1. And it came to pass, when Jesus had made an end of commanding his twelve disciples, he departed thence to teach and to preach in their cities.
 2. Now when John had heard in the prison the works of Christ, he sent two of his disciples,
@@ -402,7 +402,7 @@
 
 28. Come unto me, all /ye/ that labour and are heavy laden, and I will give you rest.
 29. Take my yoke upon you, and learn of me; for I am meek and lowly in heart: and ye shall find rest unto your souls.
-30. For my yoke /is/ easy, and my burden is light. 
+30. For my yoke /is/ easy, and my burden is light.
 * 12
 1. At that time Jesus went on the sabbath day through the corn; and his disciples were an hungred, and began to pluck the ears of corn, and to eat.
 2. But when the Pharisees saw /it/, they said unto him, Behold, thy disciples do that which is not lawful to do upon the sabbath day.
@@ -459,7 +459,7 @@
 47. Then one said unto him, Behold, thy mother and thy brethren stand without, desiring to speak with thee.
 48. But he answered and said unto him that told him, Who is my mother? and who are my brethren?
 49. And he stretched forth his hand toward his disciples, and said, Behold my mother and my brethren!
-50. For whosoever shall do the will of my Father which is in heaven, the same is my brother, and sister, and mother. 
+50. For whosoever shall do the will of my Father which is in heaven, the same is my brother, and sister, and mother.
 * 13
 1. The same day went Jesus out of the house, and sat by the sea side.
 2. And great multitudes were gathered together unto him, so that he went into a ship, and sat; and the whole multitude stood on the shore.
@@ -526,7 +526,7 @@
 55. Is not this the carpenter's son? is not his mother called Mary? and his brethren, James, and Joses, and Simon, and Judas?
 56. And his sisters, are they not all with us? Whence then hath this /man/ all these things?
 57. And they were offended in him. But Jesus said unto them, A prophet is not without honour, save in his own country, and in his own house.
-58. And he did not many mighty works there because of their unbelief. 
+58. And he did not many mighty works there because of their unbelief.
 * 14
 1. At that time Herod the tetrarch heard of the fame of Jesus,
 2. And said unto his servants, This is John the Baptist; he is risen from the dead; and therefore mighty works do shew forth themselves in him.
@@ -537,7 +537,7 @@
 6. But when Herod's birthday was kept, the daughter of Herodias danced before them, and pleased Herod.
 7. Whereupon he promised with an oath to give her whatsoever she would ask.
 8. And she, being before instructed of her mother, said, Give me here John Baptist's head in a charger.
-9. And the king was sorry: nevertheless for the oath's sake, and them which sat with him at meat, he commanded /it/ to be given /her/. 
+9. And the king was sorry: nevertheless for the oath's sake, and them which sat with him at meat, he commanded /it/ to be given /her/.
 10. And he sent, and beheaded John in the prison.
 11. And his head was brought in a charger, and given to the damsel: and she brought /it/ to her mother.
 12. And his disciples came, and took up the body, and buried it, and went and told Jesus.
@@ -568,7 +568,7 @@
 
 34. And when they were gone over, they came into the land of Gennesaret.
 35. And when the men of that place had knowledge of him, they sent out into all that country round about, and brought unto him all that were diseased;
-36. And besought him that they might only touch the hem of his garment: and as many as touched were made perfectly whole. 
+36. And besought him that they might only touch the hem of his garment: and as many as touched were made perfectly whole.
 * 15
 1. Then came to Jesus scribes and Pharisees, which were of Jerusalem, saying,
 2. Why do thy disciples transgress the tradition of the elders? for they wash not their hands when they eat bread.
@@ -611,7 +611,7 @@
 36. And he took the seven loaves and the fishes, and gave thanks, and brake /them/, and gave to his disciples, and the disciples to the multitude.
 37. And they did all eat, and were filled: and they took up of the broken /meat/ that was left seven baskets full.
 38. And they that did eat were four thousand men, beside women and children.
-39. And he sent away the multitude, and took ship, and came into the coasts of Magdala. 
+39. And he sent away the multitude, and took ship, and came into the coasts of Magdala.
 * 16
 1. The Pharisees also with the Sadducees came, and tempting desired him that he would shew them a sign from heaven.
 2. He answered and said unto them, When it is evening, ye say, /It will be/ fair weather: for the sky is red.
@@ -644,7 +644,7 @@
 25. For whosoever will save his life shall lose it: and whosoever will lose his life for my sake shall find it.
 26. For what is a man profited, if he shall gain the whole world, and lose his own soul? or what shall a man give in exchange for his soul?
 27. For the Son of man shall come in the glory of his Father with his angels; and then he shall reward every man according to his works.
-28. Verily I say unto you, There be some standing here, which shall not taste of death, till they see the Son of man coming in his kingdom. 
+28. Verily I say unto you, There be some standing here, which shall not taste of death, till they see the Son of man coming in his kingdom.
 * 17
 1. And after six days Jesus taketh Peter, James, and John his brother, and bringeth them up into an high mountain apart,
 2. And was transfigured before them: and his face did shine as the sun, and his raiment was white as the light.
@@ -675,7 +675,7 @@
 24. And when they were come to Capernaum, they that received tribute /money/ came to Peter, and said, Doth not your master pay tribute?
 25. He saith, Yes. And when he was come into the house, Jesus prevented him, saying, What thinkest thou, Simon? of whom do the kings of the earth take custom or tribute? of their own children, or of strangers?
 26. Peter saith unto him, Of strangers. Jesus saith unto him, Then are the children free.
-27. Notwithstanding, lest we should offend them, go thou to the sea, and cast an hook, and take up the fish that first cometh up; and when thou hast opened his mouth, thou shalt find a piece of money: that take, and give unto them for me and thee. 
+27. Notwithstanding, lest we should offend them, go thou to the sea, and cast an hook, and take up the fish that first cometh up; and when thou hast opened his mouth, thou shalt find a piece of money: that take, and give unto them for me and thee.
 * 18
 1. At the same time came the disciples unto Jesus, saying, Who is the greatest in the kingdom of heaven?
 2. And Jesus called a little child unto him, and set him in the midst of them,
@@ -715,7 +715,7 @@
 32. Then his lord, after that he had called him, said unto him, O thou wicked servant, I forgave thee all that debt, because thou desiredst me:
 33. Shouldest not thou also have had compassion on thy fellowservant, even as I had pity on thee?
 34. And his lord was wroth, and delivered him to the tormentors, till he should pay all that was due unto him.
-35. So likewise shall my heavenly Father do also unto you, if ye from your hearts forgive not every one his brother their trespasses. 
+35. So likewise shall my heavenly Father do also unto you, if ye from your hearts forgive not every one his brother their trespasses.
 * 19
 1. And it came to pass, /that/ when Jesus had finished these sayings, he departed from Galilee, and came into the coasts of Judaea beyond Jordan;
 2. And great multitudes followed him; and he healed them there.
@@ -752,7 +752,7 @@
 27. Then answered Peter and said unto him, Behold, we have forsaken all, and followed thee; what shall we have therefore?
 28. And Jesus said unto them, Verily I say unto you, That ye which have followed me, in the regeneration when the Son of man shall sit in the throne of his glory, ye also shall sit upon twelve thrones, judging the twelve tribes of Israel.
 29. And every one that hath forsaken houses, or brethren, or sisters, or father, or mother, or wife, or children, or lands, for my name's sake, shall receive an hundredfold, and shall inherit everlasting life.
-30. But many /that are/ first shall be last; and the last /shall be/ first. 
+30. But many /that are/ first shall be last; and the last /shall be/ first.
 * 20
 1. For the kingdom of heaven is like unto a man /that is/ an householder, which went out early in the morning to hire labourers into his vineyard.
 2. And when he had agreed with the labourers for a penny a day, he sent them into his vineyard.
@@ -790,7 +790,7 @@
 31. And the multitude rebuked them, because they should hold their peace: but they cried the more, saying, Have mercy on us, O Lord, /thou/ Son of David.
 32. And Jesus stood still, and called them, and said, What will ye that I shall do unto you?
 33. They say unto him, Lord, that our eyes may be opened.
-34. So Jesus had compassion /on them/, and touched their eyes: and immediately their eyes received sight, and they followed him. 
+34. So Jesus had compassion /on them/, and touched their eyes: and immediately their eyes received sight, and they followed him.
 * 21
 1. And when they drew nigh unto Jerusalem, and were come to Bethphage, unto the mount of Olives, then sent Jesus two disciples,
 2. Saying unto them, Go into the village over against you, and straightway ye shall find an ass tied, and a colt with her: loose /them/, and bring /them/ unto me.
@@ -842,7 +842,7 @@
 43. Therefore say I unto you, The kingdom of God shall be taken from you, and given to a nation bringing forth the fruits thereof.
 44. And whosoever shall fall on this stone shall be broken: but on whomsoever it shall fall, it will grind him to powder.
 45. And when the chief priests and Pharisees had heard his parables, they perceived that he spake of them.
-46. But when they sought to lay hands on him, they feared the multitude, because they took him for a prophet. 
+46. But when they sought to lay hands on him, they feared the multitude, because they took him for a prophet.
 * 22
 1. And Jesus answered and spake unto them again by parables, and said,
 2. The kingdom of heaven is like unto a certain king, which made a marriage for his son,
@@ -894,7 +894,7 @@
 43. He saith unto them, How then doth David in spirit call him Lord, saying,
 44. The LORD said unto my Lord, Sit thou on my right hand, till I make thine enemies thy footstool?
 45. If David then call him Lord, how is he his son?
-46. And no man was able to answer him a word, neither durst any /man/ from that day forth ask him any more /questions./ 
+46. And no man was able to answer him a word, neither durst any /man/ from that day forth ask him any more /questions./
 * 23
 1. Then spake Jesus to the multitude, and to his disciples,
 2. Saying, The scribes and the Pharisees sit in Moses' seat:
@@ -936,7 +936,7 @@
 36. Verily I say unto you, All these things shall come upon this generation.
 37. O Jerusalem, Jerusalem, /thou/ that killest the prophets, and stonest them which are sent unto thee, how often would I have gathered thy children together, even as a hen gathereth her chickens under /her/ wings, and ye would not!
 38. Behold, your house is left unto you desolate.
-39. For I say unto you, Ye shall not see me henceforth, till ye shall say, Blessed /is/ he that cometh in the name of the Lord. 
+39. For I say unto you, Ye shall not see me henceforth, till ye shall say, Blessed /is/ he that cometh in the name of the Lord.
 * 24
 1. And Jesus went out, and departed from the temple: and his disciples came to /him/ for to shew him the buildings of the temple.
 2. And Jesus said unto them, See ye not all these things? verily I say unto you, There shall not be left here one stone upon another, that shall not be thrown down.
@@ -992,7 +992,7 @@
 48. But and if that evil servant shall say in his heart, My lord delayeth his coming;
 49. And shall begin to smite /his/ fellowservants, and to eat and drink with the drunken;
 50. The lord of that servant shall come in a day when he looketh not for /him/, and in an hour that he is not aware of,
-51. And shall cut him asunder, and appoint /him/ his portion with the hypocrites: there shall be weeping and gnashing of teeth. 
+51. And shall cut him asunder, and appoint /him/ his portion with the hypocrites: there shall be weeping and gnashing of teeth.
 * 25
 1. Then shall the kingdom of heaven be likened unto ten virgins, which took their lamps, and went forth to meet the bridegroom.
 2. And five of them were wise, and five /were/ foolish.
@@ -1041,16 +1041,16 @@
 43. I was a stranger, and ye took me not in: naked, and ye clothed me not: sick, and in prison, and ye visited me not.
 44. Then shall they also answer him, saying, Lord, when saw we thee an hungred, or athirst, or a stranger, or naked, or sick, or in prison, and did not minister unto thee?
 45. Then shall he answer them, saying, Verily I say unto you, Inasmuch as ye did /it/ not to one of the least of these, ye did /it/ not to me.
-46. And these shall go away into everlasting punishment: but the righteous into life eternal. 
+46. And these shall go away into everlasting punishment: but the righteous into life eternal.
 * 26
 1. And it came to pass, when Jesus had finished all these sayings, he said unto his disciples,
 2. Ye know that after two days is /the feast of/ the passover, and the Son of man is betrayed to be crucified.
 3. Then assembled together the chief priests, and the scribes, and the elders of the people, unto the palace of the high priest, who was called Caiaphas,
-4. And consulted that they might take Jesus by subtilty, and kill /him/. 
+4. And consulted that they might take Jesus by subtilty, and kill /him/.
 5. But they said, Not on the feast /day/, lest there be an uproar among the people.
 
 6. Now when Jesus was in Bethany, in the house of Simon the leper,
-7. There came unto him a woman having an alabaster box of very precious ointment, and poured it on his head, as he sat /at meat/. 
+7. There came unto him a woman having an alabaster box of very precious ointment, and poured it on his head, as he sat /at meat/.
 8. But when his disciples saw /it/, they had indignation, saying, To what purpose /is/ this waste?
 9. For this ointment might have been sold for much, and given to the poor.
 10. When Jesus understood /it/, he said unto them, Why trouble ye the woman? for she hath wrought a good work upon me.
@@ -1125,13 +1125,13 @@
 72. And again he denied with an oath, I do not know the man.
 73. And after a while came unto /him/ they that stood by, and said to Peter, Surely thou also art /one/ of them; for thy speech bewrayeth thee.
 74. Then began he to curse and to swear, /saying/, I know not the man. And immediately the cock crew.
-75. And Peter remembered the word of Jesus, which said unto him, Before the cock crow, thou shalt deny me thrice. And he went out, and wept bitterly. 
+75. And Peter remembered the word of Jesus, which said unto him, Before the cock crow, thou shalt deny me thrice. And he went out, and wept bitterly.
 * 27
 1. When the morning was come, all the chief priests and elders of the people took counsel against Jesus to put him to death:
 2. And when they had bound him, they led /him/ away, and delivered him to Pontius Pilate the governor.
 
 3. Then Judas, which had betrayed him, when he saw that he was condemned, repented himself, and brought again the thirty pieces of silver to the chief priests and elders,
-4. Saying, I have sinned in that I have betrayed the innocent blood. And they said, What /is that/ to us? see thou /to that/. 
+4. Saying, I have sinned in that I have betrayed the innocent blood. And they said, What /is that/ to us? see thou /to that/.
 5. And he cast down the pieces of silver in the temple, and departed, and went and hanged himself.
 6. And the chief priests took the silver pieces, and said, It is not lawful for to put them into the treasury, because it is the price of blood.
 7. And they took counsel, and bought with them the potter's field, to bury strangers in.
@@ -1153,16 +1153,16 @@
 22. Pilate saith unto them, What shall I do then with Jesus which is called Christ? /They/ all say unto him, Let him be crucified.
 23. And the governor said, Why, what evil hath he done? But they cried out the more, saying, Let him be crucified.
 
-24. When Pilate saw that he could prevail nothing, but /that/ rather a tumult was made, he took water, and washed /his/ hands before the multitude, saying, I am innocent of the blood of this just person: see ye /to it/. 
+24. When Pilate saw that he could prevail nothing, but /that/ rather a tumult was made, he took water, and washed /his/ hands before the multitude, saying, I am innocent of the blood of this just person: see ye /to it/.
 25. Then answered all the people, and said, His blood /be/ on us, and on our children.
 
 26. Then released he Barabbas unto them: and when he had scourged Jesus, he delivered /him/ to be crucified.
-27. Then the soldiers of the governor took Jesus into the common hall, and gathered unto him the whole band /of soldiers/. 
+27. Then the soldiers of the governor took Jesus into the common hall, and gathered unto him the whole band /of soldiers/.
 28. And they stripped him, and put on him a scarlet robe.
 
 29. And when they had platted a crown of thorns, they put /it/ upon his head, and a reed in his right hand: and they bowed the knee before him, and mocked him, saying, Hail, King of the Jews!
 30. And they spit upon him, and took the reed, and smote him on the head.
-31. And after that they had mocked him, they took the robe off from him, and put his own raiment on him, and led him away to crucify /him/. 
+31. And after that they had mocked him, they took the robe off from him, and put his own raiment on him, and led him away to crucify /him/.
 32. And as they came out, they found a man of Cyrene, Simon by name: him they compelled to bear his cross.
 33. And when they were come unto a place called Golgotha, that is to say, a place of a skull,
 
@@ -1201,12 +1201,12 @@
 63. Saying, Sir, we remember that that deceiver said, while he was yet alive, After three days I will rise again.
 64. Command therefore that the sepulchre be made sure until the third day, lest his disciples come by night, and steal him away, and say unto the people, He is risen from the dead: so the last error shall be worse than the first.
 65. Pilate said unto them, Ye have a watch: go your way, make /it/ as sure as ye can.
-66. So they went, and made the sepulchre sure, sealing the stone, and setting a watch. 
+66. So they went, and made the sepulchre sure, sealing the stone, and setting a watch.
 * 28
 1. In the end of the sabbath, as it began to dawn toward the first /day/ of the week, came Mary Magdalene and the other Mary to see the sepulchre.
 2. And, behold, there was a great earthquake: for the angel of the Lord descended from heaven, and came and rolled back the stone from the door, and sat upon it.
 3. His countenance was like lightning, and his raiment white as snow:
-4. And for fear of him the keepers did shake, and became as dead /men/. 
+4. And for fear of him the keepers did shake, and became as dead /men/.
 5. And the angel answered and said unto the women, Fear not ye: for I know that ye seek Jesus, which was crucified.
 6. He is not here: for he is risen, as he said. Come, see the place where the Lord lay.
 7. And go quickly, and tell his disciples that he is risen from the dead; and, behold, he goeth before you into Galilee; there shall ye see him: lo, I have told you.
@@ -1226,4 +1226,4 @@
 18. And Jesus came and spake unto them, saying, All power is given unto me in heaven and in earth.
 
 19. Go ye therefore, and teach all nations, baptizing them in the name of the Father, and of the Son, and of the Holy Ghost:
-20. Teaching them to observe all things whatsoever I have commanded you: and, lo, I am with you alway, /even/ unto the end of the world. Amen.  
+20. Teaching them to observe all things whatsoever I have commanded you: and, lo, I am with you alway, /even/ unto the end of the world. Amen.

--- a/41_MRK.org
+++ b/41_MRK.org
@@ -44,7 +44,7 @@
 42. And as soon as he had spoken, immediately the leprosy departed from him, and he was cleansed.
 43. And he straitly charged him, and forthwith sent him away;
 44. And saith unto him, See thou say nothing to any man: but go thy way, shew thyself to the priest, and offer for thy cleansing those things which Moses commanded, for a testimony unto them.
-45. But he went out, and began to publish /it/ much, and to blaze abroad the matter, insomuch that Jesus could no more openly enter into the city, but was without in desert places: and they came to him from every quarter. 
+45. But he went out, and began to publish /it/ much, and to blaze abroad the matter, insomuch that Jesus could no more openly enter into the city, but was without in desert places: and they came to him from every quarter.
 * 2
 1. And again he entered into Capernaum after /some/ days; and it was noised that he was in the house.
 2. And straightway many were gathered together, insomuch that there was no room to receive /them/, no, not so much as about the door: and he preached the word unto them.
@@ -73,7 +73,7 @@
 25. And he said unto them, Have ye never read what David did, when he had need, and was an hungred, he, and they that were with him?
 26. How he went into the house of God in the days of Abiathar the high priest, and did eat the shewbread, which is not lawful to eat but for the priests, and gave also to them which were with him?
 27. And he said unto them, The sabbath was made for man, and not man for the sabbath:
-28. Therefore the Son of man is Lord also of the sabbath. 
+28. Therefore the Son of man is Lord also of the sabbath.
 * 3
 1. And he entered again into the synagogue; and there was a man there which had a withered hand.
 2. And they watched him, whether he would heal him on the sabbath day; that they might accuse him.
@@ -111,7 +111,7 @@
 32. And the multitude sat about him, and they said unto him, Behold, thy mother and thy brethren without seek for thee.
 33. And he answered them, saying, Who is my mother, or my brethren?
 34. And he looked round about on them which sat about him, and said, Behold my mother and my brethren!
-35. For whosoever shall do the will of God, the same is my brother, and my sister, and mother. 
+35. For whosoever shall do the will of God, the same is my brother, and my sister, and mother.
 * 4
 1. And he began again to teach by the sea side: and there was gathered unto him a great multitude, so that he entered into a ship, and sat in the sea; and the whole multitude was by the sea on the land.
 2. And he taught them many things by parables, and said unto them in his doctrine,
@@ -149,7 +149,7 @@
 30. And he said, Whereunto shall we liken the kingdom of God? or with what comparison shall we compare it?
 31. /It is/ like a grain of mustard seed, which, when it is sown in the earth, is less than all the seeds that be in the earth:
 32. But when it is sown, it groweth up, and becometh greater than all herbs, and shooteth out great branches; so that the fowls of the air may lodge under the shadow of it.
-33. And with many such parables spake he the word unto them, as they were able to hear /it/. 
+33. And with many such parables spake he the word unto them, as they were able to hear /it/.
 34. But without a parable spake he not unto them: and when they were alone, he expounded all things to his disciples.
 35. And the same day, when the even was come, he saith unto them, Let us pass over unto the other side.
 36. And when they had sent away the multitude, they took him even as he was in the ship. And there were also with him other little ships.
@@ -157,7 +157,7 @@
 38. And he was in the hinder part of the ship, asleep on a pillow: and they awake him, and say unto him, Master, carest thou not that we perish?
 39. And he arose, and rebuked the wind, and said unto the sea, Peace, be still. And the wind ceased, and there was a great calm.
 40. And he said unto them, Why are ye so fearful? how is it that ye have no faith?
-41. And they feared exceedingly, and said one to another, What manner of man is this, that even the wind and the sea obey him? 
+41. And they feared exceedingly, and said one to another, What manner of man is this, that even the wind and the sea obey him?
 * 5
 1. And they came over unto the other side of the sea, into the country of the Gadarenes.
 2. And when he was come out of the ship, immediately there met him out of the tombs a man with an unclean spirit,
@@ -201,13 +201,13 @@
 40. And they laughed him to scorn. But when he had put them all out, he taketh the father and the mother of the damsel, and them that were with him, and entereth in where the damsel was lying.
 41. And he took the damsel by the hand, and said unto her, Talitha cumi; which is, being interpreted, Damsel, I say unto thee, arise.
 42. And straightway the damsel arose, and walked; for she was /of the age/ of twelve years. And they were astonished with a great astonishment.
-43. And he charged them straitly that no man should know it; and commanded that something should be given her to eat. 
+43. And he charged them straitly that no man should know it; and commanded that something should be given her to eat.
 * 6
 1. And he went out from thence, and came into his own country; and his disciples follow him.
 2. And when the sabbath day was come, he began to teach in the synagogue: and many hearing /him/ were astonished, saying, From whence hath this /man/ these things? and what wisdom /is/ this which is given unto him, that even such mighty works are wrought by his hands?
 3. Is not this the carpenter, the son of Mary, the brother of James, and Joses, and of Juda, and Simon? and are not his sisters here with us? And they were offended at him.
 4. But Jesus said unto them, A prophet is not without honour, but in his own country, and among his own kin, and in his own house.
-5. And he could there do no mighty work, save that he laid his hands upon a few sick folk, and healed /them/. 
+5. And he could there do no mighty work, save that he laid his hands upon a few sick folk, and healed /them/.
 6. And he marvelled because of their unbelief. And he went round about the villages, teaching.
 
 7. And he called /unto him/ the twelve, and began to send them forth by two and two; and gave them power over unclean spirits;
@@ -216,7 +216,7 @@
 10. And he said unto them, In what place soever ye enter into an house, there abide till ye depart from that place.
 11. And whosoever shall not receive you, nor hear you, when ye depart thence, shake off the dust under your feet for a testimony against them. Verily I say unto you, It shall be more tolerable for Sodom and Gomorrha in the day of judgment, than for that city.
 12. And they went out, and preached that men should repent.
-13. And they cast out many devils, and anointed with oil many that were sick, and healed /them/. 
+13. And they cast out many devils, and anointed with oil many that were sick, and healed /them/.
 14. And king Herod heard /of him/; (for his name was spread abroad:) and he said, That John the Baptist was risen from the dead, and therefore mighty works do shew forth themselves in him.
 15. Others said, That it is Elias. And others said, That it is a prophet, or as one of the prophets.
 16. But when Herod heard /thereof/, he said, It is John, whom I beheaded: he is risen from the dead.
@@ -259,7 +259,7 @@
 53. And when they had passed over, they came into the land of Gennesaret, and drew to the shore.
 54. And when they were come out of the ship, straightway they knew him,
 55. And ran through that whole region round about, and began to carry about in beds those that were sick, where they heard he was.
-56. And whithersoever he entered, into villages, or cities, or country, they laid the sick in the streets, and besought him that they might touch if it were but the border of his garment: and as many as touched him were made whole. 
+56. And whithersoever he entered, into villages, or cities, or country, they laid the sick in the streets, and besought him that they might touch if it were but the border of his garment: and as many as touched him were made whole.
 * 7
 1. Then came together unto him the Pharisees, and certain of the scribes, which came from Jerusalem.
 2. And when they saw some of his disciples eat bread with defiled, that is to say, with unwashen, hands, they found fault.
@@ -299,8 +299,8 @@
 33. And he took him aside from the multitude, and put his fingers into his ears, and he spit, and touched his tongue;
 34. And looking up to heaven, he sighed, and saith unto him, Ephphatha, that is, Be opened.
 35. And straightway his ears were opened, and the string of his tongue was loosed, and he spake plain.
-36. And he charged them that they should tell no man: but the more he charged them, so much the more a great deal they published /it/; 
-37. And were beyond measure astonished, saying, He hath done all things well: he maketh both the deaf to hear, and the dumb to speak. 
+36. And he charged them that they should tell no man: but the more he charged them, so much the more a great deal they published /it/;
+37. And were beyond measure astonished, saying, He hath done all things well: he maketh both the deaf to hear, and the dumb to speak.
 * 8
 1. In those days the multitude being very great, and having nothing to eat, Jesus called his disciples /unto him/, and saith unto them,
 2. I have compassion on the multitude, because they have now been with me three days, and have nothing to eat:
@@ -308,7 +308,7 @@
 4. And his disciples answered him, From whence can a man satisfy these /men/ with bread here in the wilderness?
 5. And he asked them, How many loaves have ye? And they said, Seven.
 6. And he commanded the people to sit down on the ground: and he took the seven loaves, and gave thanks, and brake, and gave to his disciples to set before /them/; and they did set /them/ before the people.
-7. And they had a few small fishes: and he blessed, and commanded to set them also before /them/. 
+7. And they had a few small fishes: and he blessed, and commanded to set them also before /them/.
 8. So they did eat, and were filled: and they took up of the broken /meat/ that was left seven baskets.
 9. And they that had eaten were about four thousand: and he sent them away.
 
@@ -344,7 +344,7 @@
 35. For whosoever will save his life shall lose it; but whosoever shall lose his life for my sake and the gospel's, the same shall save it.
 36. For what shall it profit a man, if he shall gain the whole world, and lose his own soul?
 37. Or what shall a man give in exchange for his soul?
-38. Whosoever therefore shall be ashamed of me and of my words in this adulterous and sinful generation; of him also shall the Son of man be ashamed, when he cometh in the glory of his Father with the holy angels. 
+38. Whosoever therefore shall be ashamed of me and of my words in this adulterous and sinful generation; of him also shall the Son of man be ashamed, when he cometh in the glory of his Father with the holy angels.
 * 9
 1. And he said unto them, Verily I say unto you, That there be some of them that stand here, which shall not taste of death, till they have seen the kingdom of God come with power.
 
@@ -379,7 +379,7 @@
 28. And when he was come into the house, his disciples asked him privately, Why could not we cast him out?
 29. And he said unto them, This kind can come forth by nothing, but by prayer and fasting.
 
-30. And they departed thence, and passed through Galilee; and he would not that any man should know /it/. 
+30. And they departed thence, and passed through Galilee; and he would not that any man should know /it/.
 31. For he taught his disciples, and said unto them, The Son of man is delivered into the hands of men, and they shall kill him; and after that he is killed, he shall rise the third day.
 32. But they understood not that saying, and were afraid to ask him.
 
@@ -401,7 +401,7 @@
 47. And if thine eye offend thee, pluck it out: it is better for thee to enter into the kingdom of God with one eye, than having two eyes to be cast into hell fire:
 48. Where their worm dieth not, and the fire is not quenched.
 49. For every one shall be salted with fire, and every sacrifice shall be salted with salt.
-50. Salt /is/ good: but if the salt have lost his saltness, wherewith will ye season it? Have salt in yourselves, and have peace one with another. 
+50. Salt /is/ good: but if the salt have lost his saltness, wherewith will ye season it? Have salt in yourselves, and have peace one with another.
 * 10
 1. And he arose from thence, and cometh into the coasts of Judæa by the farther side of Jordan: and the people resort unto him again; and, as he was wont, he taught them again.
 
@@ -413,11 +413,11 @@
 7. For this cause shall a man leave his father and mother, and cleave to his wife;
 8. And they twain shall be one flesh: so then they are no more twain, but one flesh.
 9. What therefore God hath joined together, let not man put asunder.
-10. And in the house his disciples asked him again of the same /matter/. 
+10. And in the house his disciples asked him again of the same /matter/.
 11. And he saith unto them, Whosoever shall put away his wife, and marry another, committeth adultery against her.
 12. And if a woman shall put away her husband, and be married to another, she committeth adultery.
 
-13. And they brought young children to him, that he should touch them: and /his/ disciples rebuked those that brought /them/. 
+13. And they brought young children to him, that he should touch them: and /his/ disciples rebuked those that brought /them/.
 14. But when Jesus saw /it/, he was much displeased, and said unto them, Suffer the little children to come unto me, and forbid them not: for of such is the kingdom of God.
 15. Verily I say unto you, Whosoever shall not receive the kingdom of God as a little child, he shall not enter therein.
 16. And he took them up in his arms, put /his/ hands upon them, and blessed them.
@@ -462,7 +462,7 @@
 49. And Jesus stood still, and commanded him to be called. And they call the blind man, saying unto him, Be of good comfort, rise; he calleth thee.
 50. And he, casting away his garment, rose, and came to Jesus.
 51. And Jesus answered and said unto him, What wilt thou that I should do unto thee? The blind man said unto him, Lord, that I might receive my sight.
-52. And Jesus said unto him, Go thy way; thy faith hath made thee whole. And immediately he received his sight, and followed Jesus in the way. 
+52. And Jesus said unto him, Go thy way; thy faith hath made thee whole. And immediately he received his sight, and followed Jesus in the way.
 * 11
 1. And when they came nigh to Jerusalem, unto Bethphage and Bethany, at the mount of Olives, he sendeth forth two of his disciples,
 2. And saith unto them, Go your way into the village over against you: and as soon as ye be entered into it, ye shall find a colt tied, whereon never man sat; loose him, and bring /him/.
@@ -477,7 +477,7 @@
 11. And Jesus entered into Jerusalem, and into the temple: and when he had looked round about upon all things, and now the eventide was come, he went out unto Bethany with the twelve.
 
 12. And on the morrow, when they were come from Bethany, he was hungry:
-13. And seeing a fig tree afar off having leaves, he came, if haply he might find any thing thereon: and when he came to it, he found nothing but leaves; for the time of figs was not /yet/. 
+13. And seeing a fig tree afar off having leaves, he came, if haply he might find any thing thereon: and when he came to it, he found nothing but leaves; for the time of figs was not /yet/.
 14. And Jesus answered and said unto it, No man eat fruit of thee hereafter for ever. And his disciples heard /it./
 
 15. And they come to Jerusalem: and Jesus went into the temple, and began to cast out them that sold and bought in the temple, and overthrew the tables of the moneychangers, and the seats of them that sold doves;
@@ -500,7 +500,7 @@
 30. The baptism of John, was /it/ from heaven, or of men? answer me.
 31. And they reasoned with themselves, saying, If we shall say, From heaven; he will say, Why then did ye not believe him?
 32. But if we shall say, Of men; they feared the people: for all /men/ counted John, that he was a prophet indeed.
-33. And they answered and said unto Jesus, We cannot tell. And Jesus answering saith unto them, Neither do I tell you by what authority I do these things. 
+33. And they answered and said unto Jesus, We cannot tell. And Jesus answering saith unto them, Neither do I tell you by what authority I do these things.
 * 12
 1. And he began to speak unto them by parables. A /certain/ man planted a vineyard, and set an hedge about /it/, and digged /a place for/ the winefat, and built a tower, and let it out to husbandmen, and went into a far country.
 2. And at the season he sent to the husbandmen a servant, that he might receive from the husbandmen of the fruit of the vineyard.
@@ -551,9 +551,9 @@
 41. And Jesus sat over against the treasury, and beheld how the people cast money into the treasury: and many that were rich cast in much.
 42. And there came a certain poor widow, and she threw in two mites, which make a farthing.
 43. And he called /unto him/ his disciples, and saith unto them, Verily I say unto you, That this poor widow hath cast more in, than all they which have cast into the treasury:
-44. For all /they/ did cast in of their abundance; but she of her want did cast in all that she had, /even/ all her living. 
+44. For all /they/ did cast in of their abundance; but she of her want did cast in all that she had, /even/ all her living.
 * 13
-1. And as he went out of the temple, one of his disciples saith unto him, Master, see what manner of stones and what buildings /are here/! 
+1. And as he went out of the temple, one of his disciples saith unto him, Master, see what manner of stones and what buildings /are here/!
 2. And Jesus answering said unto him, Seest thou these great buildings? there shall not be left one stone upon another, that shall not be thrown down.
 3. And as he sat upon the mount of Olives over against the temple, Peter and James and John and Andrew asked him privately,
 4. Tell us, when shall these things be? and what /shall be/ the sign when all these things shall be fulfilled?
@@ -593,7 +593,7 @@
 34. /For the Son of man is/ as a man taking a far journey, who left his house, and gave authority to his servants, and to every man his work, and commanded the porter to watch.
 35. Watch ye therefore: for ye know not when the master of the house cometh, at even, or at midnight, or at the cockcrowing, or in the morning:
 36. Lest coming suddenly he find you sleeping.
-37. And what I say unto you I say unto all, Watch. 
+37. And what I say unto you I say unto all, Watch.
 * 14
 1. After two days was /the feast of/ the passover, and of unleavened bread: and the chief priests and the scribes sought how they might take him by craft, and put /him/ to death.
 2. But they said, Not on the feast /day/, lest there be an uproar of the people.
@@ -673,9 +673,9 @@
 67. And when she saw Peter warming himself, she looked upon him, and said, And thou also wast with Jesus of Nazareth.
 68. But he denied, saying, I know not, neither understand I what thou sayest. And he went out into the porch; and the cock crew.
 69. And a maid saw him again, and began to say to them that stood by, This is /one/ of them.
-70. And he denied it again. And a little after, they that stood by said again to Peter, Surely thou art /one/ of them: for thou art a Galilaean, and thy speech agreeth /thereto/. 
+70. And he denied it again. And a little after, they that stood by said again to Peter, Surely thou art /one/ of them: for thou art a Galilaean, and thy speech agreeth /thereto/.
 71. But he began to curse and to swear, /saying/, I know not this man of whom ye speak.
-72. And the second time the cock crew. And Peter called to mind the word that Jesus said unto him, Before the cock crow twice, thou shalt deny me thrice. And when he thought thereon, he wept. 
+72. And the second time the cock crew. And Peter called to mind the word that Jesus said unto him, Before the cock crow twice, thou shalt deny me thrice. And when he thought thereon, he wept.
 * 15
 1. And straightway in the morning the chief priests held a consultation with the elders and scribes and the whole council, and bound Jesus, and carried /him/ away, and delivered /him/ to Pilate.
 2. And Pilate asked him, Art thou the King of the Jews? And he answering said unto him, Thou sayest /it/.
@@ -694,7 +694,7 @@
 
 15. And /so/ Pilate, willing to content the people, released Barabbas unto them, and delivered Jesus, when he had scourged /him/, to be crucified.
 16. And the soldiers led him away into the hall, called Prætorium; and they call together the whole band.
-17. And they clothed him with purple, and platted a crown of thorns, and put it about his /head/, 
+17. And they clothed him with purple, and platted a crown of thorns, and put it about his /head/,
 18. And began to salute him, Hail, King of the Jews!
 19. And they smote him on the head with a reed, and did spit upon him, and bowing /their/ knees worshipped him.
 20. And when they had mocked him, they took off the purple from him, and put his own clothes on him, and led him out to crucify him.
@@ -726,7 +726,7 @@
 44. And Pilate marvelled if he were already dead: and calling /unto him/ the centurion, he asked him whether he had been any while dead.
 45. And when he knew /it/ of the centurion, he gave the body to Joseph.
 46. And he bought fine linen, and took him down, and wrapped him in the linen, and laid him in a sepulchre which was hewn out of a rock, and rolled a stone unto the door of the sepulchre.
-47. And Mary Magdalene and Mary /the mother/ of Joses beheld where he was laid. 
+47. And Mary Magdalene and Mary /the mother/ of Joses beheld where he was laid.
 * 16
 1. And when the sabbath was past, Mary Magdalene, and Mary the /mother/ of James, and Salome, had bought sweet spices, that they might come and anoint him.
 2. And very early in the morning the first /day/ of the week, they came unto the sepulchre at the rising of the sun.
@@ -751,4 +751,4 @@
 18. They shall take up serpents; and if they drink any deadly thing, it shall not hurt them; they shall lay hands on the sick, and they shall recover.
 
 19. So then after the Lord had spoken unto them, he was received up into heaven, and sat on the right hand of God.
-20. And they went forth, and preached every where, the Lord working with /them/, and confirming the word with signs following. Amen.  
+20. And they went forth, and preached every where, the Lord working with /them/, and confirming the word with signs following. Amen.

--- a/42_LUK.org
+++ b/42_LUK.org
@@ -80,7 +80,7 @@
 77. To give knowledge of salvation unto his people by the remission of their sins,
 78. Through the tender mercy of our God; whereby the dayspring from on high hath visited us,
 79. To give light to them that sit in darkness and /in/ the shadow of death, to guide our feet into the way of peace.
-80. And the child grew, and waxed strong in spirit, and was in the deserts till the day of his shewing unto Israel. 
+80. And the child grew, and waxed strong in spirit, and was in the deserts till the day of his shewing unto Israel.
 * 2
 1. And it came to pass in those days, that there went out a decree from Cæsar Augustus, that all the world should be taxed.
 2. (/And/ this taxing was first made when Cyrenius was governor of Syria.)
@@ -124,7 +124,7 @@
 40. And the child grew, and waxed strong in spirit, filled with wisdom: and the grace of God was upon him.
 41. Now his parents went to Jerusalem every year at the feast of the passover.
 42. And when he was twelve years old, they went up to Jerusalem after the custom of the feast.
-43. And when they had fulfilled the days, as they returned, the child Jesus tarried behind in Jerusalem; and Joseph and his mother knew not /of it/. 
+43. And when they had fulfilled the days, as they returned, the child Jesus tarried behind in Jerusalem; and Joseph and his mother knew not /of it/.
 44. But they, supposing him to have been in the company, went a day's journey; and they sought him among /their/ kinsfolk and acquaintance.
 45. And when they found him not, they turned back again to Jerusalem, seeking him.
 46. And it came to pass, that after three days they found him in the temple, sitting in the midst of the doctors, both hearing them, and asking them questions.
@@ -133,7 +133,7 @@
 49. And he said unto them, How is it that ye sought me? wist ye not that I must be about my Father's business?
 50. And they understood not the saying which he spake unto them.
 51. And he went down with them, and came to Nazareth, and was subject unto them: but his mother kept all these sayings in her heart.
-52. And Jesus increased in wisdom and stature, and in favour with God and man. 
+52. And Jesus increased in wisdom and stature, and in favour with God and man.
 * 3
 1. Now in the fifteenth year of the reign of Tiberius Cæsar, Pontius Pilate being governor of Judæa, and Herod being tetrarch of Galilee, and his brother Philip tetrarch of Ituraea and of the region of Trachonitis, and Lysanias the tetrarch of Abilene,
 2. Annas and Caiaphas being the high priests, the word of God came unto John the son of Zacharias in the wilderness.
@@ -172,7 +172,7 @@
 35. Which was /the son/ of Saruch, which was /the son/ of Ragau, which was /the son/ of Phalec, which was /the son/ of Heber, which was /the son/ of Sala,
 36. Which was /the son/ of Cainan, which was /the son/ of Arphaxad, which was /the son/ of Sem, which was /the son/ of Noe, which was /the son/ of Lamech,
 37. Which was /the son/ of Mathusala, which was /the son/ of Enoch, which was /the son/ of Jared, which was /the son/ of Maleleel, which was /the son/ of Cainan,
-38. Which was /the son/ of Enos, which was /the son/ of Seth, which was /the son/ of Adam, which was /the son/ of God. 
+38. Which was /the son/ of Enos, which was /the son/ of Seth, which was /the son/ of Adam, which was /the son/ of God.
 * 4
 1. And Jesus being full of the Holy Ghost returned from Jordan, and was led by the Spirit into the wilderness,
 2. Being forty days tempted of the devil. And in those days he did eat nothing: and when they were ended, he afterward hungered.
@@ -222,7 +222,7 @@
 41. And devils also came out of many, crying out, and saying, Thou art Christ the Son of God. And he rebuking /them/ suffered them not to speak: for they knew that he was Christ.
 42. And when it was day, he departed and went into a desert place: and the people sought him, and came unto him, and stayed him, that he should not depart from them.
 43. And he said unto them, I must preach the kingdom of God to other cities also: for therefore am I sent.
-44. And he preached in the synagogues of Galilee. 
+44. And he preached in the synagogues of Galilee.
 * 5
 1. And it came to pass, that, as the people pressed upon him to hear the word of God, he stood by the lake of Gennesaret,
 2. And saw two ships standing by the lake: but the fishermen were gone out of them, and were washing /their/ nets.
@@ -268,7 +268,7 @@
 36. And he spake also a parable unto them; No man putteth a piece of a new garment upon an old; if otherwise, then both the new maketh a rent, and the piece that was /taken/ out of the new agreeth not with the old.
 37. And no man putteth new wine into old bottles; else the new wine will burst the bottles, and be spilled, and the bottles shall perish.
 38. But new wine must be put into new bottles; and both are preserved.
-39. No man also having drunk old /wine/ straightway desireth new: for he saith, The old is better. 
+39. No man also having drunk old /wine/ straightway desireth new: for he saith, The old is better.
 * 6
 1. And it came to pass on the second sabbath after the first, that he went through the corn fields; and his disciples plucked the ears of corn, and did eat, rubbing /them/ in /their/ hands.
 2. And certain of the Pharisees said unto them, Why do ye that which is not lawful to do on the sabbath days?
@@ -323,7 +323,7 @@
 46. And why call ye me, Lord, Lord, and do not the things which I say?
 47. Whosoever cometh to me, and heareth my sayings, and doeth them, I will shew you to whom he is like:
 48. He is like a man which built an house, and digged deep, and laid the foundation on a rock: and when the flood arose, the stream beat vehemently upon that house, and could not shake it: for it was founded upon a rock.
-49. But he that heareth, and doeth not, is like a man that without a foundation built an house upon the earth; against which the stream did beat vehemently, and immediately it fell; and the ruin of that house was great. 
+49. But he that heareth, and doeth not, is like a man that without a foundation built an house upon the earth; against which the stream did beat vehemently, and immediately it fell; and the ruin of that house was great.
 * 7
 1. Now when he had ended all his sayings in the audience of the people, he entered into Capernaum.
 2. And a certain centurion's servant, who was dear unto him, was sick, and ready to die.
@@ -332,7 +332,7 @@
 5. For he loveth our nation, and he hath built us a synagogue.
 6. Then Jesus went with them. And when he was now not far from the house, the centurion sent friends to him, saying unto him, Lord, trouble not thyself: for I am not worthy that thou shouldest enter under my roof:
 7. Wherefore neither thought I myself worthy to come unto thee: but say in a word, and my servant shall be healed.
-8. For I also am a man set under authority, having under me soldiers, and I say unto one, Go, and he goeth; and to another, Come, and he cometh; and to my servant, Do this, and he doeth /it/. 
+8. For I also am a man set under authority, having under me soldiers, and I say unto one, Go, and he goeth; and to another, Come, and he cometh; and to my servant, Do this, and he doeth /it/.
 9. When Jesus heard these things, he marvelled at him, and turned him about, and said unto the people that followed him, I say unto you, I have not found so great faith, no, not in Israel.
 10. And they that were sent, returning to the house, found the servant whole that had been sick.
 
@@ -379,7 +379,7 @@
 47. Wherefore I say unto thee, Her sins, which are many, are forgiven; for she loved much: but to whom little is forgiven, /the same/ loveth little.
 48. And he said unto her, Thy sins are forgiven.
 49. And they that sat at meat with him began to say within themselves, Who is this that forgiveth sins also?
-50. And he said to the woman, Thy faith hath saved thee; go in peace. 
+50. And he said to the woman, Thy faith hath saved thee; go in peace.
 * 8
 1. And it came to pass afterward, that he went throughout every city and village, preaching and shewing the glad tidings of the kingdom of God: and the twelve /were/ with him,
 2. And certain women, which had been healed of evil spirits and infirmities, Mary called Magdalene, out of whom went seven devils,
@@ -445,7 +445,7 @@
 53. And they laughed him to scorn, knowing that she was dead.
 54. And he put them all out, and took her by the hand, and called, saying, Maid, arise.
 55. And her spirit came again, and she arose straightway: and he commanded to give her meat.
-56. And her parents were astonished: but he charged them that they should tell no man what was done. 
+56. And her parents were astonished: but he charged them that they should tell no man what was done.
 * 9
 1. Then he called his twelve disciples together, and gave them power and authority over all devils, and to cure diseases.
 2. And he sent them to preach the kingdom of God, and to heal the sick.
@@ -519,7 +519,7 @@
 59. And he said unto another, Follow me. But he said, Lord, suffer me first to go and bury my father.
 60. Jesus said unto him, Let the dead bury their dead: but go thou and preach the kingdom of God.
 61. And another also said, Lord, I will follow thee; but let me first go bid them farewell, which are at home at my house.
-62. And Jesus said unto him, No man, having put his hand to the plough, and looking back, is fit for the kingdom of God. 
+62. And Jesus said unto him, No man, having put his hand to the plough, and looking back, is fit for the kingdom of God.
 * 10
 1. After these things the Lord appointed other seventy also, and sent them two and two before his face into every city and place, whither he himself would come.
 2. Therefore said he unto them, The harvest truly /is/ great, but the labourers /are/ few: pray ye therefore the Lord of the harvest, that he would send forth labourers into his harvest.
@@ -567,7 +567,7 @@
 39. And she had a sister called Mary, which also sat at Jesus' feet, and heard his word.
 40. But Martha was cumbered about much serving, and came to him, and said, Lord, dost thou not care that my sister hath left me to serve alone? bid her therefore that she help me.
 41. And Jesus answered and said unto her, Martha, Martha, thou art careful and troubled about many things:
-42. But one thing is needful: and Mary hath chosen that good part, which shall not be taken away from her. 
+42. But one thing is needful: and Mary hath chosen that good part, which shall not be taken away from her.
 * 11
 1. And it came to pass, that, as he was praying in a certain place, when he ceased, one of his disciples said unto him, Lord, teach us to pray, as John also taught his disciples.
 2. And he said unto them, When ye pray, say, Our Father which art in heaven, Hallowed be thy name. Thy kingdom come. Thy will be done, as in heaven, so in earth.
@@ -627,7 +627,7 @@
 51. From the blood of Abel unto the blood of Zacharias, which perished between the altar and the temple: verily I say unto you, It shall be required of this generation.
 52. Woe unto you, lawyers! for ye have taken away the key of knowledge: ye entered not in yourselves, and them that were entering in ye hindered.
 53. And as he said these things unto them, the scribes and the Pharisees began to urge /him/ vehemently, and to provoke him to speak of many things:
-54. Laying wait for him, and seeking to catch something out of his mouth, that they might accuse him. 
+54. Laying wait for him, and seeking to catch something out of his mouth, that they might accuse him.
 * 12
 1. In the mean time, when there were gathered together an innumerable multitude of people, insomuch that they trode one upon another, he began to say unto his disciples first of all, Beware ye of the leaven of the Pharisees, which is hypocrisy.
 2. For there is nothing covered, that shall not be revealed; neither hid, that shall not be known.
@@ -694,7 +694,7 @@
 57. Yea, and why even of yourselves judge ye not what is right?
 
 58. When thou goest with thine adversary to the magistrate, /as thou art/ in the way, give diligence that thou mayest be delivered from him; lest he hale thee to the judge, and the judge deliver thee to the officer, and the officer cast thee into prison.
-59. I tell thee, thou shalt not depart thence, till thou hast paid the very last mite. 
+59. I tell thee, thou shalt not depart thence, till thou hast paid the very last mite.
 * 13
 1. There were present at that season some that told him of the Galilæans, whose blood Pilate had mingled with their sacrifices.
 2. And Jesus answering said unto them, Suppose ye that these Galilæans were sinners above all the Galilæans, because they suffered such things?
@@ -708,7 +708,7 @@
 9. And if it bear fruit, /well/: and if not, /then/ after that thou shalt cut it down.
 10. And he was teaching in one of the synagogues on the sabbath.
 
-11. And, behold, there was a woman which had a spirit of infirmity eighteen years, and was bowed together, and could in no wise lift up /herself/. 
+11. And, behold, there was a woman which had a spirit of infirmity eighteen years, and was bowed together, and could in no wise lift up /herself/.
 12. And when Jesus saw her, he called /her to him/, and said unto her, Woman, thou art loosed from thine infirmity.
 13. And he laid /his/ hands on her: and immediately she was made straight, and glorified God.
 14. And the ruler of the synagogue answered with indignation, because that Jesus had healed on the sabbath day, and said unto the people, There are six days in which men ought to work: in them therefore come and be healed, and not on the sabbath day.
@@ -735,7 +735,7 @@
 32. And he said unto them, Go ye, and tell that fox, Behold, I cast out devils, and I do cures to day and to morrow, and the third /day/ I shall be perfected.
 33. Nevertheless I must walk to day, and to morrow, and the /day/ following: for it cannot be that a prophet perish out of Jerusalem.
 34. O Jerusalem, Jerusalem, which killest the prophets, and stonest them that are sent unto thee; how often would I have gathered thy children together, as a hen /doth gather/ her brood under /her/ wings, and ye would not!
-35. Behold, your house is left unto you desolate: and verily I say unto you, Ye shall not see me, until /the time/ come when ye shall say, Blessed /is/ he that cometh in the name of the Lord. 
+35. Behold, your house is left unto you desolate: and verily I say unto you, Ye shall not see me, until /the time/ come when ye shall say, Blessed /is/ he that cometh in the name of the Lord.
 * 14
 1. And it came to pass, as he went into the house of one of the chief Pharisees to eat bread on the sabbath day, that they watched him.
 2. And, behold, there was a certain man before him which had the dropsy.
@@ -776,7 +776,7 @@
 33. So likewise, whosoever he be of you that forsaketh not all that he hath, he cannot be my disciple.
 
 34. Salt /is/ good: but if the salt have lost his savour, wherewith shall it be seasoned?
-35. It is neither fit for the land, nor yet for the dunghill; /but/ men cast it out. He that hath ears to hear, let him hear. 
+35. It is neither fit for the land, nor yet for the dunghill; /but/ men cast it out. He that hath ears to hear, let him hear.
 * 15
 1. Then drew near unto him all the publicans and sinners for to hear him.
 2. And the Pharisees and scribes murmured, saying, This man receiveth sinners, and eateth with them.
@@ -812,7 +812,7 @@
 29. And he answering said to /his/ father, Lo, these many years do I serve thee, neither transgressed I at any time thy commandment: and yet thou never gavest me a kid, that I might make merry with my friends:
 30. But as soon as this thy son was come, which hath devoured thy living with harlots, thou hast killed for him the fatted calf.
 31. And he said unto him, Son, thou art ever with me, and all that I have is thine.
-32. It was meet that we should make merry, and be glad: for this thy brother was dead, and is alive again; and was lost, and is found. 
+32. It was meet that we should make merry, and be glad: for this thy brother was dead, and is alive again; and was lost, and is found.
 * 16
 1. And he said also unto his disciples, There was a certain rich man, which had a steward; and the same was accused unto him that he had wasted his goods.
 2. And he called him, and said unto him, How is it that I hear this of thee? give an account of thy stewardship; for thou mayest be no longer steward.
@@ -846,7 +846,7 @@
 28. For I have five brethren; that he may testify unto them, lest they also come into this place of torment.
 29. Abraham saith unto him, They have Moses and the prophets; let them hear them.
 30. And he said, Nay, father Abraham: but if one went unto them from the dead, they will repent.
-31. And he said unto him, If they hear not Moses and the prophets, neither will they be persuaded, though one rose from the dead. 
+31. And he said unto him, If they hear not Moses and the prophets, neither will they be persuaded, though one rose from the dead.
 * 17
 1. Then said he unto the disciples, It is impossible but that offences will come: but woe /unto him/, through whom they come!
 2. It were better for him that a millstone were hanged about his neck, and he cast into the sea, than that he should offend one of these little ones.
@@ -887,7 +887,7 @@
 34. I tell you, in that night there shall be two /men/ in one bed; the one shall be taken, and the other shall be left.
 35. Two /women/ shall be grinding together; the one shall be taken, and the other left.
 36. Two /men/ shall be in the field; the one shall be taken, and the other left.
-37. And they answered and said unto him, Where, Lord? And he said unto them, Wheresoever the body /is/, thither will the eagles be gathered together. 
+37. And they answered and said unto him, Where, Lord? And he said unto them, Wheresoever the body /is/, thither will the eagles be gathered together.
 * 18
 1. And he spake a parable unto them /to this end/, that men ought always to pray, and not to faint;
 2. Saying, There was in a city a judge, which feared not God, neither regarded man:
@@ -933,12 +933,12 @@
 40. And Jesus stood, and commanded him to be brought unto him: and when he was come near, he asked him,
 41. Saying, What wilt thou that I shall do unto thee? And he said, Lord, that I may receive my sight.
 42. And Jesus said unto him, Receive thy sight: thy faith hath saved thee.
-43. And immediately he received his sight, and followed him, glorifying God: and all the people, when they saw /it/, gave praise unto God. 
+43. And immediately he received his sight, and followed him, glorifying God: and all the people, when they saw /it/, gave praise unto God.
 * 19
 1. And /Jesus/ entered and passed through Jericho.
 2. And, behold, /there was/ a man named Zacchæus, which was the chief among the publicans, and he was rich.
 3. And he sought to see Jesus who he was; and could not for the press, because he was little of stature.
-4. And he ran before, and climbed up into a sycomore tree to see him: for he was to pass that /way/. 
+4. And he ran before, and climbed up into a sycomore tree to see him: for he was to pass that /way/.
 5. And when Jesus came to the place, he looked up, and saw him, and said unto him, Zacchæus, make haste, and come down; for to day I must abide at thy house.
 6. And he made haste, and came down, and received him joyfully.
 7. And when they saw /it/, they all murmured, saying, That he was gone to be guest with a man that is a sinner.
@@ -984,7 +984,7 @@
 45. And he went into the temple, and began to cast out them that sold therein, and them that bought;
 46. Saying unto them, It is written, My house is the house of prayer: but ye have made it a den of thieves.
 47. And he taught daily in the temple. But the chief priests and the scribes and the chief of the people sought to destroy him,
-48. And could not find what they might do: for all the people were very attentive to hear him. 
+48. And could not find what they might do: for all the people were very attentive to hear him.
 * 20
 1. And it came to pass, /that/ on one of those days, as he taught the people in the temple, and preached the gospel, the chief priests and the scribes came upon /him/ with the elders,
 2. And spake unto him, saying, Tell us, by what authority doest thou these things? or who is he that gave thee this authority?
@@ -992,7 +992,7 @@
 4. The baptism of John, was it from heaven, or of men?
 5. And they reasoned with themselves, saying, If we shall say, From heaven; he will say, Why then believed ye him not?
 6. But and if we say, Of men; all the people will stone us: for they be persuaded that John was a prophet.
-7. And they answered, that they could not tell whence /it was/. 
+7. And they answered, that they could not tell whence /it was/.
 8. And Jesus said unto them, Neither tell I you by what authority I do these things.
 9. Then began he to speak to the people this parable; A certain man planted a vineyard, and let it forth to husbandmen, and went into a far country for a long time.
 10. And at the season he sent a servant to the husbandmen, that they should give him of the fruit of the vineyard: but the husbandmen beat him, and sent /him/ away empty.
@@ -1028,7 +1028,7 @@
 38. For he is not a God of the dead, but of the living: for all live unto him.
 
 39. Then certain of the scribes answering said, Master, thou hast well said.
-40. And after that they durst not ask him any /question at all/. 
+40. And after that they durst not ask him any /question at all/.
 41. And he said unto them, How say they that Christ is David's son?
 42. And David himself saith in the book of Psalms, The LORD said unto my Lord, Sit thou on my right hand,
 43. Till I make thine enemies thy footstool.
@@ -1036,7 +1036,7 @@
 
 45. Then in the audience of all the people he said unto his disciples,
 46. Beware of the scribes, which desire to walk in long robes, and love greetings in the markets, and the highest seats in the synagogues, and the chief rooms at feasts;
-47. Which devour widows' houses, and for a shew make long prayers: the same shall receive greater damnation. 
+47. Which devour widows' houses, and for a shew make long prayers: the same shall receive greater damnation.
 * 21
 1. And he looked up, and saw the rich men casting their gifts into the treasury.
 2. And he saw also a certain poor widow casting in thither two mites.
@@ -1078,7 +1078,7 @@
 35. For as a snare shall it come on all them that dwell on the face of the whole earth.
 36. Watch ye therefore, and pray always, that ye may be accounted worthy to escape all these things that shall come to pass, and to stand before the Son of man.
 37. And in the day time he was teaching in the temple; and at night he went out, and abode in the mount that is called /the mount/ of Olives.
-38. And all the people came early in the morning to him in the temple, for to hear him. 
+38. And all the people came early in the morning to him in the temple, for to hear him.
 * 22
 1. Now the feast of unleavened bread drew nigh, which is called the Passover.
 2. And the chief priests and scribes sought how they might kill him; for they feared the people.
@@ -1153,7 +1153,7 @@
 61. And the Lord turned, and looked upon Peter. And Peter remembered the word of the Lord, how he had said unto him, Before the cock crow, thou shalt deny me thrice.
 62. And Peter went out, and wept bitterly.
 
-63. And the men that held Jesus mocked him, and smote /him/. 
+63. And the men that held Jesus mocked him, and smote /him/.
 64. And when they had blindfolded him, they struck him on the face, and asked him, saying, Prophesy, who is it that smote thee?
 65. And many other things blasphemously spake they against him.
 
@@ -1162,7 +1162,7 @@
 68. And if I also ask /you/, ye will not answer me, nor let /me/ go.
 69. Hereafter shall the Son of man sit on the right hand of the power of God.
 70. Then said they all, Art thou then the Son of God? And he said unto them, Ye say that I am.
-71. And they said, What need we any further witness? for we ourselves have heard of his own mouth. 
+71. And they said, What need we any further witness? for we ourselves have heard of his own mouth.
 * 23
 1. And the whole multitude of them arose, and led him unto Pilate.
 2. And they began to accuse him, saying, We found this /fellow/ perverting the nation, and forbidding to give tribute to Cæsar, saying that he himself is Christ a King.
@@ -1182,7 +1182,7 @@
 13. And Pilate, when he had called together the chief priests and the rulers and the people,
 14. Said unto them, Ye have brought this man unto me, as one that perverteth the people: and, behold, I, having examined /him/ before you, have found no fault in this man touching those things whereof ye accuse him:
 15. No, nor yet Herod: for I sent you to him; and, lo, nothing worthy of death is done unto him.
-16. I will therefore chastise him, and release /him/. 
+16. I will therefore chastise him, and release /him/.
 17. (For of necessity he must release one unto them at the feast.)
 18. And they cried out all at once, saying, Away with this /man/, and release unto us Barabbas:
 19. (Who for a certain sedition made in the city, and for murder, was cast into prison.)
@@ -1227,7 +1227,7 @@
 53. And he took it down, and wrapped it in linen, and laid it in a sepulchre that was hewn in stone, wherein never man before was laid.
 54. And that day was the preparation, and the sabbath drew on.
 55. And the women also, which came with him from Galilee, followed after, and beheld the sepulchre, and how his body was laid.
-56. And they returned, and prepared spices and ointments; and rested the sabbath day according to the commandment. 
+56. And they returned, and prepared spices and ointments; and rested the sabbath day according to the commandment.
 * 24
 1. Now upon the first /day/ of the week, very early in the morning, they came unto the sepulchre, bringing the spices which they had prepared, and certain /others/ with them.
 2. And they found the stone rolled away from the sepulchre.
@@ -1285,4 +1285,4 @@
 50. And he led them out as far as to Bethany, and he lifted up his hands, and blessed them.
 51. And it came to pass, while he blessed them, he was parted from them, and carried up into heaven.
 52. And they worshipped him, and returned to Jerusalem with great joy:
-53. And were continually in the temple, praising and blessing God. Amen.  
+53. And were continually in the temple, praising and blessing God. Amen.

--- a/43_JHN.org
+++ b/43_JHN.org
@@ -56,16 +56,16 @@
 48. Nathanael saith unto him, Whence knowest thou me? Jesus answered and said unto him, Before that Philip called thee, when thou wast under the fig tree, I saw thee.
 49. Nathanael answered and saith unto him, Rabbi, thou art the Son of God; thou art the King of Israel.
 50. Jesus answered and said unto him, Because I said unto thee, I saw thee under the fig tree, believest thou? thou shalt see greater things than these.
-51. And he saith unto him, Verily, verily, I say unto you, Hereafter ye shall see heaven open, and the angels of God ascending and descending upon the Son of man. 
+51. And he saith unto him, Verily, verily, I say unto you, Hereafter ye shall see heaven open, and the angels of God ascending and descending upon the Son of man.
 * 2
 1. And the third day there was a marriage in Cana of Galilee; and the mother of Jesus was there:
 2. And both Jesus was called, and his disciples, to the marriage.
 3. And when they wanted wine, the mother of Jesus saith unto him, They have no wine.
 4. Jesus saith unto her, Woman, what have I to do with thee? mine hour is not yet come.
-5. His mother saith unto the servants, Whatsoever he saith unto you, do /it/. 
+5. His mother saith unto the servants, Whatsoever he saith unto you, do /it/.
 6. And there were set there six waterpots of stone, after the manner of the purifying of the Jews, containing two or three firkins apiece.
 7. Jesus saith unto them, Fill the waterpots with water. And they filled them up to the brim.
-8. And he saith unto them, Draw out now, and bear unto the governor of the feast. And they bare /it/. 
+8. And he saith unto them, Draw out now, and bear unto the governor of the feast. And they bare /it/.
 9. When the ruler of the feast had tasted the water that was made wine, and knew not whence it was: (but the servants which drew the water knew;) the governor of the feast called the bridegroom,
 10. And saith unto him, Every man at the beginning doth set forth good wine; and when men have well drunk, then that which is worse: /but/ thou hast kept the good wine until now.
 11. This beginning of miracles did Jesus in Cana of Galilee, and manifested forth his glory; and his disciples believed on him.
@@ -85,8 +85,8 @@
 22. When therefore he was risen from the dead, his disciples remembered that he had said this unto them; and they believed the scripture, and the word which Jesus had said.
 
 23. Now when he was in Jerusalem at the passover, in the feast /day/, many believed in his name, when they saw the miracles which he did.
-24. But Jesus did not commit himself unto them, because he knew all /men/, 
-25. And needed not that any should testify of man: for he knew what was in man. 
+24. But Jesus did not commit himself unto them, because he knew all /men/,
+25. And needed not that any should testify of man: for he knew what was in man.
 * 3
 1. There was a man of the Pharisees, named Nicodemus, a ruler of the Jews:
 2. The same came to Jesus by night, and said unto him, Rabbi, we know that thou art a teacher come from God: for no man can do these miracles that thou doest, except God be with him.
@@ -127,9 +127,9 @@
 31. He that cometh from above is above all: he that is of the earth is earthly, and speaketh of the earth: he that cometh from heaven is above all.
 32. And what he hath seen and heard, that he testifieth; and no man receiveth his testimony.
 33. He that hath received his testimony hath set to his seal that God is true.
-34. For he whom God hath sent speaketh the words of God: for God giveth not the Spirit by measure /unto him/. 
+34. For he whom God hath sent speaketh the words of God: for God giveth not the Spirit by measure /unto him/.
 35. The Father loveth the Son, and hath given all things into his hand.
-36. He that believeth on the Son hath everlasting life: and he that believeth not the Son shall not see life; but the wrath of God abideth on him. 
+36. He that believeth on the Son hath everlasting life: and he that believeth not the Son shall not see life; but the wrath of God abideth on him.
 * 4
 1. When therefore the Lord knew how the Pharisees had heard that Jesus made and baptized more disciples than John,
 2. (Though Jesus himself baptized not, but his disciples,)
@@ -188,7 +188,7 @@
 51. And as he was now going down, his servants met him, and told /him/, saying, Thy son liveth.
 52. Then enquired he of them the hour when he began to amend. And they said unto him, Yesterday at the seventh hour the fever left him.
 53. So the father knew that /it was/ at the same hour, in the which Jesus said unto him, Thy son liveth: and himself believed, and his whole house.
-54. This /is/ again the second miracle /that/ Jesus did, when he was come out of Judæa into Galilee. 
+54. This /is/ again the second miracle /that/ Jesus did, when he was come out of Judæa into Galilee.
 * 5
 1. After this there was a feast of the Jews; and Jesus went up to Jerusalem.
 2. Now there is at Jerusalem by the sheep /market/ a pool, which is called in the Hebrew tongue Bethesda, having five porches.
@@ -241,7 +241,7 @@
 44. How can ye believe, which receive honour one of another, and seek not the honour that /cometh/ from God only?
 45. Do not think that I will accuse you to the Father: there is /one/ that accuseth you, /even/ Moses, in whom ye trust.
 46. For had ye believed Moses, ye would have believed me: for he wrote of me.
-47. But if ye believe not his writings, how shall ye believe my words? 
+47. But if ye believe not his writings, how shall ye believe my words?
 * 6
 1. After these things Jesus went over the sea of Galilee, which is /the sea/ of Tiberias.
 2. And a great multitude followed him, because they saw his miracles which he did on them that were diseased.
@@ -317,7 +317,7 @@
 68. Then Simon Peter answered him, Lord, to whom shall we go? thou hast the words of eternal life.
 69. And we believe and are sure that thou art that Christ, the Son of the living God.
 70. Jesus answered them, Have not I chosen you twelve, and one of you is a devil?
-71. He spake of Judas Iscariot /the son/ of Simon: for he it was that should betray him, being one of the twelve. 
+71. He spake of Judas Iscariot /the son/ of Simon: for he it was that should betray him, being one of the twelve.
 * 7
 1. After these things Jesus walked in Galilee: for he would not walk in Jewry, because the Jews sought to kill him.
 2. Now the Jews' feast of tabernacles was at hand.
@@ -376,7 +376,7 @@
 50. Nicodemus saith unto them, (he that came to Jesus by night, being one of them,)
 51. Doth our law judge /any/ man, before it hear him, and know what he doeth?
 52. They answered and said unto him, Art thou also of Galilee? Search, and look: for out of Galilee ariseth no prophet.
-53. And every man went unto his own house. 
+53. And every man went unto his own house.
 * 8
 1. Jesus went unto the mount of Olives.
 2. And early in the morning he came again into the temple, and all the people came unto him; and he sat down, and taught them.
@@ -438,7 +438,7 @@
 56. Your father Abraham rejoiced to see my day: and he saw /it/, and was glad.
 57. Then said the Jews unto him, Thou art not yet fifty years old, and hast thou seen Abraham?
 58. Jesus said unto them, Verily, verily, I say unto you, Before Abraham was, I am.
-59. Then took they up stones to cast at him: but Jesus hid himself, and went out of the temple, going through the midst of them, and so passed by. 
+59. Then took they up stones to cast at him: but Jesus hid himself, and went out of the temple, going through the midst of them, and so passed by.
 * 9
 1. And as /Jesus/ passed by, he saw a man which was blind from /his/ birth.
 2. And his disciples asked him, saying, Master, who did sin, this man, or his parents, that he was born blind?
@@ -449,7 +449,7 @@
 7. And said unto him, Go, wash in the pool of Siloam, (which is by interpretation, Sent.) He went his way therefore, and washed, and came seeing.
 
 8. The neighbours therefore, and they which before had seen him that he was blind, said, Is not this he that sat and begged?
-9. Some said, This is he: others /said/, He is like him: /but/ he said, I am /he/. 
+9. Some said, This is he: others /said/, He is like him: /but/ he said, I am /he/.
 10. Therefore said they unto him, How were thine eyes opened?
 11. He answered and said, A man that is called Jesus made clay, and anointed mine eyes, and said unto me, Go to the pool of Siloam, and wash: and I went and washed, and I received sight.
 12. Then said they unto him, Where is he? He said, I know not.
@@ -483,7 +483,7 @@
 
 39. And Jesus said, For judgment I am come into this world, that they which see not might see; and that they which see might be made blind.
 40. And /some/ of the Pharisees which were with him heard these words, and said unto him, Are we blind also?
-41. Jesus said unto them, If ye were blind, ye should have no sin: but now ye say, We see; therefore your sin remaineth. 
+41. Jesus said unto them, If ye were blind, ye should have no sin: but now ye say, We see; therefore your sin remaineth.
 * 10
 1. Verily, verily, I say unto you, He that entereth not by the door into the sheepfold, but climbeth up some other way, the same is a thief and a robber.
 2. But he that entereth in by the door is the shepherd of the sheep.
@@ -528,7 +528,7 @@
 39. Therefore they sought again to take him: but he escaped out of their hand,
 40. And went away again beyond Jordan into the place where John at first baptized; and there he abode.
 41. And many resorted unto him, and said, John did no miracle: but all things that John spake of this man were true.
-42. And many believed on him there. 
+42. And many believed on him there.
 * 11
 1. Now a certain /man/ was sick, /named/ Lazarus, of Bethany, the town of Mary and her sister Martha.
 2. (It was /that/ Mary which anointed the Lord with ointment, and wiped his feet with her hair, whose brother Lazarus was sick.)
@@ -588,7 +588,7 @@
 
 55. And the Jews' passover was nigh at hand: and many went out of the country up to Jerusalem before the passover, to purify themselves.
 56. Then sought they for Jesus, and spake among themselves, as they stood in the temple, What think ye, that he will not come to the feast?
-57. Now both the chief priests and the Pharisees had given a commandment, that, if any man knew where he were, he should shew /it/, that they might take him. 
+57. Now both the chief priests and the Pharisees had given a commandment, that, if any man knew where he were, he should shew /it/, that they might take him.
 * 12
 1. Then Jesus six days before the passover came to Bethany, where Lazarus was which had been dead, whom he raised from the dead.
 2. There they made him a supper; and Martha served: but Lazarus was one of them that sat at the table with him.
@@ -646,7 +646,7 @@
 47. And if any man hear my words, and believe not, I judge him not: for I came not to judge the world, but to save the world.
 48. He that rejecteth me, and receiveth not my words, hath one that judgeth him: the word that I have spoken, the same shall judge him in the last day.
 49. For I have not spoken of myself; but the Father which sent me, he gave me a commandment, what I should say, and what I should speak.
-50. And I know that his commandment is life everlasting: whatsoever I speak therefore, even as the Father said unto me, so I speak. 
+50. And I know that his commandment is life everlasting: whatsoever I speak therefore, even as the Father said unto me, so I speak.
 * 13
 1. Now before the feast of the passover, when Jesus knew that his hour was come that he should depart out of this world unto the Father, having loved his own which were in the world, he loved them unto the end.
 2. And supper being ended, the devil having now put into the heart of Judas Iscariot, Simon's /son/, to betray him;
@@ -688,7 +688,7 @@
 
 36. Simon Peter said unto him, Lord, whither goest thou? Jesus answered him, Whither I go, thou canst not follow me now; but thou shalt follow me afterwards.
 37. Peter said unto him, Lord, why cannot I follow thee now? I will lay down my life for thy sake.
-38. Jesus answered him, Wilt thou lay down thy life for my sake? Verily, verily, I say unto thee, The cock shall not crow, till thou hast denied me thrice. 
+38. Jesus answered him, Wilt thou lay down thy life for my sake? Verily, verily, I say unto thee, The cock shall not crow, till thou hast denied me thrice.
 * 14
 1. Let not your heart be troubled: ye believe in God, believe also in me.
 2. In my Father's house are many mansions: if /it were/ not /so/, I would have told you. I go to prepare a place for you.
@@ -721,7 +721,7 @@
 28. Ye have heard how I said unto you, I go away, and come /again/ unto you. If ye loved me, ye would rejoice, because I said, I go unto the Father: for my Father is greater than I.
 29. And now I have told you before it come to pass, that, when it is come to pass, ye might believe.
 30. Hereafter I will not talk much with you: for the prince of this world cometh, and hath nothing in me.
-31. But that the world may know that I love the Father; and as the Father gave me commandment, even so I do. Arise, let us go hence. 
+31. But that the world may know that I love the Father; and as the Father gave me commandment, even so I do. Arise, let us go hence.
 * 15
 1. I am the true vine, and my Father is the husbandman.
 2. Every branch in me that beareth not fruit he taketh away: and every /branch/ that beareth fruit, he purgeth it, that it may bring forth more fruit.
@@ -749,7 +749,7 @@
 24. If I had not done among them the works which none other man did, they had not had sin: but now have they both seen and hated both me and my Father.
 25. But /this cometh to pass/, that the word might be fulfilled that is written in their law, They hated me without a cause.
 26. But when the Comforter is come, whom I will send unto you from the Father, /even/ the Spirit of truth, which proceedeth from the Father, he shall testify of me:
-27. And ye also shall bear witness, because ye have been with me from the beginning. 
+27. And ye also shall bear witness, because ye have been with me from the beginning.
 * 16
 1. These things have I spoken unto you, that ye should not be offended.
 2. They shall put you out of the synagogues: yea, the time cometh, that whosoever killeth you will think that he doeth God service.
@@ -783,7 +783,7 @@
 30. Now are we sure that thou knowest all things, and needest not that any man should ask thee: by this we believe that thou camest forth from God.
 31. Jesus answered them, Do ye now believe?
 32. Behold, the hour cometh, yea, is now come, that ye shall be scattered, every man to his own, and shall leave me alone: and yet I am not alone, because the Father is with me.
-33. These things I have spoken unto you, that in me ye might have peace. In the world ye shall have tribulation: but be of good cheer; I have overcome the world. 
+33. These things I have spoken unto you, that in me ye might have peace. In the world ye shall have tribulation: but be of good cheer; I have overcome the world.
 * 17
 1. These words spake Jesus, and lifted up his eyes to heaven, and said, Father, the hour is come; glorify thy Son, that thy Son also may glorify thee:
 2. As thou hast given him power over all flesh, that he should give eternal life to as many as thou hast given him.
@@ -810,7 +810,7 @@
 23. I in them, and thou in me, that they may be made perfect in one; and that the world may know that thou hast sent me, and hast loved them, as thou hast loved me.
 24. Father, I will that they also, whom thou hast given me, be with me where I am; that they may behold my glory, which thou hast given me: for thou lovedst me before the foundation of the world.
 25. O righteous Father, the world hath not known thee: but I have known thee, and these have known that thou hast sent me.
-26. And I have declared unto them thy name, and will declare /it/: that the love wherewith thou hast loved me may be in them, and I in them. 
+26. And I have declared unto them thy name, and will declare /it/: that the love wherewith thou hast loved me may be in them, and I in them.
 * 18
 1. When Jesus had spoken these words, he went forth with his disciples over the brook Cedron, where was a garden, into the which he entered, and his disciples.
 2. And Judas also, which betrayed him, knew the place: for Jesus ofttimes resorted thither with his disciples.
@@ -852,11 +852,11 @@
 35. Pilate answered, Am I a Jew? Thine own nation and the chief priests have delivered thee unto me: what hast thou done?
 36. Jesus answered, My kingdom is not of this world: if my kingdom were of this world, then would my servants fight, that I should not be delivered to the Jews: but now is my kingdom not from hence.
 37. Pilate therefore said unto him, Art thou a king then? Jesus answered, Thou sayest that I am a king. To this end was I born, and for this cause came I into the world, that I should bear witness unto the truth. Every one that is of the truth heareth my voice.
-38. Pilate saith unto him, What is truth? And when he had said this, he went out again unto the Jews, and saith unto them, I find in him no fault /at all/. 
+38. Pilate saith unto him, What is truth? And when he had said this, he went out again unto the Jews, and saith unto them, I find in him no fault /at all/.
 39. But ye have a custom, that I should release unto you one at the passover: will ye therefore that I release unto you the King of the Jews?
-40. Then cried they all again, saying, Not this man, but Barabbas. Now Barabbas was a robber. 
+40. Then cried they all again, saying, Not this man, but Barabbas. Now Barabbas was a robber.
 * 19
-1. Then Pilate therefore took Jesus, and scourged /him/. 
+1. Then Pilate therefore took Jesus, and scourged /him/.
 2. And the soldiers platted a crown of thorns, and put /it/ on his head, and they put on him a purple robe,
 3. And said, Hail, King of the Jews! and they smote him with their hands.
 4. Pilate therefore went forth again, and saith unto them, Behold, I bring him forth to you, that ye may know that I find no fault in him.
@@ -901,10 +901,10 @@
 37. And again another scripture saith, They shall look on him whom they pierced.
 
 38. And after this Joseph of Arimathaea, being a disciple of Jesus, but secretly for fear of the Jews, besought Pilate that he might take away the body of Jesus: and Pilate gave /him/ leave. He came therefore, and took the body of Jesus.
-39. And there came also Nicodemus, which at the first came to Jesus by night, and brought a mixture of myrrh and aloes, about an hundred pound /weight/. 
+39. And there came also Nicodemus, which at the first came to Jesus by night, and brought a mixture of myrrh and aloes, about an hundred pound /weight/.
 40. Then took they the body of Jesus, and wound it in linen clothes with the spices, as the manner of the Jews is to bury.
 41. Now in the place where he was crucified there was a garden; and in the garden a new sepulchre, wherein was never man yet laid.
-42. There laid they Jesus therefore because of the Jews' preparation /day/; for the sepulchre was nigh at hand. 
+42. There laid they Jesus therefore because of the Jews' preparation /day/; for the sepulchre was nigh at hand.
 * 20
 1. The first /day/ of the week cometh Mary Magdalene early, when it was yet dark, unto the sepulchre, and seeth the stone taken away from the sepulchre.
 2. Then she runneth, and cometh to Simon Peter, and to the other disciple, whom Jesus loved, and saith unto them, They have taken away the Lord out of the sepulchre, and we know not where they have laid him.
@@ -941,9 +941,9 @@
 29. Jesus saith unto him, Thomas, because thou hast seen me, thou hast believed: blessed /are/ they that have not seen, and /yet/ have believed.
 
 30. And many other signs truly did Jesus in the presence of his disciples, which are not written in this book:
-31. But these are written, that ye might believe that Jesus is the Christ, the Son of God; and that believing ye might have life through his name. 
+31. But these are written, that ye might believe that Jesus is the Christ, the Son of God; and that believing ye might have life through his name.
 * 21
-1. After these things Jesus shewed himself again to the disciples at the sea of Tiberias; and on this wise shewed he /himself/. 
+1. After these things Jesus shewed himself again to the disciples at the sea of Tiberias; and on this wise shewed he /himself/.
 2. There were together Simon Peter, and Thomas called Didymus, and Nathanael of Cana in Galilee, and the /sons/ of Zebedee, and two other of his disciples.
 3. Simon Peter saith unto them, I go a fishing. They say unto him, We also go with thee. They went forth, and entered into a ship immediately; and that night they caught nothing.
 4. But when the morning was now come, Jesus stood on the shore: but the disciples knew not that it was Jesus.
@@ -964,8 +964,8 @@
 18. Verily, verily, I say unto thee, When thou wast young, thou girdedst thyself, and walkedst whither thou wouldest: but when thou shalt be old, thou shalt stretch forth thy hands, and another shall gird thee, and carry /thee/ whither thou wouldest not.
 19. This spake he, signifying by what death he should glorify God. And when he had spoken this, he saith unto him, Follow me.
 20. Then Peter, turning about, seeth the disciple whom Jesus loved following; which also leaned on his breast at supper, and said, Lord, which is he that betrayeth thee?
-21. Peter seeing him saith to Jesus, Lord, and what /shall/ this man /do/? 
+21. Peter seeing him saith to Jesus, Lord, and what /shall/ this man /do/?
 22. Jesus saith unto him, If I will that he tarry till I come, what /is that/ to thee? follow thou me.
 23. Then went this saying abroad among the brethren, that that disciple should not die: yet Jesus said not unto him, He shall not die; but, If I will that he tarry till I come, what /is that/ to thee?
 24. This is the disciple which testifieth of these things, and wrote these things: and we know that his testimony is true.
-25. And there are also many other things which Jesus did, the which, if they should be written every one, I suppose that even the world itself could not contain the books that should be written. Amen.  
+25. And there are also many other things which Jesus did, the which, if they should be written every one, I suppose that even the world itself could not contain the books that should be written. Amen.

--- a/44_ACT.org
+++ b/44_ACT.org
@@ -26,7 +26,7 @@
 23. And they appointed two, Joseph called Barsabas, who was surnamed Justus, and Matthias.
 24. And they prayed, and said, Thou, Lord, which knowest the hearts of all /men/, shew whether of these two thou hast chosen,
 25. That he may take part of this ministry and apostleship, from which Judas by transgression fell, that he might go to his own place.
-26. And they gave forth their lots; and the lot fell upon Matthias; and he was numbered with the eleven apostles. 
+26. And they gave forth their lots; and the lot fell upon Matthias; and he was numbered with the eleven apostles.
 * 2
 1. And when the day of Pentecost was fully come, they were all with one accord in one place.
 2. And suddenly there came a sound from heaven as of a rushing mighty wind, and it filled all the house where they were sitting.
@@ -77,7 +77,7 @@
 44. And all that believed were together, and had all things common;
 45. And sold their possessions and goods, and parted them to all /men/, as every man had need.
 46. And they, continuing daily with one accord in the temple, and breaking bread from house to house, did eat their meat with gladness and singleness of heart,
-47. Praising God, and having favour with all the people. And the Lord added to the church daily such as should be saved. 
+47. Praising God, and having favour with all the people. And the Lord added to the church daily such as should be saved.
 * 3
 1. Now Peter and John went up together into the temple at the hour of prayer, /being/ the ninth /hour/.
 2. And a certain man lame from his mother's womb was carried, whom they laid daily at the gate of the temple which is called Beautiful, to ask alms of them that entered into the temple;
@@ -106,7 +106,7 @@
 23. And it shall come to pass, /that/ every soul, which will not hear that prophet, shall be destroyed from among the people.
 24. Yea, and all the prophets from Samuel and those that follow after, as many as have spoken, have likewise foretold of these days.
 25. Ye are the children of the prophets, and of the covenant which God made with our fathers, saying unto Abraham, And in thy seed shall all the kindreds of the earth be blessed.
-26. Unto you first God, having raised up his Son Jesus, sent him to bless you, in turning away every one of you from his iniquities. 
+26. Unto you first God, having raised up his Son Jesus, sent him to bless you, in turning away every one of you from his iniquities.
 * 4
 1. And as they spake unto the people, the priests, and the captain of the temple, and the Sadducees, came upon them,
 2. Being grieved that they taught the people, and preached through Jesus the resurrection from the dead.
@@ -125,7 +125,7 @@
 13. Now when they saw the boldness of Peter and John, and perceived that they were unlearned and ignorant men, they marvelled; and they took knowledge of them, that they had been with Jesus.
 14. And beholding the man which was healed standing with them, they could say nothing against it.
 15. But when they had commanded them to go aside out of the council, they conferred among themselves,
-16. Saying, What shall we do to these men? for that indeed a notable miracle hath been done by them /is/ manifest to all them that dwell in Jerusalem; and we cannot deny /it/. 
+16. Saying, What shall we do to these men? for that indeed a notable miracle hath been done by them /is/ manifest to all them that dwell in Jerusalem; and we cannot deny /it/.
 17. But that it spread no further among the people, let us straitly threaten them, that they speak henceforth to no man in this name.
 18. And they called them, and commanded them not to speak at all nor teach in the name of Jesus.
 19. But Peter and John answered and said unto them, Whether it be right in the sight of God to hearken unto you more than unto God, judge ye.
@@ -148,14 +148,14 @@
 34. Neither was there any among them that lacked: for as many as were possessors of lands or houses sold them, and brought the prices of the things that were sold,
 35. And laid /them/ down at the apostles' feet: and distribution was made unto every man according as he had need.
 36. And Joses, who by the apostles was surnamed Barnabas, (which is, being interpreted, The son of consolation,) a Levite, /and/ of the country of Cyprus,
-37. Having land, sold /it/, and brought the money, and laid /it/ at the apostles' feet. 
+37. Having land, sold /it/, and brought the money, and laid /it/ at the apostles' feet.
 * 5
 1. But a certain man named Ananias, with Sapphira his wife, sold a possession,
 2. And kept back /part/ of the price, his wife also being privy /to it/, and brought a certain part, and laid /it/ at the apostles' feet.
 3. But Peter said, Ananias, why hath Satan filled thine heart to lie to the Holy Ghost, and to keep back /part/ of the price of the land?
 4. Whiles it remained, was it not thine own? and after it was sold, was it not in thine own power? why hast thou conceived this thing in thine heart? thou hast not lied unto men, but unto God.
 5. And Ananias hearing these words fell down, and gave up the ghost: and great fear came on all them that heard these things.
-6. And the young men arose, wound him up, and carried /him/ out, and buried /him/. 
+6. And the young men arose, wound him up, and carried /him/ out, and buried /him/.
 7. And it was about the space of three hours after, when his wife, not knowing what was done, came in.
 8. And Peter answered unto her, Tell me whether ye sold the land for so much? And she said, Yea, for so much.
 9. Then Peter said unto her, How is it that ye have agreed together to tempt the Spirit of the Lord? behold, the feet of them which have buried thy husband /are/ at the door, and shall carry thee out.
@@ -196,7 +196,7 @@
 40. And to him they agreed: and when they had called the apostles, and beaten /them/, they commanded that they should not speak in the name of Jesus, and let them go.
 
 41. And they departed from the presence of the council, rejoicing that they were counted worthy to suffer shame for his name.
-42. And daily in the temple, and in every house, they ceased not to teach and preach Jesus Christ. 
+42. And daily in the temple, and in every house, they ceased not to teach and preach Jesus Christ.
 * 6
 1. And in those days, when the number of the disciples was multiplied, there arose a murmuring of the Grecians against the Hebrews, because their widows were neglected in the daily ministration.
 2. Then the twelve called the multitude of the disciples /unto them/, and said, It is not reason that we should leave the word of God, and serve tables.
@@ -214,7 +214,7 @@
 12. And they stirred up the people, and the elders, and the scribes, and came upon /him/, and caught him, and brought /him/ to the council,
 13. And set up false witnesses, which said, This man ceaseth not to speak blasphemous words against this holy place, and the law:
 14. For we have heard him say, that this Jesus of Nazareth shall destroy this place, and shall change the customs which Moses delivered us.
-15. And all that sat in the council, looking stedfastly on him, saw his face as it had been the face of an angel. 
+15. And all that sat in the council, looking stedfastly on him, saw his face as it had been the face of an angel.
 * 7
 1. Then said the high priest, Are these things so?
 2. And he said, Men, brethren, and fathers, hearken; The God of glory appeared unto our father Abraham, when he was in Mesopotamia, before he dwelt in Charran,
@@ -278,7 +278,7 @@
 57. Then they cried out with a loud voice, and stopped their ears, and ran upon him with one accord,
 58. And cast /him/ out of the city, and stoned /him/: and the witnesses laid down their clothes at a young man's feet, whose name was Saul.
 59. And they stoned Stephen, calling upon /God/, and saying, Lord Jesus, receive my spirit.
-60. And he kneeled down, and cried with a loud voice, Lord, lay not this sin to their charge. And when he had said this, he fell asleep. 
+60. And he kneeled down, and cried with a loud voice, Lord, lay not this sin to their charge. And when he had said this, he fell asleep.
 * 8
 1. And Saul was consenting unto his death. And at that time there was a great persecution against the church which was at Jerusalem; and they were all scattered abroad throughout the regions of Judæa and Samaria, except the apostles.
 2. And devout men carried Stephen /to his burial/, and made great lamentation over him.
@@ -319,7 +319,7 @@
 37. And Philip said, If thou believest with all thine heart, thou mayest. And he answered and said, I believe that Jesus Christ is the Son of God.
 38. And he commanded the chariot to stand still: and they went down both into the water, both Philip and the eunuch; and he baptized him.
 39. And when they were come up out of the water, the Spirit of the Lord caught away Philip, that the eunuch saw him no more: and he went on his way rejoicing.
-40. But Philip was found at Azotus: and passing through he preached in all the cities, till he came to Cæsarea. 
+40. But Philip was found at Azotus: and passing through he preached in all the cities, till he came to Cæsarea.
 * 9
 1. And Saul, yet breathing out threatenings and slaughter against the disciples of the Lord, went unto the high priest,
 2. And desired of him letters to Damascus to the synagogues, that if he found any of this way, whether they were men or women, he might bring them bound unto Jerusalem.
@@ -367,9 +367,9 @@
 40. But Peter put them all forth, and kneeled down, and prayed; and turning /him/ to the body said, Tabitha, arise. And she opened her eyes: and when she saw Peter, she sat up.
 41. And he gave her /his/ hand, and lifted her up, and when he had called the saints and widows, presented her alive.
 42. And it was known throughout all Joppa; and many believed in the Lord.
-43. And it came to pass, that he tarried many days in Joppa with one Simon a tanner. 
+43. And it came to pass, that he tarried many days in Joppa with one Simon a tanner.
 * 10
-1. There was a certain man in Cæsarea called Cornelius, a centurion of the band called the Italian /band/, 
+1. There was a certain man in Cæsarea called Cornelius, a centurion of the band called the Italian /band/,
 2. /A/ devout /man/, and one that feared God with all his house, which gave much alms to the people, and prayed to God alway.
 3. He saw in a vision evidently about the ninth hour of the day an angel of God coming in to him, and saying unto him, Cornelius.
 4. And when he looked on him, he was afraid, and said, What is it, Lord? And he said unto him, Thy prayers and thine alms are come up for a memorial before God.
@@ -395,7 +395,7 @@
 22. And they said, Cornelius the centurion, a just man, and one that feareth God, and of good report among all the nation of the Jews, was warned from God by an holy angel to send for thee into his house, and to hear words of thee.
 23. Then called he them in, and lodged /them/. And on the morrow Peter went away with them, and certain brethren from Joppa accompanied him.
 24. And the morrow after they entered into Cæsarea. And Cornelius waited for them, and had called together his kinsmen and near friends.
-25. And as Peter was coming in, Cornelius met him, and fell down at his feet, and worshipped /him/. 
+25. And as Peter was coming in, Cornelius met him, and fell down at his feet, and worshipped /him/.
 26. But Peter took him up, saying, Stand up; I myself also am a man.
 27. And as he talked with him, he went in, and found many that were come together.
 28. And he said unto them, Ye know how that it is an unlawful thing for a man that is a Jew to keep company, or come unto one of another nation; but God hath shewed me that I should not call any man common or unclean.
@@ -420,7 +420,7 @@
 45. And they of the circumcision which believed were astonished, as many as came with Peter, because that on the Gentiles also was poured out the gift of the Holy Ghost.
 46. For they heard them speak with tongues, and magnify God. Then answered Peter,
 47. Can any man forbid water, that these should not be baptized, which have received the Holy Ghost as well as we?
-48. And he commanded them to be baptized in the name of the Lord. Then prayed they him to tarry certain days. 
+48. And he commanded them to be baptized in the name of the Lord. Then prayed they him to tarry certain days.
 * 11
 1. And the apostles and brethren that were in Judæa heard that the Gentiles had also received the word of God.
 2. And when Peter was come up to Jerusalem, they that were of the circumcision contended with him,
@@ -454,7 +454,7 @@
 27. And in these days came prophets from Jerusalem unto Antioch.
 28. And there stood up one of them named Agabus, and signified by the Spirit that there should be great dearth throughout all the world: which came to pass in the days of Claudius Cæsar.
 29. Then the disciples, every man according to his ability, determined to send relief unto the brethren which dwelt in Judæa:
-30. Which also they did, and sent it to the elders by the hands of Barnabas and Saul. 
+30. Which also they did, and sent it to the elders by the hands of Barnabas and Saul.
 * 12
 1. Now about that time Herod the king stretched forth /his/ hands to vex certain of the church.
 2. And he killed James the brother of John with the sword.
@@ -482,7 +482,7 @@
 23. And immediately the angel of the Lord smote him, because he gave not God the glory: and he was eaten of worms, and gave up the ghost.
 
 24. But the word of God grew and multiplied.
-25. And Barnabas and Saul returned from Jerusalem, when they had fulfilled /their/ ministry, and took with them John, whose surname was Mark. 
+25. And Barnabas and Saul returned from Jerusalem, when they had fulfilled /their/ ministry, and took with them John, whose surname was Mark.
 * 13
 1. Now there were in the church that was at Antioch certain prophets and teachers; as Barnabas, and Simeon that was called Niger, and Lucius of Cyrene, and Manaen, which had been brought up with Herod the tetrarch, and Saul.
 2. As they ministered to the Lord, and fasted, the Holy Ghost said, Separate me Barnabas and Saul for the work whereunto I have called them.
@@ -512,7 +512,7 @@
 24. When John had first preached before his coming the baptism of repentance to all the people of Israel.
 25. And as John fulfilled his course, he said, Whom think ye that I am? I am not /he/. But, behold, there cometh one after me, whose shoes of /his/ feet I am not worthy to loose.
 26. Men /and/ brethren, children of the stock of Abraham, and whosoever among you feareth God, to you is the word of this salvation sent.
-27. For they that dwell at Jerusalem, and their rulers, because they knew him not, nor yet the voices of the prophets which are read every sabbath day, they have fulfilled /them/ in condemning /him/. 
+27. For they that dwell at Jerusalem, and their rulers, because they knew him not, nor yet the voices of the prophets which are read every sabbath day, they have fulfilled /them/ in condemning /him/.
 28. And though they found no cause of death /in him/, yet desired they Pilate that he should be slain.
 29. And when they had fulfilled all that was written of him, they took /him/ down from the tree, and laid /him/ in a sepulchre.
 30. But God raised him from the dead:
@@ -539,7 +539,7 @@
 49. And the word of the Lord was published throughout all the region.
 50. But the Jews stirred up the devout and honourable women, and the chief men of the city, and raised persecution against Paul and Barnabas, and expelled them out of their coasts.
 51. But they shook off the dust of their feet against them, and came unto Iconium.
-52. And the disciples were filled with joy, and with the Holy Ghost. 
+52. And the disciples were filled with joy, and with the Holy Ghost.
 * 14
 1. And it came to pass in Iconium, that they went both together into the synagogue of the Jews, and so spake, that a great multitude both of the Jews and also of the Greeks believed.
 2. But the unbelieving Jews stirred up the Gentiles, and made their minds evil affected against the brethren.
@@ -570,7 +570,7 @@
 25. And when they had preached the word in Perga, they went down into Attalia:
 26. And thence sailed to Antioch, from whence they had been recommended to the grace of God for the work which they fulfilled.
 27. And when they were come, and had gathered the church together, they rehearsed all that God had done with them, and how he had opened the door of faith unto the Gentiles.
-28. And there they abode long time with the disciples. 
+28. And there they abode long time with the disciples.
 * 15
 1. And certain men which came down from Judæa taught the brethren, /and said/, Except ye be circumcised after the manner of Moses, ye cannot be saved.
 2. When therefore Paul and Barnabas had no small dissension and disputation with them, they determined that Paul and Barnabas, and certain other of them, should go up to Jerusalem unto the apostles and elders about this question.
@@ -606,7 +606,7 @@
 29. That ye abstain from meats offered to idols, and from blood, and from things strangled, and from fornication: from which if ye keep yourselves, ye shall do well. Fare ye well.
 30. So when they were dismissed, they came to Antioch: and when they had gathered the multitude together, they delivered the epistle:
 31. /Which/ when they had read, they rejoiced for the consolation.
-32. And Judas and Silas, being prophets also themselves, exhorted the brethren with many words, and confirmed /them/. 
+32. And Judas and Silas, being prophets also themselves, exhorted the brethren with many words, and confirmed /them/.
 33. And after they had tarried /there/ a space, they were let go in peace from the brethren unto the apostles.
 34. Notwithstanding it pleased Silas to abide there still.
 35. Paul also and Barnabas continued in Antioch, teaching and preaching the word of the Lord, with many others also.
@@ -616,7 +616,7 @@
 38. But Paul thought not good to take him with them, who departed from them from Pamphylia, and went not with them to the work.
 39. And the contention was so sharp between them, that they departed asunder one from the other: and so Barnabas took Mark, and sailed unto Cyprus;
 40. And Paul chose Silas, and departed, being recommended by the brethren unto the grace of God.
-41. And he went through Syria and Cilicia, confirming the churches. 
+41. And he went through Syria and Cilicia, confirming the churches.
 * 16
 1. Then came he to Derbe and Lystra: and, behold, a certain disciple was there, named Timotheus, the son of a certain woman, which was a Jewess, and believed; but his father /was/ a Greek:
 2. Which was well reported of by the brethren that were at Lystra and Iconium.
@@ -642,7 +642,7 @@
 19. And when her masters saw that the hope of their gains was gone, they caught Paul and Silas, and drew /them/ into the marketplace unto the rulers,
 20. And brought them to the magistrates, saying, These men, being Jews, do exceedingly trouble our city,
 21. And teach customs, which are not lawful for us to receive, neither to observe, being Romans.
-22. And the multitude rose up together against them: and the magistrates rent off their clothes, and commanded to beat /them/. 
+22. And the multitude rose up together against them: and the magistrates rent off their clothes, and commanded to beat /them/.
 23. And when they had laid many stripes upon them, they cast /them/ into prison, charging the jailor to keep them safely:
 24. Who, having received such a charge, thrust them into the inner prison, and made their feet fast in the stocks.
 
@@ -661,7 +661,7 @@
 37. But Paul said unto them, They have beaten us openly uncondemned, being Romans, and have cast /us/ into prison; and now do they thrust us out privily? nay verily; but let them come themselves and fetch us out.
 38. And the serjeants told these words unto the magistrates: and they feared, when they heard that they were Romans.
 39. And they came and besought them, and brought /them/ out, and desired /them/ to depart out of the city.
-40. And they went out of the prison, and entered into /the house of/ Lydia: and when they had seen the brethren, they comforted them, and departed. 
+40. And they went out of the prison, and entered into /the house of/ Lydia: and when they had seen the brethren, they comforted them, and departed.
 * 17
 1. Now when they had passed through Amphipolis and Apollonia, they came to Thessalonica, where was a synagogue of the Jews:
 2. And Paul, as his manner was, went in unto them, and three sabbath days reasoned with them out of the scriptures,
@@ -684,7 +684,7 @@
 16. Now while Paul waited for them at Athens, his spirit was stirred in him, when he saw the city wholly given to idolatry.
 17. Therefore disputed he in the synagogue with the Jews, and with the devout persons, and in the market daily with them that met with him.
 18. Then certain philosophers of the Epicureans, and of the Stoicks, encountered him. And some said, What will this babbler say? other some, He seemeth to be a setter forth of strange gods: because he preached unto them Jesus, and the resurrection.
-19. And they took him, and brought him unto Areopagus, saying, May we know what this new doctrine, whereof thou speakest, /is/? 
+19. And they took him, and brought him unto Areopagus, saying, May we know what this new doctrine, whereof thou speakest, /is/?
 20. For thou bringest certain strange things to our ears: we would know therefore what these things mean.
 21. (For all the Athenians and strangers which were there spent their time in nothing else, but either to tell, or to hear some new thing.)
 
@@ -699,9 +699,9 @@
 30. And the times of this ignorance God winked at; but now commandeth all men every where to repent:
 31. Because he hath appointed a day, in the which he will judge the world in righteousness by /that/ man whom he hath ordained; /whereof/ he hath given assurance unto all /men/, in that he hath raised him from the dead.
 
-32. And when they heard of the resurrection of the dead, some mocked: and others said, We will hear thee again of this /matter/. 
+32. And when they heard of the resurrection of the dead, some mocked: and others said, We will hear thee again of this /matter/.
 33. So Paul departed from among them.
-34. Howbeit certain men clave unto him, and believed: among the which /was/ Dionysius the Areopagite, and a woman named Damaris, and others with them. 
+34. Howbeit certain men clave unto him, and believed: among the which /was/ Dionysius the Areopagite, and a woman named Damaris, and others with them.
 * 18
 1. After these things Paul departed from Athens, and came to Corinth;
 2. And found a certain Jew named Aquila, born in Pontus, lately come from Italy, with his wife Priscilla; (because that Claudius had commanded all Jews to depart from Rome:) and came unto them.
@@ -734,7 +734,7 @@
 25. This man was instructed in the way of the Lord; and being fervent in the spirit, he spake and taught diligently the things of the Lord, knowing only the baptism of John.
 26. And he began to speak boldly in the synagogue: whom when Aquila and Priscilla had heard, they took him unto /them/, and expounded unto him the way of God more perfectly.
 27. And when he was disposed to pass into Achaia, the brethren wrote, exhorting the disciples to receive him: who, when he was come, helped them much which had believed through grace:
-28. For he mightily convinced the Jews, /and that/ publickly, shewing by the scriptures that Jesus was Christ. 
+28. For he mightily convinced the Jews, /and that/ publickly, shewing by the scriptures that Jesus was Christ.
 * 19
 1. And it came to pass, that, while Apollos was at Corinth, Paul having passed through the upper coasts came to Ephesus: and finding certain disciples,
 2. He said unto them, Have ye received the Holy Ghost since ye believed? And they said unto him, We have not so much as heard whether there be any Holy Ghost.
@@ -778,7 +778,7 @@
 38. Wherefore if Demetrius, and the craftsmen which are with him, have a matter against any man, the law is open, and there are deputies: let them implead one another.
 39. But if ye enquire any thing concerning other matters, it shall be determined in a lawful assembly.
 40. For we are in danger to be called in question for this day's uproar, there being no cause whereby we may give an account of this concourse.
-41. And when he had thus spoken, he dismissed the assembly. 
+41. And when he had thus spoken, he dismissed the assembly.
 * 20
 1. And after the uproar was ceased, Paul called unto /him/ the disciples, and embraced /them/, and departed for to go into Macedonia.
 2. And when he had gone over those parts, and had given them much exhortation, he came into Greece,
@@ -807,7 +807,7 @@
 23. Save that the Holy Ghost witnesseth in every city, saying that bonds and afflictions abide me.
 24. But none of these things move me, neither count I my life dear unto myself, so that I might finish my course with joy, and the ministry, which I have received of the Lord Jesus, to testify the gospel of the grace of God.
 25. And now, behold, I know that ye all, among whom I have gone preaching the kingdom of God, shall see my face no more.
-26. Wherefore I take you to record this day, that I /am/ pure from the blood of all /men/. 
+26. Wherefore I take you to record this day, that I /am/ pure from the blood of all /men/.
 27. For I have not shunned to declare unto you all the counsel of God.
 
 28. Take heed therefore unto yourselves, and to all the flock, over the which the Holy Ghost hath made you overseers, to feed the church of God, which he hath purchased with his own blood.
@@ -821,7 +821,7 @@
 
 36. And when he had thus spoken, he kneeled down, and prayed with them all.
 37. And they all wept sore, and fell on Paul's neck, and kissed him,
-38. Sorrowing most of all for the words which he spake, that they should see his face no more. And they accompanied him unto the ship. 
+38. Sorrowing most of all for the words which he spake, that they should see his face no more. And they accompanied him unto the ship.
 * 21
 1. And it came to pass, that after we were gotten from them, and had launched, we came with a straight course unto Coos, and the /day/ following unto Rhodes, and from thence unto Patara:
 2. And finding a ship sailing over unto Phenicia, we went aboard, and set forth.
@@ -864,7 +864,7 @@
 37. And as Paul was to be led into the castle, he said unto the chief captain, May I speak unto thee? Who said, Canst thou speak Greek?
 38. Art not thou that Egyptian, which before these days madest an uproar, and leddest out into the wilderness four thousand men that were murderers?
 39. But Paul said, I am a man /which am/ a Jew of Tarsus, /a city/ in Cilicia, a citizen of no mean city: and, I beseech thee, suffer me to speak unto the people.
-40. And when he had given him licence, Paul stood on the stairs, and beckoned with the hand unto the people. And when there was made a great silence, he spake unto /them/ in the Hebrew tongue, saying, 
+40. And when he had given him licence, Paul stood on the stairs, and beckoned with the hand unto the people. And when there was made a great silence, he spake unto /them/ in the Hebrew tongue, saying,
 * 22
 1. Men, brethren, and fathers, hear ye my defence /which I make/ now unto you.
 2. (And when they heard that he spake in the Hebrew tongue to them, they kept the more silence: and he saith,)
@@ -877,7 +877,7 @@
 9. And they that were with me saw indeed the light, and were afraid; but they heard not the voice of him that spake to me.
 10. And I said, What shall I do, Lord? And the Lord said unto me, Arise, and go into Damascus; and there it shall be told thee of all things which are appointed for thee to do.
 11. And when I could not see for the glory of that light, being led by the hand of them that were with me, I came into Damascus.
-12. And one Ananias, a devout man according to the law, having a good report of all the Jews which dwelt /there/, 
+12. And one Ananias, a devout man according to the law, having a good report of all the Jews which dwelt /there/,
 13. Came unto me, and stood, and said unto me, Brother Saul, receive thy sight. And the same hour I looked up upon him.
 14. And he said, The God of our fathers hath chosen thee, that thou shouldest know his will, and see that Just One, and shouldest hear the voice of his mouth.
 15. For thou shalt be his witness unto all men of what thou hast seen and heard.
@@ -895,7 +895,7 @@
 27. Then the chief captain came, and said unto him, Tell me, art thou a Roman? He said, Yea.
 28. And the chief captain answered, With a great sum obtained I this freedom. And Paul said, But I was /free/ born.
 29. Then straightway they departed from him which should have examined him: and the chief captain also was afraid, after he knew that he was a Roman, and because he had bound him.
-30. On the morrow, because he would have known the certainty wherefore he was accused of the Jews, he loosed him from /his/ bands, and commanded the chief priests and all their council to appear, and brought Paul down, and set him before them. 
+30. On the morrow, because he would have known the certainty wherefore he was accused of the Jews, he loosed him from /his/ bands, and commanded the chief priests and all their council to appear, and brought Paul down, and set him before them.
 * 23
 1. And Paul, earnestly beholding the council, said, Men /and/ brethren, I have lived in all good conscience before God until this day.
 2. And the high priest Ananias commanded them that stood by him to smite him on the mouth.
@@ -931,7 +931,7 @@
 32. On the morrow they left the horsemen to go with him, and returned to the castle:
 33. Who, when they came to Cæsarea, and delivered the epistle to the governor, presented Paul also before him.
 34. And when the governor had read /the letter/, he asked of what province he was. And when he understood that /he was/ of Cilicia;
-35. I will hear thee, said he, when thine accusers are also come. And he commanded him to be kept in Herod's judgment hall. 
+35. I will hear thee, said he, when thine accusers are also come. And he commanded him to be kept in Herod's judgment hall.
 * 24
 1. And after five days Ananias the high priest descended with the elders, and /with/ a certain orator /named/ Tertullus, who informed the governor against Paul.
 2. And when he was called forth, Tertullus began to accuse /him/, saying, Seeing that by thee we enjoy great quietness, and that very worthy deeds are done unto this nation by thy providence,
@@ -961,12 +961,12 @@
 24. And after certain days, when Felix came with his wife Drusilla, which was a Jewess, he sent for Paul, and heard him concerning the faith in Christ.
 25. And as he reasoned of righteousness, temperance, and judgment to come, Felix trembled, and answered, Go thy way for this time; when I have a convenient season, I will call for thee.
 26. He hoped also that money should have been given him of Paul, that he might loose him: wherefore he sent for him the oftener, and communed with him.
-27. But after two years Porcius Festus came into Felix' room: and Felix, willing to shew the Jews a pleasure, left Paul bound. 
+27. But after two years Porcius Festus came into Felix' room: and Felix, willing to shew the Jews a pleasure, left Paul bound.
 * 25
 1. Now when Festus was come into the province, after three days he ascended from Cæsarea to Jerusalem.
 2. Then the high priest and the chief of the Jews informed him against Paul, and besought him,
 3. And desired favour against him, that he would send for him to Jerusalem, laying wait in the way to kill him.
-4. But Festus answered, that Paul should be kept at Cæsarea, and that he himself would depart shortly /thither/. 
+4. But Festus answered, that Paul should be kept at Cæsarea, and that he himself would depart shortly /thither/.
 5. Let them therefore, said he, which among you are able, go down with /me/, and accuse this man, if there be any wickedness in him.
 6. And when he had tarried among them more than ten days, he went down unto Cæsarea; and the next day sitting on the judgment seat commanded Paul to be brought.
 7. And when he was come, the Jews which came down from Jerusalem stood round about, and laid many and grievous complaints against Paul, which they could not prove.
@@ -991,7 +991,7 @@
 24. And Festus said, King Agrippa, and all men which are here present with us, ye see this man, about whom all the multitude of the Jews have dealt with me, both at Jerusalem, and /also/ here, crying that he ought not to live any longer.
 25. But when I found that he had committed nothing worthy of death, and that he himself hath appealed to Augustus, I have determined to send him.
 26. Of whom I have no certain thing to write unto my lord. Wherefore I have brought him forth before you, and specially before thee, O king Agrippa, that, after examination had, I might have somewhat to write.
-27. For it seemeth to me unreasonable to send a prisoner, and not withal to signify the crimes /laid/ against him. 
+27. For it seemeth to me unreasonable to send a prisoner, and not withal to signify the crimes /laid/ against him.
 * 26
 1. Then Agrippa said unto Paul, Thou art permitted to speak for thyself. Then Paul stretched forth the hand, and answered for himself:
 2. I think myself happy, king Agrippa, because I shall answer for myself this day before thee touching all the things whereof I am accused of the Jews:
@@ -1002,7 +1002,7 @@
 7. Unto which /promise/ our twelve tribes, instantly serving /God/ day and night, hope to come. For which hope's sake, king Agrippa, I am accused of the Jews.
 8. Why should it be thought a thing incredible with you, that God should raise the dead?
 9. I verily thought with myself, that I ought to do many things contrary to the name of Jesus of Nazareth.
-10. Which thing I also did in Jerusalem: and many of the saints did I shut up in prison, having received authority from the chief priests; and when they were put to death, I gave my voice against /them/. 
+10. Which thing I also did in Jerusalem: and many of the saints did I shut up in prison, having received authority from the chief priests; and when they were put to death, I gave my voice against /them/.
 11. And I punished them oft in every synagogue, and compelled /them/ to blaspheme; and being exceedingly mad against them, I persecuted /them/ even unto strange cities.
 12. Whereupon as I went to Damascus with authority and commission from the chief priests,
 13. At midday, O king, I saw in the way a light from heaven, above the brightness of the sun, shining round about me and them which journeyed with me.
@@ -1013,7 +1013,7 @@
 18. To open their eyes, /and/ to turn /them/ from darkness to light, and /from/ the power of Satan unto God, that they may receive forgiveness of sins, and inheritance among them which are sanctified by faith that is in me.
 19. Whereupon, O king Agrippa, I was not disobedient unto the heavenly vision:
 20. But shewed first unto them of Damascus, and at Jerusalem, and throughout all the coasts of Judæa, and /then/ to the Gentiles, that they should repent and turn to God, and do works meet for repentance.
-21. For these causes the Jews caught me in the temple, and went about to kill /me/. 
+21. For these causes the Jews caught me in the temple, and went about to kill /me/.
 22. Having therefore obtained help of God, I continue unto this day, witnessing both to small and great, saying none other things than those which the prophets and Moses did say should come:
 23. That Christ should suffer, /and/ that he should be the first that should rise from the dead, and should shew light unto the people, and to the Gentiles.
 
@@ -1025,7 +1025,7 @@
 29. And Paul said, I would to God, that not only thou, but also all that hear me this day, were both almost, and altogether such as I am, except these bonds.
 30. And when he had thus spoken, the king rose up, and the governor, and Bernice, and they that sat with them:
 31. And when they were gone aside, they talked between themselves, saying, This man doeth nothing worthy of death or of bonds.
-32. Then said Agrippa unto Festus, This man might have been set at liberty, if he had not appealed unto Cæsar. 
+32. Then said Agrippa unto Festus, This man might have been set at liberty, if he had not appealed unto Cæsar.
 * 27
 1. And when it was determined that we should sail into Italy, they delivered Paul and certain other prisoners unto /one/ named Julius, a centurion of Augustus' band.
 2. And entering into a ship of Adramyttium, we launched, meaning to sail by the coasts of Asia; /one/ Aristarchus, a Macedonian of Thessalonica, being with us.
@@ -1036,7 +1036,7 @@
 7. And when we had sailed slowly many days, and scarce were come over against Cnidus, the wind not suffering us, we sailed under Crete, over against Salmone;
 8. And, hardly passing it, came unto a place which is called The fair havens; nigh whereunto was the city /of/ Lasea.
 
-9. Now when much time was spent, and when sailing was now dangerous, because the fast was now already past, Paul admonished /them/, 
+9. Now when much time was spent, and when sailing was now dangerous, because the fast was now already past, Paul admonished /them/,
 10. And said unto them, Sirs, I perceive that this voyage will be with hurt and much damage, not only of the lading and ship, but also of our lives.
 11. Nevertheless the centurion believed the master and the owner of the ship, more than those things which were spoken by Paul.
 12. And because the haven was not commodious to winter in, the more part advised to depart thence also, if by any means they might attain to Phenice, /and there/ to winter; /which is/ an haven of Crete, and lieth toward the south west and north west.
@@ -1071,7 +1071,7 @@
 41. And falling into a place where two seas met, they ran the ship aground; and the forepart stuck fast, and remained unmoveable, but the hinder part was broken with the violence of the waves.
 42. And the soldiers' counsel was to kill the prisoners, lest any of them should swim out, and escape.
 43. But the centurion, willing to save Paul, kept them from /their/ purpose; and commanded that they which could swim should cast /themselves/ first /into the sea/, and get to land:
-44. And the rest, some on boards, and some on /broken pieces/ of the ship. And so it came to pass, that they escaped all safe to land. 
+44. And the rest, some on boards, and some on /broken pieces/ of the ship. And so it came to pass, that they escaped all safe to land.
 * 28
 1. And when they were escaped, then they knew that the island was called Melita.
 2. And the barbarous people shewed us no little kindness: for they kindled a fire, and received us every one, because of the present rain, and because of the cold.
@@ -1107,4 +1107,4 @@
 29. And when he had said these words, the Jews departed, and had great reasoning among themselves.
 
 30. And Paul dwelt two whole years in his own hired house, and received all that came in unto him,
-31. Preaching the kingdom of God, and teaching those things which concern the Lord Jesus Christ, with all confidence, no man forbidding him.  
+31. Preaching the kingdom of God, and teaching those things which concern the Lord Jesus Christ, with all confidence, no man forbidding him.

--- a/45_ROM.org
+++ b/45_ROM.org
@@ -34,7 +34,7 @@
 29. Being filled with all unrighteousness, fornication, wickedness, covetousness, maliciousness; full of envy, murder, debate, deceit, malignity; whisperers,
 30. Backbiters, haters of God, despiteful, proud, boasters, inventors of evil things, disobedient to parents,
 31. Without understanding, covenantbreakers, without natural affection, implacable, unmerciful:
-32. Who knowing the judgment of God, that they which commit such things are worthy of death, not only do the same, but have pleasure in them that do them. 
+32. Who knowing the judgment of God, that they which commit such things are worthy of death, not only do the same, but have pleasure in them that do them.
 * 2
 1. Therefore thou art inexcusable, O man, whosoever thou art that judgest: for wherein thou judgest another, thou condemnest thyself; for thou that judgest doest the same things.
 2. But we are sure that the judgment of God is according to truth against them which commit such things.
@@ -65,7 +65,7 @@
 26. Therefore if the uncircumcision keep the righteousness of the law, shall not his uncircumcision be counted for circumcision?
 27. And shall not uncircumcision which is by nature, if it fulfil the law, judge thee, who by the letter and circumcision dost transgress the law?
 28. For he is not a Jew, which is one outwardly; neither /is that/ circumcision, which is outward in the flesh:
-29. But he /is/ a Jew, which is one inwardly; and circumcision /is that/ of the heart, in the spirit, /and/ not in the letter; whose praise /is/ not of men, but of God. 
+29. But he /is/ a Jew, which is one inwardly; and circumcision /is that/ of the heart, in the spirit, /and/ not in the letter; whose praise /is/ not of men, but of God.
 * 3
 1. What advantage then hath the Jew? or what profit /is there/ of circumcision?
 2. Much every way: chiefly, because that unto them were committed the oracles of God.
@@ -100,7 +100,7 @@
 28. Therefore we conclude that a man is justified by faith without the deeds of the law.
 29. /Is he/ the God of the Jews only? /is he/ not also of the Gentiles? Yes, of the Gentiles also:
 30. Seeing /it is/ one God, which shall justify the circumcision by faith, and uncircumcision through faith.
-31. Do we then make void the law through faith? God forbid: yea, we establish the law. 
+31. Do we then make void the law through faith? God forbid: yea, we establish the law.
 * 4
 1. What shall we say then that Abraham our father, as pertaining to the flesh, hath found?
 2. For if Abraham were justified by works, he hath /whereof/ to glory; but not before God.
@@ -126,7 +126,7 @@
 22. And therefore it was imputed to him for righteousness.
 23. Now it was not written for his sake alone, that it was imputed to him;
 24. But for us also, to whom it shall be imputed, if we believe on him that raised up Jesus our Lord from the dead;
-25. Who was delivered for our offences, and was raised again for our justification. 
+25. Who was delivered for our offences, and was raised again for our justification.
 * 5
 1. Therefore being justified by faith, we have peace with God through our Lord Jesus Christ:
 2. By whom also we have access by faith into this grace wherein we stand, and rejoice in hope of the glory of God.
@@ -149,7 +149,7 @@
 18. Therefore as by the offence of one /judgment came/ upon all men to condemnation; even so by the righteousness of one /the free gift came/ upon all men unto justification of life.
 19. For as by one man's disobedience many were made sinners, so by the obedience of one shall many be made righteous.
 20. Moreover the law entered, that the offence might abound. But where sin abounded, grace did much more abound:
-21. That as sin hath reigned unto death, even so might grace reign through righteousness unto eternal life by Jesus Christ our Lord. 
+21. That as sin hath reigned unto death, even so might grace reign through righteousness unto eternal life by Jesus Christ our Lord.
 * 6
 1. What shall we say then? Shall we continue in sin, that grace may abound?
 2. God forbid. How shall we, that are dead to sin, live any longer therein?
@@ -173,7 +173,7 @@
 20. For when ye were the servants of sin, ye were free from righteousness.
 21. What fruit had ye then in those things whereof ye are now ashamed? for the end of those things /is/ death.
 22. But now being made free from sin, and become servants to God, ye have your fruit unto holiness, and the end everlasting life.
-23. For the wages of sin /is/ death; but the gift of God /is/ eternal life through Jesus Christ our Lord. 
+23. For the wages of sin /is/ death; but the gift of God /is/ eternal life through Jesus Christ our Lord.
 * 7
 1. Know ye not, brethren, (for I speak to them that know the law,) how that the law hath dominion over a man as long as he liveth?
 2. For the woman which hath an husband is bound by the law to /her/ husband so long as he liveth; but if the husband be dead, she is loosed from the law of /her/ husband.
@@ -186,7 +186,7 @@
 8. But sin, taking occasion by the commandment, wrought in me all manner of concupiscence. For without the law sin /was/ dead.
 9. For I was alive without the law once: but when the commandment came, sin revived, and I died.
 10. And the commandment, which /was ordained/ to life, I found /to be/ unto death.
-11. For sin, taking occasion by the commandment, deceived me, and by it slew /me/. 
+11. For sin, taking occasion by the commandment, deceived me, and by it slew /me/.
 12. Wherefore the law /is/ holy, and the commandment holy, and just, and good.
 13. Was then that which is good made death unto me? God forbid. But sin, that it might appear sin, working death in me by that which is good; that sin by the commandment might become exceeding sinful.
 14. For we know that the law is spiritual: but I am carnal, sold under sin.
@@ -200,7 +200,7 @@
 22. For I delight in the law of God after the inward man:
 23. But I see another law in my members, warring against the law of my mind, and bringing me into captivity to the law of sin which is in my members.
 24. O wretched man that I am! who shall deliver me from the body of this death?
-25. I thank God through Jesus Christ our Lord. So then with the mind I myself serve the law of God; but with the flesh the law of sin. 
+25. I thank God through Jesus Christ our Lord. So then with the mind I myself serve the law of God; but with the flesh the law of sin.
 * 8
 1. /There is/ therefore now no condemnation to them which are in Christ Jesus, who walk not after the flesh, but after the Spirit.
 2. For the law of the Spirit of life in Christ Jesus hath made me free from the law of sin and death.
@@ -228,7 +228,7 @@
 22. For we know that the whole creation groaneth and travaileth in pain together until now.
 23. And not only /they/, but ourselves also, which have the firstfruits of the Spirit, even we ourselves groan within ourselves, waiting for the adoption, /to wit/, the redemption of our body.
 24. For we are saved by hope: but hope that is seen is not hope: for what a man seeth, why doth he yet hope for?
-25. But if we hope for that we see not, /then/ do we with patience wait for /it/. 
+25. But if we hope for that we see not, /then/ do we with patience wait for /it/.
 26. Likewise the Spirit also helpeth our infirmities: for we know not what we should pray for as we ought: but the Spirit itself maketh intercession for us with groanings which cannot be uttered.
 27. And he that searcheth the hearts knoweth what /is/ the mind of the Spirit, because he maketh intercession for the saints according to /the will of/ God.
 28. And we know that all things work together for good to them that love God, to them who are the called according to /his/ purpose.
@@ -242,7 +242,7 @@
 36. As it is written, For thy sake we are killed all the day long; we are accounted as sheep for the slaughter.
 37. Nay, in all these things we are more than conquerors through him that loved us.
 38. For I am persuaded, that neither death, nor life, nor angels, nor principalities, nor powers, nor things present, nor things to come,
-39. Nor height, nor depth, nor any other creature, shall be able to separate us from the love of God, which is in Christ Jesus our Lord. 
+39. Nor height, nor depth, nor any other creature, shall be able to separate us from the love of God, which is in Christ Jesus our Lord.
 * 9
 1. I say the truth in Christ, I lie not, my conscience also bearing me witness in the Holy Ghost,
 2. That I have great heaviness and continual sorrow in my heart.
@@ -278,7 +278,7 @@
 30. What shall we say then? That the Gentiles, which followed not after righteousness, have attained to righteousness, even the righteousness which is of faith.
 31. But Israel, which followed after the law of righteousness, hath not attained to the law of righteousness.
 32. Wherefore? Because /they sought it/ not by faith, but as it were by the works of the law. For they stumbled at that stumblingstone;
-33. As it is written, Behold, I lay in Sion a stumblingstone and rock of offence: and whosoever believeth on him shall not be ashamed. 
+33. As it is written, Behold, I lay in Sion a stumblingstone and rock of offence: and whosoever believeth on him shall not be ashamed.
 * 10
 1. Brethren, my heart's desire and prayer to God for Israel is, that they might be saved.
 2. For I bear them record that they have a zeal of God, but not according to knowledge.
@@ -300,7 +300,7 @@
 18. But I say, Have they not heard? Yes verily, their sound went into all the earth, and their words unto the ends of the world.
 19. But I say, Did not Israel know? First Moses saith, I will provoke you to jealousy by /them that are/ no people, /and/ by a foolish nation I will anger you.
 20. But Esaias is very bold, and saith, I was found of them that sought me not; I was made manifest unto them that asked not after me.
-21. But to Israel he saith, All day long I have stretched forth my hands unto a disobedient and gainsaying people. 
+21. But to Israel he saith, All day long I have stretched forth my hands unto a disobedient and gainsaying people.
 * 11
 1. I say then, Hath God cast away his people? God forbid. For I also am an Israelite, of the seed of Abraham, /of/ the tribe of Benjamin.
 2. God hath not cast away his people which he foreknew. Wot ye not what the scripture saith of Elias? how he maketh intercession to God against Israel, saying,
@@ -341,7 +341,7 @@
 33. O the depth of the riches both of the wisdom and knowledge of God! how unsearchable /are/ his judgments, and his ways past finding out!
 34. For who hath known the mind of the Lord? or who hath been his counsellor?
 35. Or who hath first given to him, and it shall be recompensed unto him again?
-36. For of him, and through him, and to him, /are/ all things: to whom /be/ glory for ever. Amen. 
+36. For of him, and through him, and to him, /are/ all things: to whom /be/ glory for ever. Amen.
 * 12
 1. I beseech you therefore, brethren, by the mercies of God, that ye present your bodies a living sacrifice, holy, acceptable unto God, /which is/ your reasonable service.
 2. And be not conformed to this world: but be ye transformed by the renewing of your mind, that ye may prove what /is/ that good, and acceptable, and perfect, will of God.
@@ -365,7 +365,7 @@
 18. If it be possible, as much as lieth in you, live peaceably with all men.
 19. Dearly beloved, avenge not yourselves, but /rather/ give place unto wrath: for it is written, Vengeance /is/ mine; I will repay, saith the Lord.
 20. Therefore if thine enemy hunger, feed him; if he thirst, give him drink: for in so doing thou shalt heap coals of fire on his head.
-21. Be not overcome of evil, but overcome evil with good. 
+21. Be not overcome of evil, but overcome evil with good.
 * 13
 1. Let every soul be subject unto the higher powers. For there is no power but of God: the powers that be are ordained of God.
 2. Whosoever therefore resisteth the power, resisteth the ordinance of God: and they that resist shall receive to themselves damnation.
@@ -380,7 +380,7 @@
 11. And that, knowing the time, that now /it is/ high time to awake out of sleep: for now /is/ our salvation nearer than when we believed.
 12. The night is far spent, the day is at hand: let us therefore cast off the works of darkness, and let us put on the armour of light.
 13. Let us walk honestly, as in the day; not in rioting and drunkenness, not in chambering and wantonness, not in strife and envying.
-14. But put ye on the Lord Jesus Christ, and make not provision for the flesh, to /fulfil/ the lusts /thereof./ 
+14. But put ye on the Lord Jesus Christ, and make not provision for the flesh, to /fulfil/ the lusts /thereof./
 * 14
 1. Him that is weak in the faith receive ye, /but/ not to doubtful disputations.
 2. For one believeth that he may eat all things: another, who is weak, eateth herbs.
@@ -404,7 +404,7 @@
 20. For meat destroy not the work of God. All things indeed /are/ pure; but /it is/ evil for that man who eateth with offence.
 21. /It is/ good neither to eat flesh, nor to drink wine, nor /any thing/ whereby thy brother stumbleth, or is offended, or is made weak.
 22. Hast thou faith? have /it/ to thyself before God. Happy /is/ he that condemneth not himself in that thing which he alloweth.
-23. And he that doubteth is damned if he eat, because /he eateth/ not of faith: for whatsoever /is/ not of faith is sin. 
+23. And he that doubteth is damned if he eat, because /he eateth/ not of faith: for whatsoever /is/ not of faith is sin.
 * 15
 1. We then that are strong ought to bear the infirmities of the weak, and not to please ourselves.
 2. Let every one of us please /his/ neighbour for /his/ good to edification.
@@ -430,7 +430,7 @@
 21. But as it is written, To whom he was not spoken of, they shall see: and they that have not heard shall understand.
 22. For which cause also I have been much hindered from coming to you.
 23. But now having no more place in these parts, and having a great desire these many years to come unto you;
-24. Whensoever I take my journey into Spain, I will come to you: for I trust to see you in my journey, and to be brought on my way thitherward by you, if first I be somewhat filled with your /company/. 
+24. Whensoever I take my journey into Spain, I will come to you: for I trust to see you in my journey, and to be brought on my way thitherward by you, if first I be somewhat filled with your /company/.
 25. But now I go unto Jerusalem to minister unto the saints.
 26. For it hath pleased them of Macedonia and Achaia to make a certain contribution for the poor saints which are at Jerusalem.
 27. It hath pleased them verily; and their debtors they are. For if the Gentiles have been made partakers of their spiritual things, their duty is also to minister unto them in carnal things.
@@ -440,7 +440,7 @@
 30. Now I beseech you, brethren, for the Lord Jesus Christ's sake, and for the love of the Spirit, that ye strive together with me in /your/ prayers to God for me;
 31. That I may be delivered from them that do not believe in Judaea; and that my service which /I have/ for Jerusalem may be accepted of the saints;
 32. That I may come unto you with joy by the will of God, and may with you be refreshed.
-33. Now the God of peace /be/ with you all. Amen. 
+33. Now the God of peace /be/ with you all. Amen.
 * 16
 1. I commend unto you Phebe our sister, which is a servant of the church which is at Cenchrea:
 2. That ye receive her in the Lord, as becometh saints, and that ye assist her in whatsoever business she hath need of you: for she hath been a succourer of many, and of myself also.
@@ -451,7 +451,7 @@
 7. Salute Andronicus and Junia, my kinsmen, and my fellowprisoners, who are of note among the apostles, who also were in Christ before me.
 8. Greet Amplias my beloved in the Lord.
 9. Salute Urbane, our helper in Christ, and Stachys my beloved.
-10. Salute Apelles approved in Christ. Salute them which are of Aristobulus' /household/. 
+10. Salute Apelles approved in Christ. Salute them which are of Aristobulus' /household/.
 11. Salute Herodion my kinsman. Greet them that be of the /household/ of Narcissus, which are in the Lord.
 12. Salute Tryphena and Tryphosa, who labour in the Lord. Salute the beloved Persis, which laboured much in the Lord.
 13. Salute Rufus chosen in the Lord, and his mother and mine.
@@ -471,4 +471,4 @@
 
 25. Now to him that is of power to stablish you according to my gospel, and the preaching of Jesus Christ, according to the revelation of the mystery, which was kept secret since the world began,
 26. But now is made manifest, and by the scriptures of the prophets, according to the commandment of the everlasting God, made known to all nations for the obedience of faith:
-27. To God only wise, /be/ glory through Jesus Christ for ever. Amen.  Written to the Romans from Corinthus, /and sent/ by Phebe servant of the church at Cenchrea. 
+27. To God only wise, /be/ glory through Jesus Christ for ever. Amen.  Written to the Romans from Corinthus, /and sent/ by Phebe servant of the church at Cenchrea.

--- a/46_1CO.org
+++ b/46_1CO.org
@@ -28,12 +28,12 @@
 23. But we preach Christ crucified, unto the Jews a stumblingblock, and unto the Greeks foolishness;
 24. But unto them which are called, both Jews and Greeks, Christ the power of God, and the wisdom of God.
 25. Because the foolishness of God is wiser than men; and the weakness of God is stronger than men.
-26. For ye see your calling, brethren, how that not many wise men after the flesh, not many mighty, not many noble, /are called/: 
+26. For ye see your calling, brethren, how that not many wise men after the flesh, not many mighty, not many noble, /are called/:
 27. But God hath chosen the foolish things of the world to confound the wise; and God hath chosen the weak things of the world to confound the things which are mighty;
 28. And base things of the world, and things which are despised, hath God chosen, /yea/, and things which are not, to bring to nought things that are:
 29. That no flesh should glory in his presence.
 30. But of him are ye in Christ Jesus, who of God is made unto us wisdom, and righteousness, and sanctification, and redemption:
-31. That, according as it is written, He that glorieth, let him glory in the Lord. 
+31. That, according as it is written, He that glorieth, let him glory in the Lord.
 * 2
 1. And I, brethren, when I came to you, came not with excellency of speech or of wisdom, declaring unto you the testimony of God.
 2. For I determined not to know any thing among you, save Jesus Christ, and him crucified.
@@ -50,7 +50,7 @@
 13. Which things also we speak, not in the words which man's wisdom teacheth, but which the Holy Ghost teacheth; comparing spiritual things with spiritual.
 14. But the natural man receiveth not the things of the Spirit of God: for they are foolishness unto him: neither can he know /them/, because they are spiritually discerned.
 15. But he that is spiritual judgeth all things, yet he himself is judged of no man.
-16. For who hath known the mind of the Lord, that he may instruct him? But we have the mind of Christ. 
+16. For who hath known the mind of the Lord, that he may instruct him? But we have the mind of Christ.
 * 3
 1. And I, brethren, could not speak unto you as unto spiritual, but as unto carnal, /even/ as unto babes in Christ.
 2. I have fed you with milk, and not with meat: for hitherto ye were not able /to bear it/, neither yet now are ye able.
@@ -76,7 +76,7 @@
 20. And again, The Lord knoweth the thoughts of the wise, that they are vain.
 21. Therefore let no man glory in men. For all things are yours;
 22. Whether Paul, or Apollos, or Cephas, or the world, or life, or death, or things present, or things to come; all are yours;
-23. And ye are Christ's; and Christ /is/ God's. 
+23. And ye are Christ's; and Christ /is/ God's.
 * 4
 1. Let a man so account of us, as of the ministers of Christ, and stewards of the mysteries of God.
 2. Moreover it is required in stewards, that a man be found faithful.
@@ -84,21 +84,21 @@
 4. For I know nothing by myself; yet am I not hereby justified: but he that judgeth me is the Lord.
 5. Therefore judge nothing before the time, until the Lord come, who both will bring to light the hidden things of darkness, and will make manifest the counsels of the hearts: and then shall every man have praise of God.
 6. And these things, brethren, I have in a figure transferred to myself and /to/ Apollos for your sakes; that ye might learn in us not to think /of men/ above that which is written, that no one of you be puffed up for one against another.
-7. For who maketh thee to differ /from another/? and what hast thou that thou didst not receive? now if thou didst receive /it/, why dost thou glory, as if thou hadst not received /it/? 
+7. For who maketh thee to differ /from another/? and what hast thou that thou didst not receive? now if thou didst receive /it/, why dost thou glory, as if thou hadst not received /it/?
 8. Now ye are full, now ye are rich, ye have reigned as kings without us: and I would to God ye did reign, that we also might reign with you.
 9. For I think that God hath set forth us the apostles last, as it were appointed to death: for we are made a spectacle unto the world, and to angels, and to men.
 10. We /are/ fools for Christ's sake, but ye /are/ wise in Christ; we /are/ weak, but ye /are/ strong; ye /are/ honourable, but we /are/ despised.
 11. Even unto this present hour we both hunger, and thirst, and are naked, and are buffeted, and have no certain dwellingplace;
 12. And labour, working with our own hands: being reviled, we bless; being persecuted, we suffer it:
 13. Being defamed, we intreat: we are made as the filth of the world, /and are/ the offscouring of all things unto this day.
-14. I write not these things to shame you, but as my beloved sons I warn /you/. 
+14. I write not these things to shame you, but as my beloved sons I warn /you/.
 15. For though ye have ten thousand instructers in Christ, yet /have ye/ not many fathers: for in Christ Jesus I have begotten you through the gospel.
 16. Wherefore I beseech you, be ye followers of me.
 17. For this cause have I sent unto you Timotheus, who is my beloved son, and faithful in the Lord, who shall bring you into remembrance of my ways which be in Christ, as I teach every where in every church.
 18. Now some are puffed up, as though I would not come to you.
 19. But I will come to you shortly, if the Lord will, and will know, not the speech of them which are puffed up, but the power.
 20. For the kingdom of God /is/ not in word, but in power.
-21. What will ye? shall I come unto you with a rod, or in love, and /in/ the spirit of meekness? 
+21. What will ye? shall I come unto you with a rod, or in love, and /in/ the spirit of meekness?
 * 5
 1. It is reported commonly /that there is/ fornication among you, and such fornication as is not so much as named among the Gentiles, that one should have his father's wife.
 2. And ye are puffed up, and have not rather mourned, that he that hath done this deed might be taken away from among you.
@@ -112,7 +112,7 @@
 10. Yet not altogether with the fornicators of this world, or with the covetous, or extortioners, or with idolaters; for then must ye needs go out of the world.
 11. But now I have written unto you not to keep company, if any man that is called a brother be a fornicator, or covetous, or an idolater, or a railer, or a drunkard, or an extortioner; with such an one no not to eat.
 12. For what have I to do to judge them also that are without? do not ye judge them that are within?
-13. But them that are without God judgeth. Therefore put away from among yourselves that wicked person. 
+13. But them that are without God judgeth. Therefore put away from among yourselves that wicked person.
 * 6
 1. Dare any of you, having a matter against another, go to law before the unjust, and not before the saints?
 2. Do ye not know that the saints shall judge the world? and if the world shall be judged by you, are ye unworthy to judge the smallest matters?
@@ -134,7 +134,7 @@
 17. But he that is joined unto the Lord is one spirit.
 18. Flee fornication. Every sin that a man doeth is without the body; but he that committeth fornication sinneth against his own body.
 19. What? know ye not that your body is the temple of the Holy Ghost /which is/ in you, which ye have of God, and ye are not your own?
-20. For ye are bought with a price: therefore glorify God in your body, and in your spirit, which are God's. 
+20. For ye are bought with a price: therefore glorify God in your body, and in your spirit, which are God's.
 * 7
 1. Now concerning the things whereof ye wrote unto me: /It is/ good for a man not to touch a woman.
 2. Nevertheless, /to avoid/ fornication, let every man have his own wife, and let every woman have her own husband.
@@ -177,7 +177,7 @@
 37. Nevertheless he that standeth stedfast in his heart, having no necessity, but hath power over his own will, and hath so decreed in his heart that he will keep his virgin, doeth well.
 38. So then he that giveth /her/ in marriage doeth well; but he that giveth /her/ not in marriage doeth better.
 39. The wife is bound by the law as long as her husband liveth; but if her husband be dead, she is at liberty to be married to whom she will; only in the Lord.
-40. But she is happier if she so abide, after my judgment: and I think also that I have the Spirit of God. 
+40. But she is happier if she so abide, after my judgment: and I think also that I have the Spirit of God.
 * 8
 1. Now as touching things offered unto idols, we know that we all have knowledge. Knowledge puffeth up, but charity edifieth.
 2. And if any man think that he knoweth any thing, he knoweth nothing yet as he ought to know.
@@ -191,7 +191,7 @@
 10. For if any man see thee which hast knowledge sit at meat in the idol's temple, shall not the conscience of him which is weak be emboldened to eat those things which are offered to idols;
 11. And through thy knowledge shall the weak brother perish, for whom Christ died?
 12. But when ye sin so against the brethren, and wound their weak conscience, ye sin against Christ.
-13. Wherefore, if meat make my brother to offend, I will eat no flesh while the world standeth, lest I make my brother to offend. 
+13. Wherefore, if meat make my brother to offend, I will eat no flesh while the world standeth, lest I make my brother to offend.
 * 9
 1. Am I not an apostle? am I not free? have I not seen Jesus Christ our Lord? are not ye my work in the Lord?
 2. If I be not an apostle unto others, yet doubtless I am to you: for the seal of mine apostleship are ye in the Lord.
@@ -215,11 +215,11 @@
 20. And unto the Jews I became as a Jew, that I might gain the Jews; to them that are under the law, as under the law, that I might gain them that are under the law;
 21. To them that are without law, as without law, (being not without law to God, but under the law to Christ,) that I might gain them that are without law.
 22. To the weak became I as weak, that I might gain the weak: I am made all things to all /men/, that I might by all means save some.
-23. And this I do for the gospel's sake, that I might be partaker thereof with /you/. 
+23. And this I do for the gospel's sake, that I might be partaker thereof with /you/.
 24. Know ye not that they which run in a race run all, but one receiveth the prize? So run, that ye may obtain.
 25. And every man that striveth for the mastery is temperate in all things. Now they /do it/ to obtain a corruptible crown; but we an incorruptible.
 26. I therefore so run, not as uncertainly; so fight I, not as one that beateth the air:
-27. But I keep under my body, and bring /it/ into subjection: lest that by any means, when I have preached to others, I myself should be a castaway. 
+27. But I keep under my body, and bring /it/ into subjection: lest that by any means, when I have preached to others, I myself should be a castaway.
 * 10
 1. Moreover, brethren, I would not that ye should be ignorant, how that all our fathers were under the cloud, and all passed through the sea;
 2. And were all baptized unto Moses in the cloud and in the sea;
@@ -245,7 +245,7 @@
 21. Ye cannot drink the cup of the Lord, and the cup of devils: ye cannot be partakers of the Lord's table, and of the table of devils.
 22. Do we provoke the Lord to jealousy? are we stronger than he?
 23. All things are lawful for me, but all things are not expedient: all things are lawful for me, but all things edify not.
-24. Let no man seek his own, but every man another's /wealth/. 
+24. Let no man seek his own, but every man another's /wealth/.
 25. Whatsoever is sold in the shambles, /that/ eat, asking no question for conscience sake:
 26. For the earth /is/ the Lord's, and the fulness thereof.
 27. If any of them that believe not bid you /to a feast/, and ye be disposed to go; whatsoever is set before you, eat, asking no question for conscience sake.
@@ -254,7 +254,7 @@
 30. For if I by grace be a partaker, why am I evil spoken of for that for which I give thanks?
 31. Whether therefore ye eat, or drink, or whatsoever ye do, do all to the glory of God.
 32. Give none offence, neither to the Jews, nor to the Gentiles, nor to the church of God:
-33. Even as I please all /men/ in all /things/, not seeking mine own profit, but the /profit/ of many, that they may be saved. 
+33. Even as I please all /men/ in all /things/, not seeking mine own profit, but the /profit/ of many, that they may be saved.
 * 11
 1. Be ye followers of me, even as I also /am/ of Christ.
 
@@ -291,7 +291,7 @@
 31. For if we would judge ourselves, we should not be judged.
 32. But when we are judged, we are chastened of the Lord, that we should not be condemned with the world.
 33. Wherefore, my brethren, when ye come together to eat, tarry one for another.
-34. And if any man hunger, let him eat at home; that ye come not together unto condemnation. And the rest will I set in order when I come. 
+34. And if any man hunger, let him eat at home; that ye come not together unto condemnation. And the rest will I set in order when I come.
 * 12
 1. Now concerning spiritual /gifts/, brethren, I would not have you ignorant.
 2. Ye know that ye were Gentiles, carried away unto these dumb idols, even as ye were led.
@@ -323,7 +323,7 @@
 28. And God hath set some in the church, first apostles, secondarily prophets, thirdly teachers, after that miracles, then gifts of healings, helps, governments, diversities of tongues.
 29. /Are/ all apostles? /are/ all prophets? /are/ all teachers? /are/ all workers of miracles?
 30. Have all the gifts of healing? do all speak with tongues? do all interpret?
-31. But covet earnestly the best gifts: and yet shew I unto you a more excellent way. 
+31. But covet earnestly the best gifts: and yet shew I unto you a more excellent way.
 * 13
 1. Though I speak with the tongues of men and of angels, and have not charity, I am become /as/ sounding brass, or a tinkling cymbal.
 2. And though I have /the gift of/ prophecy, and understand all mysteries, and all knowledge; and though I have all faith, so that I could remove mountains, and have not charity, I am nothing.
@@ -337,7 +337,7 @@
 10. But when that which is perfect is come, then that which is in part shall be done away.
 11. When I was a child, I spake as a child, I understood as a child, I thought as a child: but when I became a man, I put away childish things.
 12. For now we see through a glass, darkly; but then face to face: now I know in part; but then shall I know even as also I am known.
-13. And now abideth faith, hope, charity, these three; but the greatest of these /is/ charity. 
+13. And now abideth faith, hope, charity, these three; but the greatest of these /is/ charity.
 * 14
 1. Follow after charity, and desire spiritual /gifts/, but rather that ye may prophesy.
 2. For he that speaketh in an /unknown/ tongue speaketh not unto men, but unto God: for no man understandeth /him/; howbeit in the spirit he speaketh mysteries.
@@ -378,7 +378,7 @@
 37. If any man think himself to be a prophet, or spiritual, let him acknowledge that the things that I write unto you are the commandments of the Lord.
 38. But if any man be ignorant, let him be ignorant.
 39. Wherefore, brethren, covet to prophesy, and forbid not to speak with tongues.
-40. Let all things be done decently and in order. 
+40. Let all things be done decently and in order.
 * 15
 1. Moreover, brethren, I declare unto you the gospel which I preached unto you, which also ye have received, and wherein ye stand;
 2. By which also ye are saved, if ye keep in memory what I preached unto you, unless ye have believed in vain.
@@ -417,7 +417,7 @@
 
 35. But some /man/ will say, How are the dead raised up? and with what body do they come?
 36. /Thou/ fool, that which thou sowest is not quickened, except it die:
-37. And that which thou sowest, thou sowest not that body that shall be, but bare grain, it may chance of wheat, or of some other /grain/: 
+37. And that which thou sowest, thou sowest not that body that shall be, but bare grain, it may chance of wheat, or of some other /grain/:
 38. But God giveth it a body as it hath pleased him, and to every seed his own body.
 39. All flesh /is/ not the same flesh: but /there is/ one /kind of/ flesh of men, another flesh of beasts, another of fishes, /and/ another of birds.
 40. /There are/ also celestial bodies, and bodies terrestrial: but the glory of the celestial /is/ one, and the /glory/ of the terrestrial /is/ another.
@@ -438,7 +438,7 @@
 55. O death, where /is/ thy sting? O grave, where /is/ thy victory?
 56. The sting of death /is/ sin; and the strength of sin /is/ the law.
 57. But thanks /be/ to God, which giveth us the victory through our Lord Jesus Christ.
-58. Therefore, my beloved brethren, be ye stedfast, unmoveable, always abounding in the work of the Lord, forasmuch as ye know that your labour is not in vain in the Lord. 
+58. Therefore, my beloved brethren, be ye stedfast, unmoveable, always abounding in the work of the Lord, forasmuch as ye know that your labour is not in vain in the Lord.
 * 16
 1. Now concerning the collection for the saints, as I have given order to the churches of Galatia, even so do ye.
 2. Upon the first /day/ of the week let every one of you lay by him in store, as /God/ hath prospered him, that there be no gatherings when I come.
@@ -449,7 +449,7 @@
 7. For I will not see you now by the way; but I trust to tarry a while with you, if the Lord permit.
 8. But I will tarry at Ephesus until Pentecost.
 9. For a great door and effectual is opened unto me, and /there are/ many adversaries.
-10. Now if Timotheus come, see that he may be with you without fear: for he worketh the work of the Lord, as I also /do/. 
+10. Now if Timotheus come, see that he may be with you without fear: for he worketh the work of the Lord, as I also /do/.
 11. Let no man therefore despise him: but conduct him forth in peace, that he may come unto me: for I look for him with the brethren.
 12. As touching /our/ brother Apollos, I greatly desired him to come unto you with the brethren: but his will was not at all to come at this time; but he will come when he shall have convenient time.
 13. Watch ye, stand fast in the faith, quit you like men, be strong.
@@ -464,4 +464,4 @@
 21. The salutation of /me/ Paul with mine own hand.
 22. If any man love not the Lord Jesus Christ, let him be Anathema Maranatha.
 23. The grace of our Lord Jesus Christ /be/ with you.
-24. My love /be/ with you all in Christ Jesus. Amen.   The first /epistle/ to the Corinthians was written from Philippi by Stephanas, and Fortunatus, and Achaicus, and Timotheus. 
+24. My love /be/ with you all in Christ Jesus. Amen.   The first /epistle/ to the Corinthians was written from Philippi by Stephanas, and Fortunatus, and Achaicus, and Timotheus.

--- a/47_2CO.org
+++ b/47_2CO.org
@@ -9,7 +9,7 @@
 7. And our hope of you /is/ stedfast, knowing, that as ye are partakers of the sufferings, so /shall ye be/ also of the consolation.
 8. For we would not, brethren, have you ignorant of our trouble which came to us in Asia, that we were pressed out of measure, above strength, insomuch that we despaired even of life:
 9. But we had the sentence of death in ourselves, that we should not trust in ourselves, but in God which raiseth the dead:
-10. Who delivered us from so great a death, and doth deliver: in whom we trust that he will yet deliver /us/; 
+10. Who delivered us from so great a death, and doth deliver: in whom we trust that he will yet deliver /us/;
 11. Ye also helping together by prayer for us, that for the gift /bestowed/ upon us by the means of many persons thanks may be given by many on our behalf.
 
 12. For our rejoicing is this, the testimony of our conscience, that in simplicity and godly sincerity, not with fleshly wisdom, but by the grace of God, we have had our conversation in the world, and more abundantly to you-ward.
@@ -25,7 +25,7 @@
 21. Now he which stablisheth us with you in Christ, and hath anointed us, /is/ God;
 22. Who hath also sealed us, and given the earnest of the Spirit in our hearts.
 23. Moreover I call God for a record upon my soul, that to spare you I came not as yet unto Corinth.
-24. Not for that we have dominion over your faith, but are helpers of your joy: for by faith ye stand. 
+24. Not for that we have dominion over your faith, but are helpers of your joy: for by faith ye stand.
 * 2
 1. But I determined this with myself, that I would not come again to you in heaviness.
 2. For if I make you sorry, who is he then that maketh me glad, but the same which is made sorry by me?
@@ -43,7 +43,7 @@
 14. Now thanks /be/ unto God, which always causeth us to triumph in Christ, and maketh manifest the savour of his knowledge by us in every place.
 15. For we are unto God a sweet savour of Christ, in them that are saved, and in them that perish:
 16. To the one /we are/ the savour of death unto death; and to the other the savour of life unto life. And who /is/ sufficient for these things?
-17. For we are not as many, which corrupt the word of God: but as of sincerity, but as of God, in the sight of God speak we in Christ. 
+17. For we are not as many, which corrupt the word of God: but as of sincerity, but as of God, in the sight of God speak we in Christ.
 * 3
 1. Do we begin again to commend ourselves? or need we, as some /others/, epistles of commendation to you, or /letters/ of commendation from you?
 2. Ye are our epistle written in our hearts, known and read of all men:
@@ -63,7 +63,7 @@
 15. But even unto this day, when Moses is read, the vail is upon their heart.
 16. Nevertheless when it shall turn to the Lord, the vail shall be taken away.
 17. Now the Lord is that Spirit: and where the Spirit of the Lord /is/, there /is/ liberty.
-18. But we all, with open face beholding as in a glass the glory of the Lord, are changed into the same image from glory to glory, /even/ as by the Spirit of the Lord. 
+18. But we all, with open face beholding as in a glass the glory of the Lord, are changed into the same image from glory to glory, /even/ as by the Spirit of the Lord.
 * 4
 1. Therefore seeing we have this ministry, as we have received mercy, we faint not;
 2. But have renounced the hidden things of dishonesty, not walking in craftiness, nor handling the word of God deceitfully; but by manifestation of the truth commending ourselves to every man's conscience in the sight of God.
@@ -83,7 +83,7 @@
 15. For all things /are/ for your sakes, that the abundant grace might through the thanksgiving of many redound to the glory of God.
 16. For which cause we faint not; but though our outward man perish, yet the inward /man/ is renewed day by day.
 17. For our light affliction, which is but for a moment, worketh for us a far more exceeding /and/ eternal weight of glory;
-18. While we look not at the things which are seen, but at the things which are not seen: for the things which are seen /are/ temporal; but the things which are not seen /are/ eternal. 
+18. While we look not at the things which are seen, but at the things which are not seen: for the things which are seen /are/ temporal; but the things which are not seen /are/ eternal.
 * 5
 1. For we know that if our earthly house of /this/ tabernacle were dissolved, we have a building of God, an house not made with hands, eternal in the heavens.
 2. For in this we groan, earnestly desiring to be clothed upon with our house which is from heaven:
@@ -106,7 +106,7 @@
 18. And all things /are/ of God, who hath reconciled us to himself by Jesus Christ, and hath given to us the ministry of reconciliation;
 19. To wit, that God was in Christ, reconciling the world unto himself, not imputing their trespasses unto them; and hath committed unto us the word of reconciliation.
 20. Now then we are ambassadors for Christ, as though God did beseech /you/ by us: we pray /you/ in Christ's stead, be ye reconciled to God.
-21. For he hath made him /to be/ sin for us, who knew no sin; that we might be made the righteousness of God in him. 
+21. For he hath made him /to be/ sin for us, who knew no sin; that we might be made the righteousness of God in him.
 * 6
 1. We then, /as/ workers together /with him/, beseech /you/ also that ye receive not the grace of God in vain.
 2. (For he saith, I have heard thee in a time accepted, and in the day of salvation have I succoured thee: behold, now /is/ the accepted time; behold, now /is/ the day of salvation.)
@@ -126,12 +126,12 @@
 15. And what concord hath Christ with Belial? or what part hath he that believeth with an infidel?
 16. And what agreement hath the temple of God with idols? for ye are the temple of the living God; as God hath said, I will dwell in them, and walk in /them/; and I will be their God, and they shall be my people.
 17. Wherefore come out from among them, and be ye separate, saith the Lord, and touch not the unclean /thing/; and I will receive you,
-18. And will be a Father unto you, and ye shall be my sons and daughters, saith the Lord Almighty. 
+18. And will be a Father unto you, and ye shall be my sons and daughters, saith the Lord Almighty.
 * 7
 1. Having therefore these promises, dearly beloved, let us cleanse ourselves from all filthiness of the flesh and spirit, perfecting holiness in the fear of God.
 
 2. Receive us; we have wronged no man, we have corrupted no man, we have defrauded no man.
-3. I speak not /this/ to condemn /you/: for I have said before, that ye are in our hearts to die and live with /you/. 
+3. I speak not /this/ to condemn /you/: for I have said before, that ye are in our hearts to die and live with /you/.
 4. Great /is/ my boldness of speech toward you, great /is/ my glorying of you: I am filled with comfort, I am exceeding joyful in all our tribulation.
 5. For, when we were come into Macedonia, our flesh had no rest, but we were troubled on every side; without /were/ fightings, within /were/ fears.
 6. Nevertheless God, that comforteth those that are cast down, comforted us by the coming of Titus;
@@ -144,7 +144,7 @@
 13. Therefore we were comforted in your comfort: yea, and exceedingly the more joyed we for the joy of Titus, because his spirit was refreshed by you all.
 14. For if I have boasted any thing to him of you, I am not ashamed; but as we spake all things to you in truth, even so our boasting, which /I made/ before Titus, is found a truth.
 15. And his inward affection is more abundant toward you, whilst he remembereth the obedience of you all, how with fear and trembling ye received him.
-16. I rejoice therefore that I have confidence in you in all /things./ 
+16. I rejoice therefore that I have confidence in you in all /things./
 * 8
 1. Moreover, brethren, we do you to wit of the grace of God bestowed on the churches of Macedonia;
 2. How that in a great trial of affliction the abundance of their joy and their deep poverty abounded unto the riches of their liberality.
@@ -169,7 +169,7 @@
 21. Providing for honest things, not only in the sight of the Lord, but also in the sight of men.
 22. And we have sent with them our brother, whom we have oftentimes proved diligent in many things, but now much more diligent, upon the great confidence which /I have/ in you.
 23. Whether /any do enquire/ of Titus, /he is/ my partner and fellowhelper concerning you: or our brethren /be enquired of, they are/ the messengers of the churches, /and/ the glory of Christ.
-24. Wherefore shew ye to them, and before the churches, the proof of your love, and of our boasting on your behalf. 
+24. Wherefore shew ye to them, and before the churches, the proof of your love, and of our boasting on your behalf.
 * 9
 1. For as touching the ministering to the saints, it is superfluous for me to write to you:
 2. For I know the forwardness of your mind, for which I boast of you to them of Macedonia, that Achaia was ready a year ago; and your zeal hath provoked very many.
@@ -183,9 +183,9 @@
 10. Now he that ministereth seed to the sower both minister bread for /your/ food, and multiply your seed sown, and increase the fruits of your righteousness;)
 11. Being enriched in every thing to all bountifulness, which causeth through us thanksgiving to God.
 12. For the administration of this service not only supplieth the want of the saints, but is abundant also by many thanksgivings unto God;
-13. Whiles by the experiment of this ministration they glorify God for your professed subjection unto the gospel of Christ, and for /your/ liberal distribution unto them, and unto all /men/; 
+13. Whiles by the experiment of this ministration they glorify God for your professed subjection unto the gospel of Christ, and for /your/ liberal distribution unto them, and unto all /men/;
 14. And by their prayer for you, which long after you for the exceeding grace of God in you.
-15. Thanks /be/ unto God for his unspeakable gift. 
+15. Thanks /be/ unto God for his unspeakable gift.
 * 10
 1. Now I Paul myself beseech you by the meekness and gentleness of Christ, who in presence /am/ base among you, but being absent am bold toward you:
 2. But I beseech /you/, that I may not be bold when I am present with that confidence, wherewith I think to be bold against some, which think of us as if we walked according to the flesh.
@@ -204,17 +204,17 @@
 15. Not boasting of things without /our/ measure, /that is/, of other men's labours; but having hope, when your faith is increased, that we shall be enlarged by you according to our rule abundantly,
 16. To preach the gospel in the /regions/ beyond you, /and/ not to boast in another man's line of things made ready to our hand.
 17. But he that glorieth, let him glory in the Lord.
-18. For not he that commendeth himself is approved, but whom the Lord commendeth. 
+18. For not he that commendeth himself is approved, but whom the Lord commendeth.
 * 11
 1. Would to God ye could bear with me a little in /my/ folly: and indeed bear with me.
 2. For I am jealous over you with godly jealousy: for I have espoused you to one husband, that I may present /you as/ a chaste virgin to Christ.
 3. But I fear, lest by any means, as the serpent beguiled Eve through his subtilty, so your minds should be corrupted from the simplicity that is in Christ.
-4. For if he that cometh preacheth another Jesus, whom we have not preached, or /if/ ye receive another spirit, which ye have not received, or another gospel, which ye have not accepted, ye might well bear with /him/. 
+4. For if he that cometh preacheth another Jesus, whom we have not preached, or /if/ ye receive another spirit, which ye have not received, or another gospel, which ye have not accepted, ye might well bear with /him/.
 5. For I suppose I was not a whit behind the very chiefest apostles.
 6. But though /I be/ rude in speech, yet not in knowledge; but we have been throughly made manifest among you in all things.
 7. Have I committed an offence in abasing myself that ye might be exalted, because I have preached to you the gospel of God freely?
 8. I robbed other churches, taking wages /of them/, to do you service.
-9. And when I was present with you, and wanted, I was chargeable to no man: for that which was lacking to me the brethren which came from Macedonia supplied: and in all /things/ I have kept myself from being burdensome unto you, and /so/ will I keep /myself/. 
+9. And when I was present with you, and wanted, I was chargeable to no man: for that which was lacking to me the brethren which came from Macedonia supplied: and in all /things/ I have kept myself from being burdensome unto you, and /so/ will I keep /myself/.
 10. As the truth of Christ is in me, no man shall stop me of this boasting in the regions of Achaia.
 11. Wherefore? because I love you not? God knoweth.
 12. But what I do, that I will do, that I may cut off occasion from them which desire occasion; that wherein they glory, they may be found even as we.
@@ -239,7 +239,7 @@
 30. If I must needs glory, I will glory of the things which concern mine infirmities.
 31. The God and Father of our Lord Jesus Christ, which is blessed for evermore, knoweth that I lie not.
 32. In Damascus the governor under Aretas the king kept the city of the Damascenes with a garrison, desirous to apprehend me:
-33. And through a window in a basket was I let down by the wall, and escaped his hands. 
+33. And through a window in a basket was I let down by the wall, and escaped his hands.
 * 12
 1. It is not expedient for me doubtless to glory. I will come to visions and revelations of the Lord.
 2. I knew a man in Christ above fourteen years ago, (whether in the body, I cannot tell; or whether out of the body, I cannot tell: God knoweth;) such an one caught up to the third heaven.
@@ -262,7 +262,7 @@
 18. I desired Titus, and with /him/ I sent a brother. Did Titus make a gain of you? walked we not in the same spirit? /walked we/ not in the same steps?
 19. Again, think ye that we excuse ourselves unto you? we speak before God in Christ: but /we do/ all things, dearly beloved, for your edifying.
 20. For I fear, lest, when I come, I shall not find you such as I would, and /that/ I shall be found unto you such as ye would not: lest /there be/ debates, envyings, wraths, strifes, backbitings, whisperings, swellings, tumults:
-21. /And/ lest, when I come again, my God will humble me among you, and /that/ I shall bewail many which have sinned already, and have not repented of the uncleanness and fornication and lasciviousness which they have committed. 
+21. /And/ lest, when I come again, my God will humble me among you, and /that/ I shall bewail many which have sinned already, and have not repented of the uncleanness and fornication and lasciviousness which they have committed.
 * 13
 1. This /is/ the third /time/ I am coming to you. In the mouth of two or three witnesses shall every word be established.
 2. I told you before, and foretell you, as if I were present, the second time; and being absent now I write to them which heretofore have sinned, and to all other, that, if I come again, I will not spare:
@@ -279,4 +279,4 @@
 12. Greet one another with an holy kiss.
 
 13. All the saints salute you.
-14. The grace of the Lord Jesus Christ, and the love of God, and the communion of the Holy Ghost, /be/ with you all. Amen.   The second /epistle/ to the Corinthians was written from Philippi, /a city/ of Macedonia, by Titus and Lucas. 
+14. The grace of the Lord Jesus Christ, and the love of God, and the communion of the Holy Ghost, /be/ with you all. Amen.   The second /epistle/ to the Corinthians was written from Philippi, /a city/ of Macedonia, by Titus and Lucas.

--- a/48_GAL.org
+++ b/48_GAL.org
@@ -25,7 +25,7 @@
 21. Afterwards I came into the regions of Syria and Cilicia;
 22. And was unknown by face unto the churches of Judaea which were in Christ:
 23. But they had heard only, That he which persecuted us in times past now preacheth the faith which once he destroyed.
-24. And they glorified God in me. 
+24. And they glorified God in me.
 * 2
 1. Then fourteen years after I went up again to Jerusalem with Barnabas, and took Titus with /me/ also.
 2. And I went up by revelation, and communicated unto them that gospel which I preach among the Gentiles, but privately to them which were of reputation, lest by any means I should run, or had run, in vain.
@@ -47,7 +47,7 @@
 18. For if I build again the things which I destroyed, I make myself a transgressor.
 19. For I through the law am dead to the law, that I might live unto God.
 20. I am crucified with Christ: nevertheless I live; yet not I, but Christ liveth in me: and the life which I now live in the flesh I live by the faith of the Son of God, who loved me, and gave himself for me.
-21. I do not frustrate the grace of God: for if righteousness /come/ by the law, then Christ is dead in vain. 
+21. I do not frustrate the grace of God: for if righteousness /come/ by the law, then Christ is dead in vain.
 * 3
 1. O foolish Galatians, who hath bewitched you, that ye should not obey the truth, before whose eyes Jesus Christ hath been evidently set forth, crucified among you?
 2. This only would I learn of you, Received ye the Spirit by the works of the law, or by the hearing of faith?
@@ -79,7 +79,7 @@
 26. For ye are all the children of God by faith in Christ Jesus.
 27. For as many of you as have been baptized into Christ have put on Christ.
 28. There is neither Jew nor Greek, there is neither bond nor free, there is neither male nor female: for ye are all one in Christ Jesus.
-29. And if ye /be/ Christ's, then are ye Abraham's seed, and heirs according to the promise. 
+29. And if ye /be/ Christ's, then are ye Abraham's seed, and heirs according to the promise.
 * 4
 1. Now I say, /That/ the heir, as long as he is a child, differeth nothing from a servant, though he be lord of all;
 2. But is under tutors and governors until the time appointed of the father.
@@ -114,7 +114,7 @@
 28. Now we, brethren, as Isaac was, are the children of promise.
 29. But as then he that was born after the flesh persecuted him /that was born/ after the Spirit, even so /it is/ now.
 30. Nevertheless what saith the scripture? Cast out the bondwoman and her son: for the son of the bondwoman shall not be heir with the son of the freewoman.
-31. So then, brethren, we are not children of the bondwoman, but of the free. 
+31. So then, brethren, we are not children of the bondwoman, but of the free.
 * 5
 1. Stand fast therefore in the liberty wherewith Christ hath made us free, and be not entangled again with the yoke of bondage.
 
@@ -142,7 +142,7 @@
 23. Meekness, temperance: against such there is no law.
 24. And they that are Christ's have crucified the flesh with the affections and lusts.
 25. If we live in the Spirit, let us also walk in the Spirit.
-26. Let us not be desirous of vain glory, provoking one another, envying one another. 
+26. Let us not be desirous of vain glory, provoking one another, envying one another.
 * 6
 1. Brethren, if a man be overtaken in a fault, ye which are spiritual, restore such an one in the spirit of meekness; considering thyself, lest thou also be tempted.
 2. Bear ye one another's burdens, and so fulfil the law of Christ.
@@ -161,4 +161,4 @@
 15. For in Christ Jesus neither circumcision availeth any thing, nor uncircumcision, but a new creature.
 16. And as many as walk according to this rule, peace /be/ on them, and mercy, and upon the Israel of God.
 17. From henceforth let no man trouble me: for I bear in my body the marks of the Lord Jesus.
-18. Brethren, the grace of our Lord Jesus Christ /be/ with your spirit. Amen.  Unto the Galatians written from Rome. 
+18. Brethren, the grace of our Lord Jesus Christ /be/ with your spirit. Amen.  Unto the Galatians written from Rome.

--- a/49_EPH.org
+++ b/49_EPH.org
@@ -21,10 +21,10 @@
 17. That the God of our Lord Jesus Christ, the Father of glory, may give unto you the spirit of wisdom and revelation in the knowledge of him:
 18. The eyes of your understanding being enlightened; that ye may know what is the hope of his calling, and what the riches of the glory of his inheritance in the saints,
 19. And what /is/ the exceeding greatness of his power to us-ward who believe, according to the working of his mighty power,
-20. Which he wrought in Christ, when he raised him from the dead, and set /him/ at his own right hand in the heavenly /places/, 
+20. Which he wrought in Christ, when he raised him from the dead, and set /him/ at his own right hand in the heavenly /places/,
 21. Far above all principality, and power, and might, and dominion, and every name that is named, not only in this world, but also in that which is to come:
 22. And hath put all /things/ under his feet, and gave him /to be/ the head over all /things/ to the church,
-23. Which is his body, the fulness of him that filleth all in all. 
+23. Which is his body, the fulness of him that filleth all in all.
 * 2
 1. And you /hath he quickened/, who were dead in trespasses and sins;
 2. Wherein in time past ye walked according to the course of this world, according to the prince of the power of the air, the spirit that now worketh in the children of disobedience:
@@ -40,15 +40,15 @@
 11. Wherefore remember, that ye /being/ in time past Gentiles in the flesh, who are called Uncircumcision by that which is called the Circumcision in the flesh made by hands;
 12. That at that time ye were without Christ, being aliens from the commonwealth of Israel, and strangers from the covenants of promise, having no hope, and without God in the world:
 13. But now in Christ Jesus ye who sometimes were far off are made nigh by the blood of Christ.
-14. For he is our peace, who hath made both one, and hath broken down the middle wall of partition /between us/; 
+14. For he is our peace, who hath made both one, and hath broken down the middle wall of partition /between us/;
 15. Having abolished in his flesh the enmity, /even/ the law of commandments /contained/ in ordinances; for to make in himself of twain one new man, /so/ making peace;
 16. And that he might reconcile both unto God in one body by the cross, having slain the enmity thereby:
 17. And came and preached peace to you which were afar off, and to them that were nigh.
 18. For through him we both have access by one Spirit unto the Father.
 19. Now therefore ye are no more strangers and foreigners, but fellowcitizens with the saints, and of the household of God;
-20. And are built upon the foundation of the apostles and prophets, Jesus Christ himself being the chief corner /stone/; 
+20. And are built upon the foundation of the apostles and prophets, Jesus Christ himself being the chief corner /stone/;
 21. In whom all the building fitly framed together groweth unto an holy temple in the Lord:
-22. In whom ye also are builded together for an habitation of God through the Spirit. 
+22. In whom ye also are builded together for an habitation of God through the Spirit.
 * 3
 1. For this cause I Paul, the prisoner of Jesus Christ for you Gentiles,
 2. If ye have heard of the dispensation of the grace of God which is given me to you-ward:
@@ -71,7 +71,7 @@
 19. And to know the love of Christ, which passeth knowledge, that ye might be filled with all the fulness of God.
 
 20. Now unto him that is able to do exceeding abundantly above all that we ask or think, according to the power that worketh in us,
-21. Unto him /be/ glory in the church by Christ Jesus throughout all ages, world without end. Amen. 
+21. Unto him /be/ glory in the church by Christ Jesus throughout all ages, world without end. Amen.
 * 4
 1. I therefore, the prisoner of the Lord, beseech you that ye walk worthy of the vocation wherewith ye are called,
 2. With all lowliness and meekness, with longsuffering, forbearing one another in love;
@@ -106,7 +106,7 @@
 29. Let no corrupt communication proceed out of your mouth, but that which is good to the use of edifying, that it may minister grace unto the hearers.
 30. And grieve not the holy Spirit of God, whereby ye are sealed unto the day of redemption.
 31. Let all bitterness, and wrath, and anger, and clamour, and evil speaking, be put away from you, with all malice:
-32. And be ye kind one to another, tenderhearted, forgiving one another, even as God for Christ's sake hath forgiven you. 
+32. And be ye kind one to another, tenderhearted, forgiving one another, even as God for Christ's sake hath forgiven you.
 * 5
 1. Be ye therefore followers of God, as dear children;
 2. And walk in love, as Christ also hath loved us, and hath given himself for us an offering and a sacrifice to God for a sweetsmelling savour.
@@ -118,13 +118,13 @@
 8. For ye were sometimes darkness, but now /are ye/ light in the Lord: walk as children of light:
 9. (For the fruit of the Spirit /is/ in all goodness and righteousness and truth;)
 10. Proving what is acceptable unto the Lord.
-11. And have no fellowship with the unfruitful works of darkness, but rather reprove /them/. 
+11. And have no fellowship with the unfruitful works of darkness, but rather reprove /them/.
 12. For it is a shame even to speak of those things which are done of them in secret.
 13. But all things that are reproved are made manifest by the light: for whatsoever doth make manifest is light.
 14. Wherefore he saith, Awake thou that sleepest, and arise from the dead, and Christ shall give thee light.
 15. See then that ye walk circumspectly, not as fools, but as wise,
 16. Redeeming the time, because the days are evil.
-17. Wherefore be ye not unwise, but understanding what the will of the Lord /is/. 
+17. Wherefore be ye not unwise, but understanding what the will of the Lord /is/.
 18. And be not drunk with wine, wherein is excess; but be filled with the Spirit;
 19. Speaking to yourselves in psalms and hymns and spiritual songs, singing and making melody in your heart to the Lord;
 20. Giving thanks always for all things unto God and the Father in the name of our Lord Jesus Christ;
@@ -140,7 +140,7 @@
 30. For we are members of his body, of his flesh, and of his bones.
 31. For this cause shall a man leave his father and mother, and shall be joined unto his wife, and they two shall be one flesh.
 32. This is a great mystery: but I speak concerning Christ and the church.
-33. Nevertheless let every one of you in particular so love his wife even as himself; and the wife /see/ that she reverence /her/ husband. 
+33. Nevertheless let every one of you in particular so love his wife even as himself; and the wife /see/ that she reverence /her/ husband.
 * 6
 1. Children, obey your parents in the Lord: for this is right.
 2. Honour thy father and mother; (which is the first commandment with promise;)
@@ -168,4 +168,4 @@
 22. Whom I have sent unto you for the same purpose, that ye might know our affairs, and /that/ he might comfort your hearts.
 
 23. Peace /be/ to the brethren, and love with faith, from God the Father and the Lord Jesus Christ.
-24. Grace /be/ with all them that love our Lord Jesus Christ in sincerity. Amen.  Written from Rome unto the Ephesians by Tychicus. 
+24. Grace /be/ with all them that love our Lord Jesus Christ in sincerity. Amen.  Written from Rome unto the Ephesians by Tychicus.

--- a/50_PHP.org
+++ b/50_PHP.org
@@ -13,7 +13,7 @@
 11. Being filled with the fruits of righteousness, which are by Jesus Christ, unto the glory and praise of God.
 
 12. But I would ye should understand, brethren, that the things /which happened/ unto me have fallen out rather unto the furtherance of the gospel;
-13. So that my bonds in Christ are manifest in all the palace, and in all other /places/; 
+13. So that my bonds in Christ are manifest in all the palace, and in all other /places/;
 14. And many of the brethren in the Lord, waxing confident by my bonds, are much more bold to speak the word without fear.
 15. Some indeed preach Christ even of envy and strife; and some also of good will:
 16. The one preach Christ of contention, not sincerely, supposing to add affliction to my bonds:
@@ -30,7 +30,7 @@
 27. Only let your conversation be as it becometh the gospel of Christ: that whether I come and see you, or else be absent, I may hear of your affairs, that ye stand fast in one spirit, with one mind striving together for the faith of the gospel;
 28. And in nothing terrified by your adversaries: which is to them an evident token of perdition, but to you of salvation, and that of God.
 29. For unto you it is given in the behalf of Christ, not only to believe on him, but also to suffer for his sake;
-30. Having the same conflict which ye saw in me, and now hear /to be/ in me. 
+30. Having the same conflict which ye saw in me, and now hear /to be/ in me.
 * 2
 1. If /there be/ therefore any consolation in Christ, if any comfort of love, if any fellowship of the Spirit, if any bowels and mercies,
 2. Fulfil ye my joy, that ye be likeminded, having the same love, /being/ of one accord, of one mind.
@@ -63,7 +63,7 @@
 27. For indeed he was sick nigh unto death: but God had mercy on him; and not on him only, but on me also, lest I should have sorrow upon sorrow.
 28. I sent him therefore the more carefully, that, when ye see him again, ye may rejoice, and that I may be the less sorrowful.
 29. Receive him therefore in the Lord with all gladness; and hold such in reputation:
-30. Because for the work of Christ he was nigh unto death, not regarding his life, to supply your lack of service toward me. 
+30. Because for the work of Christ he was nigh unto death, not regarding his life, to supply your lack of service toward me.
 * 3
 1. Finally, my brethren, rejoice in the Lord. To write the same things to you, to me indeed /is/ not grievous, but for you /it is/ safe.
 
@@ -86,7 +86,7 @@
 18. (For many walk, of whom I have told you often, and now tell you even weeping, /that they are/ the enemies of the cross of Christ:
 19. Whose end /is/ destruction, whose God /is their/ belly, and /whose/ glory /is/ in their shame, who mind earthly things.)
 20. For our conversation is in heaven; from whence also we look for the Saviour, the Lord Jesus Christ:
-21. Who shall change our vile body, that it may be fashioned like unto his glorious body, according to the working whereby he is able even to subdue all things unto himself. 
+21. Who shall change our vile body, that it may be fashioned like unto his glorious body, according to the working whereby he is able even to subdue all things unto himself.
 * 4
 1. Therefore, my brethren dearly beloved and longed for, my joy and crown, so stand fast in the Lord, /my/ dearly beloved.
 2. I beseech Euodias, and beseech Syntyche, that they be of the same mind in the Lord.
@@ -112,4 +112,4 @@
 
 21. Salute every saint in Christ Jesus. The brethren which are with me greet you.
 22. All the saints salute you, chiefly they that are of Caesar's household.
-23. The grace of our Lord Jesus Christ /be/ with you all. Amen.  It was written to the Philippians from Rome by Epaphroditus. 
+23. The grace of our Lord Jesus Christ /be/ with you all. Amen.  It was written to the Philippians from Rome by Epaphroditus.

--- a/51_COL.org
+++ b/51_COL.org
@@ -28,7 +28,7 @@
 26. /Even/ the mystery which hath been hid from ages and from generations, but now is made manifest to his saints:
 27. To whom God would make known what /is/ the riches of the glory of this mystery among the Gentiles; which is Christ in you, the hope of glory:
 28. Whom we preach, warning every man, and teaching every man in all wisdom; that we may present every man perfect in Christ Jesus:
-29. Whereunto I also labour, striving according to his working, which worketh in me mightily. 
+29. Whereunto I also labour, striving according to his working, which worketh in me mightily.
 * 2
 1. For I would that ye knew what great conflict I have for you, and /for/ them at Laodicea, and /for/ as many as have not seen my face in the flesh;
 2. That their hearts might be comforted, being knit together in love, and unto all riches of the full assurance of understanding, to the acknowledgement of the mystery of God, and of the Father, and of Christ;
@@ -46,7 +46,7 @@
 13. And you, being dead in your sins and the uncircumcision of your flesh, hath he quickened together with him, having forgiven you all trespasses;
 14. Blotting out the handwriting of ordinances that was against us, which was contrary to us, and took it out of the way, nailing it to his cross;
 15. /And/ having spoiled principalities and powers, he made a shew of them openly, triumphing over them in it.
-16. Let no man therefore judge you in meat, or in drink, or in respect of an holyday, or of the new moon, or of the sabbath /days/: 
+16. Let no man therefore judge you in meat, or in drink, or in respect of an holyday, or of the new moon, or of the sabbath /days/:
 17. Which are a shadow of things to come; but the body /is/ of Christ.
 18. Let no man beguile you of your reward in a voluntary humility and worshipping of angels, intruding into those things which he hath not seen, vainly puffed up by his fleshly mind,
 19. And not holding the Head, from which all the body by joints and bands having nourishment ministered, and knit together, increaseth with the increase of God.
@@ -54,7 +54,7 @@
 20. Wherefore if ye be dead with Christ from the rudiments of the world, why, as though living in the world, are ye subject to ordinances,
 21. (Touch not; taste not; handle not;
 22. Which all are to perish with the using;) after the commandments and doctrines of men?
-23. Which things have indeed a shew of wisdom in will worship, and humility, and neglecting of the body; not in any honour to the satisfying of the flesh. 
+23. Which things have indeed a shew of wisdom in will worship, and humility, and neglecting of the body; not in any honour to the satisfying of the flesh.
 * 3
 1. If ye then be risen with Christ, seek those things which are above, where Christ sitteth on the right hand of God.
 2. Set your affection on things above, not on things on the earth.
@@ -82,7 +82,7 @@
 22. Servants, obey in all things /your/ masters according to the flesh; not with eyeservice, as menpleasers; but in singleness of heart, fearing God:
 23. And whatsoever ye do, do /it/ heartily, as to the Lord, and not unto men;
 24. Knowing that of the Lord ye shall receive the reward of the inheritance: for ye serve the Lord Christ.
-25. But he that doeth wrong shall receive for the wrong which he hath done: and there is no respect of persons. 
+25. But he that doeth wrong shall receive for the wrong which he hath done: and there is no respect of persons.
 * 4
 1. Masters, give unto /your/ servants that which is just and equal; knowing that ye also have a Master in heaven.
 
@@ -104,4 +104,4 @@
 15. Salute the brethren which are in Laodicea, and Nymphas, and the church which is in his house.
 16. And when this epistle is read among you, cause that it be read also in the church of the Laodiceans; and that ye likewise read the /epistle/ from Laodicea.
 17. And say to Archippus, Take heed to the ministry which thou hast received in the Lord, that thou fulfil it.
-18. The salutation by the hand of me Paul. Remember my bonds. Grace /be/ with you. Amen.  Written from Rome to the Colossians by Tychicus and Onesimus. 
+18. The salutation by the hand of me Paul. Remember my bonds. Grace /be/ with you. Amen.  Written from Rome to the Colossians by Tychicus and Onesimus.

--- a/52_1TH.org
+++ b/52_1TH.org
@@ -9,7 +9,7 @@
 7. So that ye were ensamples to all that believe in Macedonia and Achaia.
 8. For from you sounded out the word of the Lord not only in Macedonia and Achaia, but also in every place your faith to God-ward is spread abroad; so that we need not to speak any thing.
 9. For they themselves shew of us what manner of entering in we had unto you, and how ye turned to God from idols to serve the living and true God;
-10. And to wait for his Son from heaven, whom he raised from the dead, /even/ Jesus, which delivered us from the wrath to come. 
+10. And to wait for his Son from heaven, whom he raised from the dead, /even/ Jesus, which delivered us from the wrath to come.
 * 2
 1. For yourselves, brethren, know our entrance in unto you, that it was not in vain:
 2. But even after that we had suffered before, and were shamefully entreated, as ye know, at Philippi, we were bold in our God to speak unto you the gospel of God with much contention.
@@ -32,7 +32,7 @@
 17. But we, brethren, being taken from you for a short time in presence, not in heart, endeavoured the more abundantly to see your face with great desire.
 18. Wherefore we would have come unto you, even I Paul, once and again; but Satan hindered us.
 19. For what /is/ our hope, or joy, or crown of rejoicing? /Are/ not even ye in the presence of our Lord Jesus Christ at his coming?
-20. For ye are our glory and joy. 
+20. For ye are our glory and joy.
 * 3
 1. Wherefore when we could no longer forbear, we thought it good to be left at Athens alone;
 2. And sent Timotheus, our brother, and minister of God, and our fellowlabourer in the gospel of Christ, to establish you, and to comfort you concerning your faith:
@@ -46,7 +46,7 @@
 10. Night and day praying exceedingly that we might see your face, and might perfect that which is lacking in your faith?
 11. Now God himself and our Father, and our Lord Jesus Christ, direct our way unto you.
 12. And the Lord make you to increase and abound in love one toward another, and toward all /men/, even as we /do/ toward you:
-13. To the end he may stablish your hearts unblameable in holiness before God, even our Father, at the coming of our Lord Jesus Christ with all his saints. 
+13. To the end he may stablish your hearts unblameable in holiness before God, even our Father, at the coming of our Lord Jesus Christ with all his saints.
 * 4
 1. Furthermore then we beseech you, brethren, and exhort /you/ by the Lord Jesus, that as ye have received of us how ye ought to walk and to please God, /so/ ye would abound more and more.
 2. For ye know what commandments we gave you by the Lord Jesus.
@@ -66,7 +66,7 @@
 15. For this we say unto you by the word of the Lord, that we which are alive /and/ remain unto the coming of the Lord shall not prevent them which are asleep.
 16. For the Lord himself shall descend from heaven with a shout, with the voice of the archangel, and with the trump of God: and the dead in Christ shall rise first:
 17. Then we which are alive /and/ remain shall be caught up together with them in the clouds, to meet the Lord in the air: and so shall we ever be with the Lord.
-18. Wherefore comfort one another with these words. 
+18. Wherefore comfort one another with these words.
 * 5
 1. But of the times and the seasons, brethren, ye have no need that I write unto you.
 2. For yourselves know perfectly that the day of the Lord so cometh as a thief in the night.
@@ -82,8 +82,8 @@
 
 12. And we beseech you, brethren, to know them which labour among you, and are over you in the Lord, and admonish you;
 13. And to esteem them very highly in love for their work's sake. /And/ be at peace among yourselves.
-14. Now we exhort you, brethren, warn them that are unruly, comfort the feebleminded, support the weak, be patient toward all /men/. 
-15. See that none render evil for evil unto any /man/; but ever follow that which is good, both among yourselves, and to all /men/. 
+14. Now we exhort you, brethren, warn them that are unruly, comfort the feebleminded, support the weak, be patient toward all /men/.
+15. See that none render evil for evil unto any /man/; but ever follow that which is good, both among yourselves, and to all /men/.
 16. Rejoice evermore.
 17. Pray without ceasing.
 18. In every thing give thanks: for this is the will of God in Christ Jesus concerning you.
@@ -97,4 +97,4 @@
 
 26. Greet all the brethren with an holy kiss.
 27. I charge you by the Lord that this epistle be read unto all the holy brethren.
-28. The grace of our Lord Jesus Christ /be/ with you. Amen.   The first /epistle/ unto the Thessalonians was written from Athens. 
+28. The grace of our Lord Jesus Christ /be/ with you. Amen.   The first /epistle/ unto the Thessalonians was written from Athens.

--- a/53_2TH.org
+++ b/53_2TH.org
@@ -12,7 +12,7 @@
 9. Who shall be punished with everlasting destruction from the presence of the Lord, and from the glory of his power;
 10. When he shall come to be glorified in his saints, and to be admired in all them that believe (because our testimony among you was believed) in that day.
 11. Wherefore also we pray always for you, that our God would count you worthy of /this/ calling, and fulfil all the good pleasure of /his/ goodness, and the work of faith with power:
-12. That the name of our Lord Jesus Christ may be glorified in you, and ye in him, according to the grace of our God and the Lord Jesus Christ. 
+12. That the name of our Lord Jesus Christ may be glorified in you, and ye in him, according to the grace of our God and the Lord Jesus Christ.
 * 2
 1. Now we beseech you, brethren, by the coming of our Lord Jesus Christ, and /by/ our gathering together unto him,
 2. That ye be not soon shaken in mind, or be troubled, neither by spirit, nor by word, nor by letter as from us, as that the day of Christ is at hand.
@@ -31,7 +31,7 @@
 14. Whereunto he called you by our gospel, to the obtaining of the glory of our Lord Jesus Christ.
 15. Therefore, brethren, stand fast, and hold the traditions which ye have been taught, whether by word, or our epistle.
 16. Now our Lord Jesus Christ himself, and God, even our Father, which hath loved us, and hath given /us/ everlasting consolation and good hope through grace,
-17. Comfort your hearts, and stablish you in every good word and work. 
+17. Comfort your hearts, and stablish you in every good word and work.
 * 3
 1. Finally, brethren, pray for us, that the word of the Lord may have /free/ course, and be glorified, even as /it is/ with you:
 2. And that we may be delivered from unreasonable and wicked men: for all /men/ have not faith.
@@ -52,4 +52,4 @@
 16. Now the Lord of peace himself give you peace always by all means. The Lord /be/ with you all.
 
 17. The salutation of Paul with mine own hand, which is the token in every epistle: so I write.
-18. The grace of our Lord Jesus Christ /be/ with you all. Amen.  The second /epistle/ to the Thessalonians was written from Athens. 
+18. The grace of our Lord Jesus Christ /be/ with you all. Amen.  The second /epistle/ to the Thessalonians was written from Athens.

--- a/54_1TI.org
+++ b/54_1TI.org
@@ -4,7 +4,7 @@
 2. Unto Timothy, /my/ own son in the faith: Grace, mercy, /and/ peace, from God our Father and Jesus Christ our Lord.
 
 3. As I besought thee to abide still at Ephesus, when I went into Macedonia, that thou mightest charge some that they teach no other doctrine,
-4. Neither give heed to fables and endless genealogies, which minister questions, rather than godly edifying which is in faith: /so do/. 
+4. Neither give heed to fables and endless genealogies, which minister questions, rather than godly edifying which is in faith: /so do/.
 5. Now the end of the commandment is charity out of a pure heart, and /of/ a good conscience, and /of/ faith unfeigned:
 6. From which some having swerved have turned aside unto vain jangling;
 7. Desiring to be teachers of the law; understanding neither what they say, nor whereof they affirm.
@@ -20,7 +20,7 @@
 17. Now unto the King eternal, immortal, invisible, the only wise God, /be/ honour and glory for ever and ever. Amen.
 18. This charge I commit unto thee, son Timothy, according to the prophecies which went before on thee, that thou by them mightest war a good warfare;
 19. Holding faith, and a good conscience; which some having put away concerning faith have made shipwreck:
-20. Of whom is Hymenaeus and Alexander; whom I have delivered unto Satan, that they may learn not to blaspheme. 
+20. Of whom is Hymenaeus and Alexander; whom I have delivered unto Satan, that they may learn not to blaspheme.
 * 2
 1. I exhort therefore, that, first of all, supplications, prayers, intercessions, /and/ giving of thanks, be made for all men;
 2. For kings, and /for/ all that are in authority; that we may lead a quiet and peaceable life in all godliness and honesty.
@@ -36,7 +36,7 @@
 12. But I suffer not a woman to teach, nor to usurp authority over the man, but to be in silence.
 13. For Adam was first formed, then Eve.
 14. And Adam was not deceived, but the woman being deceived was in the transgression.
-15. Notwithstanding she shall be saved in childbearing, if they continue in faith and charity and holiness with sobriety. 
+15. Notwithstanding she shall be saved in childbearing, if they continue in faith and charity and holiness with sobriety.
 * 3
 1. This /is/ a true saying, If a man desire the office of a bishop, he desireth a good work.
 2. A bishop then must be blameless, the husband of one wife, vigilant, sober, of good behaviour, given to hospitality, apt to teach;
@@ -53,7 +53,7 @@
 13. For they that have used the office of a deacon well purchase to themselves a good degree, and great boldness in the faith which is in Christ Jesus.
 14. These things write I unto thee, hoping to come unto thee shortly:
 15. But if I tarry long, that thou mayest know how thou oughtest to behave thyself in the house of God, which is the church of the living God, the pillar and ground of the truth.
-16. And without controversy great is the mystery of godliness: God was manifest in the flesh, justified in the Spirit, seen of angels, preached unto the Gentiles, believed on in the world, received up into glory. 
+16. And without controversy great is the mystery of godliness: God was manifest in the flesh, justified in the Spirit, seen of angels, preached unto the Gentiles, believed on in the world, received up into glory.
 * 4
 1. Now the Spirit speaketh expressly, that in the latter times some shall depart from the faith, giving heed to seducing spirits, and doctrines of devils;
 2. Speaking lies in hypocrisy; having their conscience seared with a hot iron;
@@ -71,7 +71,7 @@
 13. Till I come, give attendance to reading, to exhortation, to doctrine.
 14. Neglect not the gift that is in thee, which was given thee by prophecy, with the laying on of the hands of the presbytery.
 15. Meditate upon these things; give thyself wholly to them; that thy profiting may appear to all.
-16. Take heed unto thyself, and unto the doctrine; continue in them: for in doing this thou shalt both save thyself, and them that hear thee. 
+16. Take heed unto thyself, and unto the doctrine; continue in them: for in doing this thou shalt both save thyself, and them that hear thee.
 * 5
 1. Rebuke not an elder, but intreat /him/ as a father; /and/ the younger men as brethren;
 2. The elder women as mothers; the younger as sisters, with all purity.
@@ -97,7 +97,7 @@
 22. Lay hands suddenly on no man, neither be partaker of other men's sins: keep thyself pure.
 23. Drink no longer water, but use a little wine for thy stomach's sake and thine often infirmities.
 24. Some men's sins are open beforehand, going before to judgment; and some /men/ they follow after.
-25. Likewise also the good works /of some/ are manifest beforehand; and they that are otherwise cannot be hid. 
+25. Likewise also the good works /of some/ are manifest beforehand; and they that are otherwise cannot be hid.
 * 6
 1. Let as many servants as are under the yoke count their own masters worthy of all honour, that the name of God and /his/ doctrine be not blasphemed.
 2. And they that have believing masters, let them not despise /them/, because they are brethren; but rather do /them/ service, because they are faithful and beloved, partakers of the benefit. These things teach and exhort.
@@ -120,4 +120,4 @@
 18. That they do good, that they be rich in good works, ready to distribute, willing to communicate;
 19. Laying up in store for themselves a good foundation against the time to come, that they may lay hold on eternal life.
 20. O Timothy, keep that which is committed to thy trust, avoiding profane /and/ vain babblings, and oppositions of science falsely so called:
-21. Which some professing have erred concerning the faith. Grace /be/ with thee. Amen.  The first to Timothy was written from Laodicea, which is the chiefest city of Phrygia Pacatiana. 
+21. Which some professing have erred concerning the faith. Grace /be/ with thee. Amen.  The first to Timothy was written from Laodicea, which is the chiefest city of Phrygia Pacatiana.

--- a/55_2TI.org
+++ b/55_2TI.org
@@ -16,8 +16,8 @@
 14. That good thing which was committed unto thee keep by the Holy Ghost which dwelleth in us.
 15. This thou knowest, that all they which are in Asia be turned away from me; of whom are Phygellus and Hermogenes.
 16. The Lord give mercy unto the house of Onesiphorus; for he oft refreshed me, and was not ashamed of my chain:
-17. But, when he was in Rome, he sought me out very diligently, and found /me/. 
-18. The Lord grant unto him that he may find mercy of the Lord in that day: and in how many things he ministered unto me at Ephesus, thou knowest very well. 
+17. But, when he was in Rome, he sought me out very diligently, and found /me/.
+18. The Lord grant unto him that he may find mercy of the Lord in that day: and in how many things he ministered unto me at Ephesus, thou knowest very well.
 * 2
 1. Thou therefore, my son, be strong in the grace that is in Christ Jesus.
 2. And the things that thou hast heard of me among many witnesses, the same commit thou to faithful men, who shall be able to teach others also.
@@ -29,7 +29,7 @@
 8. Remember that Jesus Christ of the seed of David was raised from the dead according to my gospel:
 9. Wherein I suffer trouble, as an evil doer, /even/ unto bonds; but the word of God is not bound.
 10. Therefore I endure all things for the elect's sakes, that they may also obtain the salvation which is in Christ Jesus with eternal glory.
-11. /It is/ a faithful saying: For if we be dead with /him/, we shall also live with /him/: 
+11. /It is/ a faithful saying: For if we be dead with /him/, we shall also live with /him/:
 12. If we suffer, we shall also reign with /him/: if we deny /him/, he also will deny us:
 13. If we believe not, /yet/ he abideth faithful: he cannot deny himself.
 14. Of these things put /them/ in remembrance, charging /them/ before the Lord that they strive not about words to no profit, /but/ to the subverting of the hearers.
@@ -44,7 +44,7 @@
 23. But foolish and unlearned questions avoid, knowing that they do gender strifes.
 24. And the servant of the Lord must not strive; but be gentle unto all /men/, apt to teach, patient,
 25. In meekness instructing those that oppose themselves; if God peradventure will give them repentance to the acknowledging of the truth;
-26. And /that/ they may recover themselves out of the snare of the devil, who are taken captive by him at his will. 
+26. And /that/ they may recover themselves out of the snare of the devil, who are taken captive by him at his will.
 * 3
 1. This know also, that in the last days perilous times shall come.
 2. For men shall be lovers of their own selves, covetous, boasters, proud, blasphemers, disobedient to parents, unthankful, unholy,
@@ -59,10 +59,10 @@
 11. Persecutions, afflictions, which came unto me at Antioch, at Iconium, at Lystra; what persecutions I endured: but out of /them/ all the Lord delivered me.
 12. Yea, and all that will live godly in Christ Jesus shall suffer persecution.
 13. But evil men and seducers shall wax worse and worse, deceiving, and being deceived.
-14. But continue thou in the things which thou hast learned and hast been assured of, knowing of whom thou hast learned /them/; 
+14. But continue thou in the things which thou hast learned and hast been assured of, knowing of whom thou hast learned /them/;
 15. And that from a child thou hast known the holy scriptures, which are able to make thee wise unto salvation through faith which is in Christ Jesus.
 16. All scripture /is/ given by inspiration of God, and /is/ profitable for doctrine, for reproof, for correction, for instruction in righteousness:
-17. That the man of God may be perfect, throughly furnished unto all good works. 
+17. That the man of God may be perfect, throughly furnished unto all good works.
 * 4
 1. I charge /thee/ therefore before God, and the Lord Jesus Christ, who shall judge the quick and the dead at his appearing and his kingdom;
 2. Preach the word; be instant in season, out of season; reprove, rebuke, exhort with all longsuffering and doctrine.
@@ -87,4 +87,4 @@
 19. Salute Prisca and Aquila, and the household of Onesiphorus.
 20. Erastus abode at Corinth: but Trophimus have I left at Miletum sick.
 21. Do thy diligence to come before winter. Eubulus greeteth thee, and Pudens, and Linus, and Claudia, and all the brethren.
-22. The Lord Jesus Christ /be/ with thy spirit. Grace /be/ with you. Amen.  The second /epistle/ unto Timotheus, ordained the first bishop of the church of the Ephesians, was written from Rome, when Paul was brought before Nero the second time. 
+22. The Lord Jesus Christ /be/ with thy spirit. Grace /be/ with you. Amen.  The second /epistle/ unto Timotheus, ordained the first bishop of the church of the Ephesians, was written from Rome, when Paul was brought before Nero the second time.

--- a/56_TIT.org
+++ b/56_TIT.org
@@ -16,7 +16,7 @@
 13. This witness is true. Wherefore rebuke them sharply, that they may be sound in the faith;
 14. Not giving heed to Jewish fables, and commandments of men, that turn from the truth.
 15. Unto the pure all things /are/ pure: but unto them that are defiled and unbelieving /is/ nothing pure; but even their mind and conscience is defiled.
-16. They profess that they know God; but in works they deny /him/, being abominable, and disobedient, and unto every good work reprobate. 
+16. They profess that they know God; but in works they deny /him/, being abominable, and disobedient, and unto every good work reprobate.
 * 2
 1. But speak thou the things which become sound doctrine:
 2. That the aged men be sober, grave, temperate, sound in faith, in charity, in patience.
@@ -32,7 +32,7 @@
 12. Teaching us that, denying ungodliness and worldly lusts, we should live soberly, righteously, and godly, in this present world;
 13. Looking for that blessed hope, and the glorious appearing of the great God and our Saviour Jesus Christ;
 14. Who gave himself for us, that he might redeem us from all iniquity, and purify unto himself a peculiar people, zealous of good works.
-15. These things speak, and exhort, and rebuke with all authority. Let no man despise thee. 
+15. These things speak, and exhort, and rebuke with all authority. Let no man despise thee.
 * 3
 1. Put them in mind to be subject to principalities and powers, to obey magistrates, to be ready to every good work,
 2. To speak evil of no man, to be no brawlers, /but/ gentle, shewing all meekness unto all men.
@@ -49,4 +49,4 @@
 12. When I shall send Artemas unto thee, or Tychicus, be diligent to come unto me to Nicopolis: for I have determined there to winter.
 13. Bring Zenas the lawyer and Apollos on their journey diligently, that nothing be wanting unto them.
 14. And let ours also learn to maintain good works for necessary uses, that they be not unfruitful.
-15. All that are with me salute thee. Greet them that love us in the faith. Grace /be/ with you all. Amen.  It was written to Titus, ordained the first bishop of the church of the Cretians, from Nicopolis of Macedonia. 
+15. All that are with me salute thee. Greet them that love us in the faith. Grace /be/ with you all. Amen.  It was written to Titus, ordained the first bishop of the church of the Cretians, from Nicopolis of Macedonia.

--- a/57_PHM.org
+++ b/57_PHM.org
@@ -27,4 +27,4 @@
 
 23. There salute thee Epaphras, my fellowprisoner in Christ Jesus;
 24. Marcus, Aristarchus, Demas, Lucas, my fellowlabourers.
-25. The grace of our Lord Jesus Christ /be/ with your spirit. Amen.  Written from Rome to Philemon, by Onesimus, a servant. 
+25. The grace of our Lord Jesus Christ /be/ with your spirit. Amen.  Written from Rome to Philemon, by Onesimus, a servant.

--- a/58_HEB.org
+++ b/58_HEB.org
@@ -13,11 +13,11 @@
 11. They shall perish; but thou remainest; and they all shall wax old as doth a garment;
 12. And as a vesture shalt thou fold them up, and they shall be changed: but thou art the same, and thy years shall not fail.
 13. But to which of the angels said he at any time, Sit on my right hand, until I make thine enemies thy footstool?
-14. Are they not all ministering spirits, sent forth to minister for them who shall be heirs of salvation? 
+14. Are they not all ministering spirits, sent forth to minister for them who shall be heirs of salvation?
 * 2
 1. Therefore we ought to give the more earnest heed to the things which we have heard, lest at any time we should let /them/ slip.
 2. For if the word spoken by angels was stedfast, and every transgression and disobedience received a just recompence of reward;
-3. How shall we escape, if we neglect so great salvation; which at the first began to be spoken by the Lord, and was confirmed unto us by them that heard /him/; 
+3. How shall we escape, if we neglect so great salvation; which at the first began to be spoken by the Lord, and was confirmed unto us by them that heard /him/;
 4. God also bearing /them/ witness, both with signs and wonders, and with divers miracles, and gifts of the Holy Ghost, according to his own will?
 
 5. For unto the angels hath he not put in subjection the world to come, whereof we speak.
@@ -33,7 +33,7 @@
 15. And deliver them who through fear of death were all their lifetime subject to bondage.
 16. For verily he took not on /him the nature of/ angels; but he took on /him/ the seed of Abraham.
 17. Wherefore in all things it behoved him to be made like unto /his/ brethren, that he might be a merciful and faithful high priest in things /pertaining/ to God, to make reconciliation for the sins of the people.
-18. For in that he himself hath suffered being tempted, he is able to succour them that are tempted. 
+18. For in that he himself hath suffered being tempted, he is able to succour them that are tempted.
 * 3
 1. Wherefore, holy brethren, partakers of the heavenly calling, consider the Apostle and High Priest of our profession, Christ Jesus;
 2. Who was faithful to him that appointed him, as also Moses /was faithful/ in all his house.
@@ -53,10 +53,10 @@
 16. For some, when they had heard, did provoke: howbeit not all that came out of Egypt by Moses.
 17. But with whom was he grieved forty years? /was it/ not with them that had sinned, whose carcases fell in the wilderness?
 18. And to whom sware he that they should not enter into his rest, but to them that believed not?
-19. So we see that they could not enter in because of unbelief. 
+19. So we see that they could not enter in because of unbelief.
 * 4
 1. Let us therefore fear, lest, a promise being left /us/ of entering into his rest, any of you should seem to come short of it.
-2. For unto us was the gospel preached, as well as unto them: but the word preached did not profit them, not being mixed with faith in them that heard /it/. 
+2. For unto us was the gospel preached, as well as unto them: but the word preached did not profit them, not being mixed with faith in them that heard /it/.
 3. For we which have believed do enter into rest, as he said, As I have sworn in my wrath, if they shall enter into my rest: although the works were finished from the foundation of the world.
 4. For he spake in a certain place of the seventh /day/ on this wise, And God did rest the seventh day from all his works.
 5. And in this /place/ again, If they shall enter into my rest.
@@ -70,7 +70,7 @@
 13. Neither is there any creature that is not manifest in his sight: but all things /are/ naked and opened unto the eyes of him with whom we have to do.
 14. Seeing then that we have a great high priest, that is passed into the heavens, Jesus the Son of God, let us hold fast /our/ profession.
 15. For we have not an high priest which cannot be touched with the feeling of our infirmities; but was in all points tempted like as /we are, yet/ without sin.
-16. Let us therefore come boldly unto the throne of grace, that we may obtain mercy, and find grace to help in time of need. 
+16. Let us therefore come boldly unto the throne of grace, that we may obtain mercy, and find grace to help in time of need.
 * 5
 1. For every high priest taken from among men is ordained for men in things /pertaining/ to God, that he may offer both gifts and sacrifices for sins:
 2. Who can have compassion on the ignorant, and on them that are out of the way; for that he himself also is compassed with infirmity.
@@ -86,7 +86,7 @@
 11. Of whom we have many things to say, and hard to be uttered, seeing ye are dull of hearing.
 12. For when for the time ye ought to be teachers, ye have need that one teach you again which /be/ the first principles of the oracles of God; and are become such as have need of milk, and not of strong meat.
 13. For every one that useth milk /is/ unskilful in the word of righteousness: for he is a babe.
-14. But strong meat belongeth to them that are of full age, /even/ those who by reason of use have their senses exercised to discern both good and evil. 
+14. But strong meat belongeth to them that are of full age, /even/ those who by reason of use have their senses exercised to discern both good and evil.
 * 6
 1. Therefore leaving the principles of the doctrine of Christ, let us go on unto perfection; not laying again the foundation of repentance from dead works, and of faith toward God,
 2. Of the doctrine of baptisms, and of laying on of hands, and of resurrection of the dead, and of eternal judgment.
@@ -107,7 +107,7 @@
 17. Wherein God, willing more abundantly to shew unto the heirs of promise the immutability of his counsel, confirmed /it/ by an oath:
 18. That by two immutable things, in which /it was/ impossible for God to lie, we might have a strong consolation, who have fled for refuge to lay hold upon the hope set before us:
 19. Which /hope/ we have as an anchor of the soul, both sure and stedfast, and which entereth into that within the veil;
-20. Whither the forerunner is for us entered, /even/ Jesus, made an high priest for ever after the order of Melchisedec. 
+20. Whither the forerunner is for us entered, /even/ Jesus, made an high priest for ever after the order of Melchisedec.
 * 7
 1. For this Melchisedec, king of Salem, priest of the most high God, who met Abraham returning from the slaughter of the kings, and blessed him;
 2. To whom also Abraham gave a tenth part of all; first being by interpretation King of righteousness, and after that also King of Salem, which is, King of peace;
@@ -128,7 +128,7 @@
 17. For he testifieth, Thou /art/ a priest for ever after the order of Melchisedec.
 18. For there is verily a disannulling of the commandment going before for the weakness and unprofitableness thereof.
 19. For the law made nothing perfect, but the bringing in of a better hope /did/; by the which we draw nigh unto God.
-20. And inasmuch as not without an oath /he was made priest/: 
+20. And inasmuch as not without an oath /he was made priest/:
 21. (For those priests were made without an oath; but this with an oath by him that said unto him, The Lord sware and will not repent, Thou /art/ a priest for ever after the order of Melchisedec:)
 22. By so much was Jesus made a surety of a better testament.
 23. And they truly were many priests, because they were not suffered to continue by reason of death:
@@ -136,7 +136,7 @@
 25. Wherefore he is able also to save them to the uttermost that come unto God by him, seeing he ever liveth to make intercession for them.
 26. For such an high priest became us, /who is/ holy, harmless, undefiled, separate from sinners, and made higher than the heavens;
 27. Who needeth not daily, as those high priests, to offer up sacrifice, first for his own sins, and then for the people's: for this he did once, when he offered up himself.
-28. For the law maketh men high priests which have infirmity; but the word of the oath, which was since the law, /maketh/ the Son, who is consecrated for evermore. 
+28. For the law maketh men high priests which have infirmity; but the word of the oath, which was since the law, /maketh/ the Son, who is consecrated for evermore.
 * 8
 1. Now of the things which we have spoken /this is/ the sum: We have such an high priest, who is set on the right hand of the throne of the Majesty in the heavens;
 2. A minister of the sanctuary, and of the true tabernacle, which the Lord pitched, and not man.
@@ -150,20 +150,20 @@
 10. For this /is/ the covenant that I will make with the house of Israel after those days, saith the Lord; I will put my laws into their mind, and write them in their hearts: and I will be to them a God, and they shall be to me a people:
 11. And they shall not teach every man his neighbour, and every man his brother, saying, Know the Lord: for all shall know me, from the least to the greatest.
 12. For I will be merciful to their unrighteousness, and their sins and their iniquities will I remember no more.
-13. In that he saith, A new /covenant/, he hath made the first old. Now that which decayeth and waxeth old /is/ ready to vanish away. 
+13. In that he saith, A new /covenant/, he hath made the first old. Now that which decayeth and waxeth old /is/ ready to vanish away.
 * 9
 1. Then verily the first /covenant/ had also ordinances of divine service, and a worldly sanctuary.
 2. For there was a tabernacle made; the first, wherein /was/ the candlestick, and the table, and the shewbread; which is called the sanctuary.
 3. And after the second veil, the tabernacle which is called the Holiest of all;
 4. Which had the golden censer, and the ark of the covenant overlaid round about with gold, wherein /was/ the golden pot that had manna, and Aaron's rod that budded, and the tables of the covenant;
 5. And over it the cherubims of glory shadowing the mercyseat; of which we cannot now speak particularly.
-6. Now when these things were thus ordained, the priests went always into the first tabernacle, accomplishing the service /of God/. 
+6. Now when these things were thus ordained, the priests went always into the first tabernacle, accomplishing the service /of God/.
 7. But into the second /went/ the high priest alone once every year, not without blood, which he offered for himself, and /for/ the errors of the people:
 8. The Holy Ghost this signifying, that the way into the holiest of all was not yet made manifest, while as the first tabernacle was yet standing:
 9. Which /was/ a figure for the time then present, in which were offered both gifts and sacrifices, that could not make him that did the service perfect, as pertaining to the conscience;
 10. /Which stood/ only in meats and drinks, and divers washings, and carnal ordinances, imposed /on them/ until the time of reformation.
 11. But Christ being come an high priest of good things to come, by a greater and more perfect tabernacle, not made with hands, that is to say, not of this building;
-12. Neither by the blood of goats and calves, but by his own blood he entered in once into the holy place, having obtained eternal redemption /for us/. 
+12. Neither by the blood of goats and calves, but by his own blood he entered in once into the holy place, having obtained eternal redemption /for us/.
 13. For if the blood of bulls and of goats, and the ashes of an heifer sprinkling the unclean, sanctifieth to the purifying of the flesh:
 14. How much more shall the blood of Christ, who through the eternal Spirit offered himself without spot to God, purge your conscience from dead works to serve the living God?
 15. And for this cause he is the mediator of the new testament, that by means of death, for the redemption of the transgressions /that were/ under the first testament, they which are called might receive the promise of eternal inheritance.
@@ -179,7 +179,7 @@
 25. Nor yet that he should offer himself often, as the high priest entereth into the holy place every year with blood of others;
 26. For then must he often have suffered since the foundation of the world: but now once in the end of the world hath he appeared to put away sin by the sacrifice of himself.
 27. And as it is appointed unto men once to die, but after this the judgment:
-28. So Christ was once offered to bear the sins of many; and unto them that look for him shall he appear the second time without sin unto salvation. 
+28. So Christ was once offered to bear the sins of many; and unto them that look for him shall he appear the second time without sin unto salvation.
 * 10
 1. For the law having a shadow of good things to come, /and/ not the very image of the things, can never with those sacrifices which they offered year by year continually make the comers thereunto perfect.
 2. For then would they not have ceased to be offered? because that the worshippers once purged should have had no more conscience of sins.
@@ -190,7 +190,7 @@
 7. Then said I, Lo, I come (in the volume of the book it is written of me,) to do thy will, O God.
 8. Above when he said, Sacrifice and offering and burnt offerings and /offering/ for sin thou wouldest not, neither hadst pleasure /therein/; which are offered by the law;
 9. Then said he, Lo, I come to do thy will, O God. He taketh away the first, that he may establish the second.
-10. By the which will we are sanctified through the offering of the body of Jesus Christ once /for all/. 
+10. By the which will we are sanctified through the offering of the body of Jesus Christ once /for all/.
 11. And every priest standeth daily ministering and offering oftentimes the same sacrifices, which can never take away sins:
 12. But this man, after he had offered one sacrifice for sins for ever, sat down on the right hand of God;
 13. From henceforth expecting till his enemies be made his footstool.
@@ -220,7 +220,7 @@
 36. For ye have need of patience, that, after ye have done the will of God, ye might receive the promise.
 37. For yet a little while, and he that shall come will come, and will not tarry.
 38. Now the just shall live by faith: but if /any man/ draw back, my soul shall have no pleasure in him.
-39. But we are not of them who draw back unto perdition; but of them that believe to the saving of the soul. 
+39. But we are not of them who draw back unto perdition; but of them that believe to the saving of the soul.
 * 11
 1. Now faith is the substance of things hoped for, the evidence of things not seen.
 2. For by it the elders obtained a good report.
@@ -238,7 +238,7 @@
 14. For they that say such things declare plainly that they seek a country.
 15. And truly, if they had been mindful of that /country/ from whence they came out, they might have had opportunity to have returned.
 16. But now they desire a better /country/, that is, an heavenly: wherefore God is not ashamed to be called their God: for he hath prepared for them a city.
-17. By faith Abraham, when he was tried, offered up Isaac: and he that had received the promises offered up his only begotten /son/, 
+17. By faith Abraham, when he was tried, offered up Isaac: and he that had received the promises offered up his only begotten /son/,
 18. Of whom it was said, That in Isaac shall thy seed be called:
 19. Accounting that God /was/ able to raise /him/ up, even from the dead; from whence also he received him in a figure.
 20. By faith Isaac blessed Jacob and Esau concerning things to come.
@@ -261,7 +261,7 @@
 37. They were stoned, they were sawn asunder, were tempted, were slain with the sword: they wandered about in sheepskins and goatskins; being destitute, afflicted, tormented;
 38. (Of whom the world was not worthy:) they wandered in deserts, and /in/ mountains, and /in/ dens and caves of the earth.
 39. And these all, having obtained a good report through faith, received not the promise:
-40. God having provided some better thing for us, that they without us should not be made perfect. 
+40. God having provided some better thing for us, that they without us should not be made perfect.
 * 12
 1. Wherefore seeing we also are compassed about with so great a cloud of witnesses, let us lay aside every weight, and the sin which doth so easily beset /us/, and let us run with patience the race that is set before us,
 2. Looking unto Jesus the author and finisher of /our/ faith; who for the joy that was set before him endured the cross, despising the shame, and is set down at the right hand of the throne of God.
@@ -291,7 +291,7 @@
 26. Whose voice then shook the earth: but now he hath promised, saying, Yet once more I shake not the earth only, but also heaven.
 27. And this /word/, Yet once more, signifieth the removing of those things that are shaken, as of things that are made, that those things which cannot be shaken may remain.
 28. Wherefore we receiving a kingdom which cannot be moved, let us have grace, whereby we may serve God acceptably with reverence and godly fear:
-29. For our God /is/ a consuming fire. 
+29. For our God /is/ a consuming fire.
 * 13
 1. Let brotherly love continue.
 2. Be not forgetful to entertain strangers: for thereby some have entertained angels unawares.
@@ -319,4 +319,4 @@
 22. And I beseech you, brethren, suffer the word of exhortation: for I have written a letter unto you in few words.
 23. Know ye that /our/ brother Timothy is set at liberty; with whom, if he come shortly, I will see you.
 24. Salute all them that have the rule over you, and all the saints. They of Italy salute you.
-25. Grace /be/ with you all. Amen.  Written to the Hebrews from Italy by Timothy. 
+25. Grace /be/ with you all. Amen.  Written to the Hebrews from Italy by Timothy.

--- a/59_JAS.org
+++ b/59_JAS.org
@@ -28,7 +28,7 @@
 24. For he beholdeth himself, and goeth his way, and straightway forgetteth what manner of man he was.
 25. But whoso looketh into the perfect law of liberty, and continueth /therein/, he being not a forgetful hearer, but a doer of the work, this man shall be blessed in his deed.
 26. If any man among you seem to be religious, and bridleth not his tongue, but deceiveth his own heart, this man's religion /is/ vain.
-27. Pure religion and undefiled before God and the Father is this, To visit the fatherless and widows in their affliction, /and/ to keep himself unspotted from the world. 
+27. Pure religion and undefiled before God and the Father is this, To visit the fatherless and widows in their affliction, /and/ to keep himself unspotted from the world.
 * 2
 1. My brethren, have not the faith of our Lord Jesus Christ, /the Lord/ of glory, with respect of persons.
 2. For if there come unto your assembly a man with a gold ring, in goodly apparel, and there come in also a poor man in vile raiment;
@@ -55,7 +55,7 @@
 23. And the scripture was fulfilled which saith, Abraham believed God, and it was imputed unto him for righteousness: and he was called the Friend of God.
 24. Ye see then how that by works a man is justified, and not by faith only.
 25. Likewise also was not Rahab the harlot justified by works, when she had received the messengers, and had sent /them/ out another way?
-26. For as the body without the spirit is dead, so faith without works is dead also. 
+26. For as the body without the spirit is dead, so faith without works is dead also.
 * 3
 1. My brethren, be not many masters, knowing that we shall receive the greater condemnation.
 2. For in many things we offend all. If any man offend not in word, the same /is/ a perfect man, /and/ able also to bridle the whole body.
@@ -74,7 +74,7 @@
 15. This wisdom descendeth not from above, but /is/ earthly, sensual, devilish.
 16. For where envying and strife /is/, there /is/ confusion and every evil work.
 17. But the wisdom that is from above is first pure, then peaceable, gentle, /and/ easy to be intreated, full of mercy and good fruits, without partiality, and without hypocrisy.
-18. And the fruit of righteousness is sown in peace of them that make peace. 
+18. And the fruit of righteousness is sown in peace of them that make peace.
 * 4
 1. From whence /come/ wars and fightings among you? /come they/ not hence, /even/ of your lusts that war in your members?
 2. Ye lust, and have not: ye kill, and desire to have, and cannot obtain: ye fight and war, yet ye have not, because ye ask not.
@@ -93,9 +93,9 @@
 14. Whereas ye know not what /shall be/ on the morrow. For what /is/ your life? It is even a vapour, that appeareth for a little time, and then vanisheth away.
 15. For that ye /ought/ to say, If the Lord will, we shall live, and do this, or that.
 16. But now ye rejoice in your boastings: all such rejoicing is evil.
-17. Therefore to him that knoweth to do good, and doeth /it/ not, to him it is sin. 
+17. Therefore to him that knoweth to do good, and doeth /it/ not, to him it is sin.
 * 5
-1. Go to now, /ye/ rich men, weep and howl for your miseries that shall come upon /you/. 
+1. Go to now, /ye/ rich men, weep and howl for your miseries that shall come upon /you/.
 2. Your riches are corrupted, and your garments are motheaten.
 3. Your gold and silver is cankered; and the rust of them shall be a witness against you, and shall eat your flesh as it were fire. Ye have heaped treasure together for the last days.
 4. Behold, the hire of the labourers who have reaped down your fields, which is of you kept back by fraud, crieth: and the cries of them which have reaped are entered into the ears of the Lord of sabaoth.
@@ -115,4 +115,4 @@
 17. Elias was a man subject to like passions as we are, and he prayed earnestly that it might not rain: and it rained not on the earth by the space of three years and six months.
 18. And he prayed again, and the heaven gave rain, and the earth brought forth her fruit.
 19. Brethren, if any of you do err from the truth, and one convert him;
-20. Let him know, that he which converteth the sinner from the error of his way shall save a soul from death, and shall hide a multitude of sins.  
+20. Let him know, that he which converteth the sinner from the error of his way shall save a soul from death, and shall hide a multitude of sins.

--- a/60_1PE.org
+++ b/60_1PE.org
@@ -25,7 +25,7 @@
 22. Seeing ye have purified your souls in obeying the truth through the Spirit unto unfeigned love of the brethren, /see that ye/ love one another with a pure heart fervently:
 23. Being born again, not of corruptible seed, but of incorruptible, by the word of God, which liveth and abideth for ever.
 24. For all flesh /is/ as grass, and all the glory of man as the flower of grass. The grass withereth, and the flower thereof falleth away:
-25. But the word of the Lord endureth for ever. And this is the word which by the gospel is preached unto you. 
+25. But the word of the Lord endureth for ever. And this is the word which by the gospel is preached unto you.
 * 2
 1. Wherefore laying aside all malice, and all guile, and hypocrisies, and envies, and all evil speakings,
 2. As newborn babes, desire the sincere milk of the word, that ye may grow thereby:
@@ -53,7 +53,7 @@
 22. Who did no sin, neither was guile found in his mouth:
 23. Who, when he was reviled, reviled not again; when he suffered, he threatened not; but committed /himself/ to him that judgeth righteously:
 24. Who his own self bare our sins in his own body on the tree, that we, being dead to sins, should live unto righteousness: by whose stripes ye were healed.
-25. For ye were as sheep going astray; but are now returned unto the Shepherd and Bishop of your souls. 
+25. For ye were as sheep going astray; but are now returned unto the Shepherd and Bishop of your souls.
 * 3
 1. Likewise, ye wives, /be/ in subjection to your own husbands; that, if any obey not the word, they also may without the word be won by the conversation of the wives;
 2. While they behold your chaste conversation /coupled/ with fear.
@@ -77,12 +77,12 @@
 19. By which also he went and preached unto the spirits in prison;
 20. Which sometime were disobedient, when once the longsuffering of God waited in the days of Noah, while the ark was a preparing, wherein few, that is, eight souls were saved by water.
 21. The like figure whereunto /even/ baptism doth also now save us (not the putting away of the filth of the flesh, but the answer of a good conscience toward God,) by the resurrection of Jesus Christ:
-22. Who is gone into heaven, and is on the right hand of God; angels and authorities and powers being made subject unto him. 
+22. Who is gone into heaven, and is on the right hand of God; angels and authorities and powers being made subject unto him.
 * 4
 1. Forasmuch then as Christ hath suffered for us in the flesh, arm yourselves likewise with the same mind: for he that hath suffered in the flesh hath ceased from sin;
 2. That he no longer should live the rest of /his/ time in the flesh to the lusts of men, but to the will of God.
 3. For the time past of /our/ life may suffice us to have wrought the will of the Gentiles, when we walked in lasciviousness, lusts, excess of wine, revellings, banquetings, and abominable idolatries:
-4. Wherein they think it strange that ye run not with /them/ to the same excess of riot, speaking evil of /you/: 
+4. Wherein they think it strange that ye run not with /them/ to the same excess of riot, speaking evil of /you/:
 5. Who shall give account to him that is ready to judge the quick and the dead.
 6. For for this cause was the gospel preached also to them that are dead, that they might be judged according to men in the flesh, but live according to God in the spirit.
 
@@ -99,7 +99,7 @@
 16. Yet if /any man suffer/ as a Christian, let him not be ashamed; but let him glorify God on this behalf.
 17. For the time /is come/ that judgment must begin at the house of God: and if /it/ first /begin/ at us, what shall the end /be/ of them that obey not the gospel of God?
 18. And if the righteous scarcely be saved, where shall the ungodly and the sinner appear?
-19. Wherefore let them that suffer according to the will of God commit the keeping of their souls /to him/ in well doing, as unto a faithful Creator. 
+19. Wherefore let them that suffer according to the will of God commit the keeping of their souls /to him/ in well doing, as unto a faithful Creator.
 * 5
 1. The elders which are among you I exhort, who am also an elder, and a witness of the sufferings of Christ, and also a partaker of the glory that shall be revealed:
 2. Feed the flock of God which is among you, taking the oversight /thereof/, not by constraint, but willingly; not for filthy lucre, but of a ready mind;
@@ -116,4 +116,4 @@
 
 12. By Silvanus, a faithful brother unto you, as I suppose, I have written briefly, exhorting, and testifying that this is the true grace of God wherein ye stand.
 13. The /church that is/ at Babylon, elected together with /you/, saluteth you; and /so doth/ Marcus my son.
-14. Greet ye one another with a kiss of charity. Peace /be/ with you all that are in Christ Jesus. Amen.  
+14. Greet ye one another with a kiss of charity. Peace /be/ with you all that are in Christ Jesus. Amen.

--- a/61_2PE.org
+++ b/61_2PE.org
@@ -21,7 +21,7 @@
 18. And this voice which came from heaven we heard, when we were with him in the holy mount.
 19. We have also a more sure word of prophecy; whereunto ye do well that ye take heed, as unto a light that shineth in a dark place, until the day dawn, and the day star arise in your hearts:
 20. Knowing this first, that no prophecy of the scripture is of any private interpretation.
-21. For the prophecy came not in old time by the will of man: but holy men of God spake /as they were/ moved by the Holy Ghost. 
+21. For the prophecy came not in old time by the will of man: but holy men of God spake /as they were/ moved by the Holy Ghost.
 * 2
 1. But there were false prophets also among the people, even as there shall be false teachers among you, who privily shall bring in damnable heresies, even denying the Lord that bought them, and bring upon themselves swift destruction.
 2. And many shall follow their pernicious ways; by reason of whom the way of truth shall be evil spoken of.
@@ -44,7 +44,7 @@
 19. While they promise them liberty, they themselves are the servants of corruption: for of whom a man is overcome, of the same is he brought in bondage.
 20. For if after they have escaped the pollutions of the world through the knowledge of the Lord and Saviour Jesus Christ, they are again entangled therein, and overcome, the latter end is worse with them than the beginning.
 21. For it had been better for them not to have known the way of righteousness, than, after they have known /it/, to turn from the holy commandment delivered unto them.
-22. But it is happened unto them according to the true proverb, The dog /is/ turned to his own vomit again; and the sow that was washed to her wallowing in the mire. 
+22. But it is happened unto them according to the true proverb, The dog /is/ turned to his own vomit again; and the sow that was washed to her wallowing in the mire.
 * 3
 1. This second epistle, beloved, I now write unto you; in /both/ which I stir up your pure minds by way of remembrance:
 2. That ye may be mindful of the words which were spoken before by the holy prophets, and of the commandment of us the apostles of the Lord and Saviour:
@@ -63,4 +63,4 @@
 15. And account /that/ the longsuffering of our Lord /is/ salvation; even as our beloved brother Paul also according to the wisdom given unto him hath written unto you;
 16. As also in all /his/ epistles, speaking in them of these things; in which are some things hard to be understood, which they that are unlearned and unstable wrest, as /they do/ also the other scriptures, unto their own destruction.
 17. Ye therefore, beloved, seeing ye know /these things/ before, beware lest ye also, being led away with the error of the wicked, fall from your own stedfastness.
-18. But grow in grace, and /in/ the knowledge of our Lord and Saviour Jesus Christ. To him /be/ glory both now and for ever. Amen.  
+18. But grow in grace, and /in/ the knowledge of our Lord and Saviour Jesus Christ. To him /be/ glory both now and for ever. Amen.

--- a/62_1JN.org
+++ b/62_1JN.org
@@ -10,7 +10,7 @@
 7. But if we walk in the light, as he is in the light, we have fellowship one with another, and the blood of Jesus Christ his Son cleanseth us from all sin.
 8. If we say that we have no sin, we deceive ourselves, and the truth is not in us.
 9. If we confess our sins, he is faithful and just to forgive us /our/ sins, and to cleanse us from all unrighteousness.
-10. If we say that we have not sinned, we make him a liar, and his word is not in us. 
+10. If we say that we have not sinned, we make him a liar, and his word is not in us.
 * 2
 1. My little children, these things write I unto you, that ye sin not. And if any man sin, we have an advocate with the Father, Jesus Christ the righteous:
 2. And he is the propitiation for our sins: and not for ours only, but also for /the sins of/ the whole world.
@@ -36,13 +36,13 @@
 20. But ye have an unction from the Holy One, and ye know all things.
 21. I have not written unto you because ye know not the truth, but because ye know it, and that no lie is of the truth.
 22. Who is a liar but he that denieth that Jesus is the Christ? He is antichrist, that denieth the Father and the Son.
-23. Whosoever denieth the Son, the same hath not the Father: /(but) he that acknowledgeth the Son hath the Father also/. 
+23. Whosoever denieth the Son, the same hath not the Father: /(but) he that acknowledgeth the Son hath the Father also/.
 24. Let that therefore abide in you, which ye have heard from the beginning. If that which ye have heard from the beginning shall remain in you, ye also shall continue in the Son, and in the Father.
 25. And this is the promise that he hath promised us, /even/ eternal life.
 26. These /things/ have I written unto you concerning them that seduce you.
 27. But the anointing which ye have received of him abideth in you, and ye need not that any man teach you: but as the same anointing teacheth you of all things, and is truth, and is no lie, and even as it hath taught you, ye shall abide in him.
 28. And now, little children, abide in him; that, when he shall appear, we may have confidence, and not be ashamed before him at his coming.
-29. If ye know that he is righteous, ye know that every one that doeth righteousness is born of him. 
+29. If ye know that he is righteous, ye know that every one that doeth righteousness is born of him.
 * 3
 1. Behold, what manner of love the Father hath bestowed upon us, that we should be called the sons of God: therefore the world knoweth us not, because it knew him not.
 2. Beloved, now are we the sons of God, and it doth not yet appear what we shall be: but we know that, when he shall appear, we shall be like him; for we shall see him as he is.
@@ -68,7 +68,7 @@
 21. Beloved, if our heart condemn us not, /then/ have we confidence toward God.
 22. And whatsoever we ask, we receive of him, because we keep his commandments, and do those things that are pleasing in his sight.
 23. And this is his commandment, That we should believe on the name of his Son Jesus Christ, and love one another, as he gave us commandment.
-24. And he that keepeth his commandments dwelleth in him, and he in him. And hereby we know that he abideth in us, by the Spirit which he hath given us. 
+24. And he that keepeth his commandments dwelleth in him, and he in him. And hereby we know that he abideth in us, by the Spirit which he hath given us.
 * 4
 1. Beloved, believe not every spirit, but try the spirits whether they are of God: because many false prophets are gone out into the world.
 2. Hereby know ye the Spirit of God: Every spirit that confesseth that Jesus Christ is come in the flesh is of God:
@@ -91,7 +91,7 @@
 18. There is no fear in love; but perfect love casteth out fear: because fear hath torment. He that feareth is not made perfect in love.
 19. We love him, because he first loved us.
 20. If a man say, I love God, and hateth his brother, he is a liar: for he that loveth not his brother whom he hath seen, how can he love God whom he hath not seen?
-21. And this commandment have we from him, That he who loveth God love his brother also. 
+21. And this commandment have we from him, That he who loveth God love his brother also.
 * 5
 1. Whosoever believeth that Jesus is the Christ is born of God: and every one that loveth him that begat loveth him also that is begotten of him.
 2. By this we know that we love the children of God, when we love God, and keep his commandments.
@@ -113,4 +113,4 @@
 18. We know that whosoever is born of God sinneth not; but he that is begotten of God keepeth himself, and that wicked one toucheth him not.
 19. /And/ we know that we are of God, and the whole world lieth in wickedness.
 20. And we know that the Son of God is come, and hath given us an understanding, that we may know him that is true, and we are in him that is true, /even/ in his Son Jesus Christ. This is the true God, and eternal life.
-21. Little children, keep yourselves from idols. Amen.  
+21. Little children, keep yourselves from idols. Amen.

--- a/63_2JN.org
+++ b/63_2JN.org
@@ -14,4 +14,4 @@
 11. For he that biddeth him God speed is partaker of his evil deeds.
 
 12. Having many things to write unto you, I would not /write/ with paper and ink: but I trust to come unto you, and speak face to face, that our joy may be full.
-13. The children of thy elect sister greet thee. Amen.  
+13. The children of thy elect sister greet thee. Amen.

--- a/64_3JN.org
+++ b/64_3JN.org
@@ -17,4 +17,4 @@
 12. Demetrius hath good report of all /men/, and of the truth itself: yea, and we /also/ bear record; and ye know that our record is true.
 
 13. I had many things to write, but I will not with ink and pen write unto thee:
-14. But I trust I shall shortly see thee, and we shall speak face to face. Peace /be/ to thee. /Our/ friends salute thee. Greet the friends by name.  
+14. But I trust I shall shortly see thee, and we shall speak face to face. Peace /be/ to thee. /Our/ friends salute thee. Greet the friends by name.

--- a/65_JUD.org
+++ b/65_JUD.org
@@ -27,4 +27,4 @@
 23. And others save with fear, pulling /them/ out of the fire; hating even the garment spotted by the flesh.
 
 24. Now unto him that is able to keep you from falling, and to present /you/ faultless before the presence of his glory with exceeding joy,
-25. To the only wise God our Saviour, /be/ glory and majesty, dominion and power, both now and ever. Amen.  
+25. To the only wise God our Saviour, /be/ glory and majesty, dominion and power, both now and ever. Amen.

--- a/66_REV.org
+++ b/66_REV.org
@@ -21,7 +21,7 @@
 18. I /am/ he that liveth, and was dead; and, behold, I am alive for evermore, Amen; and have the keys of hell and of death.
 
 19. Write the things which thou hast seen, and the things which are, and the things which shall be hereafter;
-20. The mystery of the seven stars which thou sawest in my right hand, and the seven golden candlesticks. The seven stars are the angels of the seven churches: and the seven candlesticks which thou sawest are the seven churches. 
+20. The mystery of the seven stars which thou sawest in my right hand, and the seven golden candlesticks. The seven stars are the angels of the seven churches: and the seven candlesticks which thou sawest are the seven churches.
 * 2
 1. Unto the angel of the church of Ephesus write; These things saith he that holdeth the seven stars in his right hand, who walketh in the midst of the seven golden candlesticks;
 2. I know thy works, and thy labour, and thy patience, and how thou canst not bear them which are evil: and thou hast tried them which say they are apostles, and are not, and hast found them liars:
@@ -54,7 +54,7 @@
 26. And he that overcometh, and keepeth my works unto the end, to him will I give power over the nations:
 27. And he shall rule them with a rod of iron; as the vessels of a potter shall they be broken to shivers: even as I received of my Father.
 28. And I will give him the morning star.
-29. He that hath an ear, let him hear what the Spirit saith unto the churches. 
+29. He that hath an ear, let him hear what the Spirit saith unto the churches.
 * 3
 1. And unto the angel of the church in Sardis write; These things saith he that hath the seven Spirits of God, and the seven stars; I know thy works, that thou hast a name that thou livest, and art dead.
 2. Be watchful, and strengthen the things which remain, that are ready to die: for I have not found thy works perfect before God.
@@ -79,7 +79,7 @@
 19. As many as I love, I rebuke and chasten: be zealous therefore, and repent.
 20. Behold, I stand at the door, and knock: if any man hear my voice, and open the door, I will come in to him, and will sup with him, and he with me.
 21. To him that overcometh will I grant to sit with me in my throne, even as I also overcame, and am set down with my Father in his throne.
-22. He that hath an ear, let him hear what the Spirit saith unto the churches. 
+22. He that hath an ear, let him hear what the Spirit saith unto the churches.
 * 4
 1. After this I looked, and, behold, a door /was/ opened in heaven: and the first voice which I heard /was/ as it were of a trumpet talking with me; which said, Come up hither, and I will shew thee things which must be hereafter.
 2. And immediately I was in the spirit: and, behold, a throne was set in heaven, and /one/ sat on the throne.
@@ -91,7 +91,7 @@
 8. And the four beasts had each of them six wings about /him/; and /they were/ full of eyes within: and they rest not day and night, saying, Holy, holy, holy, Lord God Almighty, which was, and is, and is to come.
 9. And when those beasts give glory and honour and thanks to him that sat on the throne, who liveth for ever and ever,
 10. The four and twenty elders fall down before him that sat on the throne, and worship him that liveth for ever and ever, and cast their crowns before the throne, saying,
-11. Thou art worthy, O Lord, to receive glory and honour and power: for thou hast created all things, and for thy pleasure they are and were created. 
+11. Thou art worthy, O Lord, to receive glory and honour and power: for thou hast created all things, and for thy pleasure they are and were created.
 * 5
 1. And I saw in the right hand of him that sat on the throne a book written within and on the backside, sealed with seven seals.
 2. And I saw a strong angel proclaiming with a loud voice, Who is worthy to open the book, and to loose the seals thereof?
@@ -106,7 +106,7 @@
 11. And I beheld, and I heard the voice of many angels round about the throne and the beasts and the elders: and the number of them was ten thousand times ten thousand, and thousands of thousands;
 12. Saying with a loud voice, Worthy is the Lamb that was slain to receive power, and riches, and wisdom, and strength, and honour, and glory, and blessing.
 13. And every creature which is in heaven, and on the earth, and under the earth, and such as are in the sea, and all that are in them, heard I saying, Blessing, and honour, and glory, and power, /be/ unto him that sitteth upon the throne, and unto the Lamb for ever and ever.
-14. And the four beasts said, Amen. And the four /and/ twenty elders fell down and worshipped him that liveth for ever and ever. 
+14. And the four beasts said, Amen. And the four /and/ twenty elders fell down and worshipped him that liveth for ever and ever.
 * 6
 1. And I saw when the Lamb opened one of the seals, and I heard, as it were the noise of thunder, one of the four beasts saying, Come and see.
 2. And I saw, and behold a white horse: and he that sat on him had a bow; and a crown was given unto him: and he went forth conquering, and to conquer.
@@ -124,7 +124,7 @@
 14. And the heaven departed as a scroll when it is rolled together; and every mountain and island were moved out of their places.
 15. And the kings of the earth, and the great men, and the rich men, and the chief captains, and the mighty men, and every bondman, and every free man, hid themselves in the dens and in the rocks of the mountains;
 16. And said to the mountains and rocks, Fall on us, and hide us from the face of him that sitteth on the throne, and from the wrath of the Lamb:
-17. For the great day of his wrath is come; and who shall be able to stand? 
+17. For the great day of his wrath is come; and who shall be able to stand?
 * 7
 1. And after these things I saw four angels standing on the four corners of the earth, holding the four winds of the earth, that the wind should not blow on the earth, nor on the sea, nor on any tree.
 2. And I saw another angel ascending from the east, having the seal of the living God: and he cried with a loud voice to the four angels, to whom it was given to hurt the earth and the sea,
@@ -142,7 +142,7 @@
 14. And I said unto him, Sir, thou knowest. And he said to me, These are they which came out of great tribulation, and have washed their robes, and made them white in the blood of the Lamb.
 15. Therefore are they before the throne of God, and serve him day and night in his temple: and he that sitteth on the throne shall dwell among them.
 16. They shall hunger no more, neither thirst any more; neither shall the sun light on them, nor any heat.
-17. For the Lamb which is in the midst of the throne shall feed them, and shall lead them unto living fountains of waters: and God shall wipe away all tears from their eyes. 
+17. For the Lamb which is in the midst of the throne shall feed them, and shall lead them unto living fountains of waters: and God shall wipe away all tears from their eyes.
 * 8
 1. And when he had opened the seventh seal, there was silence in heaven about the space of half an hour.
 2. And I saw the seven angels which stood before God; and to them were given seven trumpets.
@@ -157,7 +157,7 @@
 10. And the third angel sounded, and there fell a great star from heaven, burning as it were a lamp, and it fell upon the third part of the rivers, and upon the fountains of waters;
 11. And the name of the star is called Wormwood: and the third part of the waters became wormwood; and many men died of the waters, because they were made bitter.
 12. And the fourth angel sounded, and the third part of the sun was smitten, and the third part of the moon, and the third part of the stars; so as the third part of them was darkened, and the day shone not for a third part of it, and the night likewise.
-13. And I beheld, and heard an angel flying through the midst of heaven, saying with a loud voice, Woe, woe, woe, to the inhabiters of the earth by reason of the other voices of the trumpet of the three angels, which are yet to sound! 
+13. And I beheld, and heard an angel flying through the midst of heaven, saying with a loud voice, Woe, woe, woe, to the inhabiters of the earth by reason of the other voices of the trumpet of the three angels, which are yet to sound!
 * 9
 1. And the fifth angel sounded, and I saw a star fall from heaven unto the earth: and to him was given the key of the bottomless pit.
 2. And he opened the bottomless pit; and there arose a smoke out of the pit, as the smoke of a great furnace; and the sun and the air were darkened by reason of the smoke of the pit.
@@ -180,7 +180,7 @@
 18. By these three was the third part of men killed, by the fire, and by the smoke, and by the brimstone, which issued out of their mouths.
 19. For their power is in their mouth, and in their tails: for their tails /were/ like unto serpents, and had heads, and with them they do hurt.
 20. And the rest of the men which were not killed by these plagues yet repented not of the works of their hands, that they should not worship devils, and idols of gold, and silver, and brass, and stone, and of wood: which neither can see, nor hear, nor walk:
-21. Neither repented they of their murders, nor of their sorceries, nor of their fornication, nor of their thefts. 
+21. Neither repented they of their murders, nor of their sorceries, nor of their fornication, nor of their thefts.
 * 10
 1. And I saw another mighty angel come down from heaven, clothed with a cloud: and a rainbow /was/ upon his head, and his face /was/ as it were the sun, and his feet as pillars of fire:
 2. And he had in his hand a little book open: and he set his right foot upon the sea, and /his/ left /foot/ on the earth,
@@ -192,7 +192,7 @@
 8. And the voice which I heard from heaven spake unto me again, and said, Go /and/ take the little book which is open in the hand of the angel which standeth upon the sea and upon the earth.
 9. And I went unto the angel, and said unto him, Give me the little book. And he said unto me, Take /it/, and eat it up; and it shall make thy belly bitter, but it shall be in thy mouth sweet as honey.
 10. And I took the little book out of the angel's hand, and ate it up; and it was in my mouth sweet as honey: and as soon as I had eaten it, my belly was bitter.
-11. And he said unto me, Thou must prophesy again before many peoples, and nations, and tongues, and kings. 
+11. And he said unto me, Thou must prophesy again before many peoples, and nations, and tongues, and kings.
 * 11
 1. And there was given me a reed like unto a rod: and the angel stood, saying, Rise, and measure the temple of God, and the altar, and them that worship therein.
 2. But the court which is without the temple leave out, and measure it not; for it is given unto the Gentiles: and the holy city shall they tread under foot forty /and/ two months.
@@ -212,7 +212,7 @@
 16. And the four and twenty elders, which sat before God on their seats, fell upon their faces, and worshipped God,
 17. Saying, We give thee thanks, O Lord God Almighty, which art, and wast, and art to come; because thou hast taken to thee thy great power, and hast reigned.
 18. And the nations were angry, and thy wrath is come, and the time of the dead, that they should be judged, and that thou shouldest give reward unto thy servants the prophets, and to the saints, and them that fear thy name, small and great; and shouldest destroy them which destroy the earth.
-19. And the temple of God was opened in heaven, and there was seen in his temple the ark of his testament: and there were lightnings, and voices, and thunderings, and an earthquake, and great hail. 
+19. And the temple of God was opened in heaven, and there was seen in his temple the ark of his testament: and there were lightnings, and voices, and thunderings, and an earthquake, and great hail.
 * 12
 1. And there appeared a great wonder in heaven; a woman clothed with the sun, and the moon under her feet, and upon her head a crown of twelve stars:
 2. And she being with child cried, travailing in birth, and pained to be delivered.
@@ -226,11 +226,11 @@
 10. And I heard a loud voice saying in heaven, Now is come salvation, and strength, and the kingdom of our God, and the power of his Christ: for the accuser of our brethren is cast down, which accused them before our God day and night.
 11. And they overcame him by the blood of the Lamb, and by the word of their testimony; and they loved not their lives unto the death.
 12. Therefore rejoice, /ye/ heavens, and ye that dwell in them. Woe to the inhabiters of the earth and of the sea! for the devil is come down unto you, having great wrath, because he knoweth that he hath but a short time.
-13. And when the dragon saw that he was cast unto the earth, he persecuted the woman which brought forth the man /child/. 
+13. And when the dragon saw that he was cast unto the earth, he persecuted the woman which brought forth the man /child/.
 14. And to the woman were given two wings of a great eagle, that she might fly into the wilderness, into her place, where she is nourished for a time, and times, and half a time, from the face of the serpent.
 15. And the serpent cast out of his mouth water as a flood after the woman, that he might cause her to be carried away of the flood.
 16. And the earth helped the woman, and the earth opened her mouth, and swallowed up the flood which the dragon cast out of his mouth.
-17. And the dragon was wroth with the woman, and went to make war with the remnant of her seed, which keep the commandments of God, and have the testimony of Jesus Christ. 
+17. And the dragon was wroth with the woman, and went to make war with the remnant of her seed, which keep the commandments of God, and have the testimony of Jesus Christ.
 * 13
 1. And I stood upon the sand of the sea, and saw a beast rise up out of the sea, having seven heads and ten horns, and upon his horns ten crowns, and upon his heads the name of blasphemy.
 2. And the beast which I saw was like unto a leopard, and his feet were as /the feet/ of a bear, and his mouth as the mouth of a lion: and the dragon gave him his power, and his seat, and great authority.
@@ -249,7 +249,7 @@
 15. And he had power to give life unto the image of the beast, that the image of the beast should both speak, and cause that as many as would not worship the image of the beast should be killed.
 16. And he causeth all, both small and great, rich and poor, free and bond, to receive a mark in their right hand, or in their foreheads:
 17. And that no man might buy or sell, save he that had the mark, or the name of the beast, or the number of his name.
-18. Here is wisdom. Let him that hath understanding count the number of the beast: for it is the number of a man; and his number /is/ Six hundred threescore /and/ six. 
+18. Here is wisdom. Let him that hath understanding count the number of the beast: for it is the number of a man; and his number /is/ Six hundred threescore /and/ six.
 * 14
 1. And I looked, and, lo, a Lamb stood on the mount Sion, and with him an hundred forty /and/ four thousand, having his Father's name written in their foreheads.
 2. And I heard a voice from heaven, as the voice of many waters, and as the voice of a great thunder: and I heard the voice of harpers harping with their harps:
@@ -272,7 +272,7 @@
 17. And another angel came out of the temple which is in heaven, he also having a sharp sickle.
 18. And another angel came out from the altar, which had power over fire; and cried with a loud cry to him that had the sharp sickle, saying, Thrust in thy sharp sickle, and gather the clusters of the vine of the earth; for her grapes are fully ripe.
 19. And the angel thrust in his sickle into the earth, and gathered the vine of the earth, and cast /it/ into the great winepress of the wrath of God.
-20. And the winepress was trodden without the city, and blood came out of the winepress, even unto the horse bridles, by the space of a thousand /and/ six hundred furlongs. 
+20. And the winepress was trodden without the city, and blood came out of the winepress, even unto the horse bridles, by the space of a thousand /and/ six hundred furlongs.
 * 15
 1. And I saw another sign in heaven, great and marvellous, seven angels having the seven last plagues; for in them is filled up the wrath of God.
 2. And I saw as it were a sea of glass mingled with fire: and them that had gotten the victory over the beast, and over his image, and over his mark, /and/ over the number of his name, stand on the sea of glass, having the harps of God.
@@ -281,7 +281,7 @@
 5. And after that I looked, and, behold, the temple of the tabernacle of the testimony in heaven was opened:
 6. And the seven angels came out of the temple, having the seven plagues, clothed in pure and white linen, and having their breasts girded with golden girdles.
 7. And one of the four beasts gave unto the seven angels seven golden vials full of the wrath of God, who liveth for ever and ever.
-8. And the temple was filled with smoke from the glory of God, and from his power; and no man was able to enter into the temple, till the seven plagues of the seven angels were fulfilled. 
+8. And the temple was filled with smoke from the glory of God, and from his power; and no man was able to enter into the temple, till the seven plagues of the seven angels were fulfilled.
 * 16
 1. And I heard a great voice out of the temple saying to the seven angels, Go your ways, and pour out the vials of the wrath of God upon the earth.
 2. And the first went, and poured out his vial upon the earth; and there fell a noisome and grievous sore upon the men which had the mark of the beast, and /upon/ them which worshipped his image.
@@ -303,7 +303,7 @@
 18. And there were voices, and thunders, and lightnings; and there was a great earthquake, such as was not since men were upon the earth, so mighty an earthquake, /and/ so great.
 19. And the great city was divided into three parts, and the cities of the nations fell: and great Babylon came in remembrance before God, to give unto her the cup of the wine of the fierceness of his wrath.
 20. And every island fled away, and the mountains were not found.
-21. And there fell upon men a great hail out of heaven, /every stone/ about the weight of a talent: and men blasphemed God because of the plague of the hail; for the plague thereof was exceeding great. 
+21. And there fell upon men a great hail out of heaven, /every stone/ about the weight of a talent: and men blasphemed God because of the plague of the hail; for the plague thereof was exceeding great.
 * 17
 1. And there came one of the seven angels which had the seven vials, and talked with me, saying unto me, Come hither; I will shew unto thee the judgment of the great whore that sitteth upon many waters:
 2. With whom the kings of the earth have committed fornication, and the inhabitants of the earth have been made drunk with the wine of her fornication.
@@ -322,7 +322,7 @@
 15. And he saith unto me, The waters which thou sawest, where the whore sitteth, are peoples, and multitudes, and nations, and tongues.
 16. And the ten horns which thou sawest upon the beast, these shall hate the whore, and shall make her desolate and naked, and shall eat her flesh, and burn her with fire.
 17. For God hath put in their hearts to fulfil his will, and to agree, and give their kingdom unto the beast, until the words of God shall be fulfilled.
-18. And the woman which thou sawest is that great city, which reigneth over the kings of the earth. 
+18. And the woman which thou sawest is that great city, which reigneth over the kings of the earth.
 * 18
 1. And after these things I saw another angel come down from heaven, having great power; and the earth was lightened with his glory.
 2. And he cried mightily with a strong voice, saying, Babylon the great is fallen, is fallen, and is become the habitation of devils, and the hold of every foul spirit, and a cage of every unclean and hateful bird.
@@ -347,7 +347,7 @@
 21. And a mighty angel took up a stone like a great millstone, and cast /it/ into the sea, saying, Thus with violence shall that great city Babylon be thrown down, and shall be found no more at all.
 22. And the voice of harpers, and musicians, and of pipers, and trumpeters, shall be heard no more at all in thee; and no craftsman, of whatsoever craft /he be/, shall be found any more in thee; and the sound of a millstone shall be heard no more at all in thee;
 23. And the light of a candle shall shine no more at all in thee; and the voice of the bridegroom and of the bride shall be heard no more at all in thee: for thy merchants were the great men of the earth; for by thy sorceries were all nations deceived.
-24. And in her was found the blood of prophets, and of saints, and of all that were slain upon the earth. 
+24. And in her was found the blood of prophets, and of saints, and of all that were slain upon the earth.
 * 19
 1. And after these things I heard a great voice of much people in heaven, saying, Alleluia; Salvation, and glory, and honour, and power, unto the Lord our God:
 2. For true and righteous /are/ his judgments: for he hath judged the great whore, which did corrupt the earth with her fornication, and hath avenged the blood of his servants at her hand.
@@ -370,7 +370,7 @@
 18. That ye may eat the flesh of kings, and the flesh of captains, and the flesh of mighty men, and the flesh of horses, and of them that sit on them, and the flesh of all /men, both/ free and bond, both small and great.
 19. And I saw the beast, and the kings of the earth, and their armies, gathered together to make war against him that sat on the horse, and against his army.
 20. And the beast was taken, and with him the false prophet that wrought miracles before him, with which he deceived them that had received the mark of the beast, and them that worshipped his image. These both were cast alive into a lake of fire burning with brimstone.
-21. And the remnant were slain with the sword of him that sat upon the horse, which /sword/ proceeded out of his mouth: and all the fowls were filled with their flesh. 
+21. And the remnant were slain with the sword of him that sat upon the horse, which /sword/ proceeded out of his mouth: and all the fowls were filled with their flesh.
 * 20
 1. And I saw an angel come down from heaven, having the key of the bottomless pit and a great chain in his hand.
 2. And he laid hold on the dragon, that old serpent, which is the Devil, and Satan, and bound him a thousand years,
@@ -387,7 +387,7 @@
 12. And I saw the dead, small and great, stand before God; and the books were opened: and another book was opened, which is /the book/ of life: and the dead were judged out of those things which were written in the books, according to their works.
 13. And the sea gave up the dead which were in it; and death and hell delivered up the dead which were in them: and they were judged every man according to their works.
 14. And death and hell were cast into the lake of fire. This is the second death.
-15. And whosoever was not found written in the book of life was cast into the lake of fire. 
+15. And whosoever was not found written in the book of life was cast into the lake of fire.
 * 21
 1. And I saw a new heaven and a new earth: for the first heaven and the first earth were passed away; and there was no more sea.
 2. And I John saw the holy city, new Jerusalem, coming down from God out of heaven, prepared as a bride adorned for her husband.
@@ -416,7 +416,7 @@
 24. And the nations of them which are saved shall walk in the light of it: and the kings of the earth do bring their glory and honour into it.
 25. And the gates of it shall not be shut at all by day: for there shall be no night there.
 26. And they shall bring the glory and honour of the nations into it.
-27. And there shall in no wise enter into it any thing that defileth, neither /whatsoever/ worketh abomination, or /maketh/ a lie: but they which are written in the Lamb's book of life. 
+27. And there shall in no wise enter into it any thing that defileth, neither /whatsoever/ worketh abomination, or /maketh/ a lie: but they which are written in the Lamb's book of life.
 * 22
 1. And he shewed me a pure river of water of life, clear as crystal, proceeding out of the throne of God and of the Lamb.
 2. In the midst of the street of it, and on either side of the river, /was there/ the tree of life, which bare twelve /manner of/ fruits, /and/ yielded her fruit every month: and the leaves of the tree /were/ for the healing of the nations.
@@ -440,4 +440,4 @@
 18. For I testify unto every man that heareth the words of the prophecy of this book, If any man shall add unto these things, God shall add unto him the plagues that are written in this book:
 19. And if any man shall take away from the words of the book of this prophecy, God shall take away his part out of the book of life, and out of the holy city, and /from/ the things which are written in this book.
 20. He which testifieth these things saith, Surely I come quickly. Amen. Even so, come, Lord Jesus.
-21. The grace of our Lord Jesus Christ /be/ with you all. Amen.  
+21. The grace of our Lord Jesus Christ /be/ with you all. Amen.

--- a/README.org
+++ b/README.org
@@ -32,7 +32,7 @@ the whole Bible, follow the steps below:
 *IMPORTANT:* The script includes an option to overwrite an existing file. Make
 sure to move your file to another location if you plan on making notes, or
 adding changes to the file, so that you don't overwrite it in the future.
-  
+
 * Acknowledgements
 
 Most of the heavy lifting was done using [[github:alphapapa/sword-to-org][sword-to-org]]. Kudos!


### PR DESCRIPTION
Trimmed whitespace in all .org files using `find . -not -iwholename '*.git*' -type f -print0 | xargs -0 perl -pi -e 's/ +$//'` command in the project root.